### PR TITLE
Enhance model training with tuning and validation metrics

### DIFF
--- a/ml/model_utils.py
+++ b/ml/model_utils.py
@@ -1,6 +1,11 @@
 import joblib
 import os
-from sklearn.metrics import accuracy_score, classification_report
+from sklearn.metrics import (
+    accuracy_score,
+    classification_report,
+    confusion_matrix,
+    f1_score,
+)
 
 def save_model(model, path):
     """
@@ -18,9 +23,18 @@ def load_model(path):
     return joblib.load(path)
 
 def evaluate_model(model, X_test, y_test):
-    """
-    Prints basic evaluation metrics for classification.
+    """Print evaluation metrics for classification models.
+
+    Returns
+    -------
+    tuple
+        (accuracy, f1) scores for further analysis.
     """
     preds = model.predict(X_test)
-    print("Accuracy:", accuracy_score(y_test, preds))
+    acc = accuracy_score(y_test, preds)
+    f1 = f1_score(y_test, preds, average="weighted")
+    print("Accuracy:", acc)
+    print("F1 score:", f1)
     print("Classification report:\n", classification_report(y_test, preds))
+    print("Confusion matrix:\n", confusion_matrix(y_test, preds))
+    return acc, f1

--- a/ml/train.py
+++ b/ml/train.py
@@ -1,19 +1,80 @@
-import pandas as pd
 from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import GridSearchCV, train_test_split
+from typing import Optional, Dict
 import joblib
 import os
 
+from ml.model_utils import evaluate_model
+
 MODEL_PATH = "ml/model.pkl"
 
-def train_model(X, y, model_path=MODEL_PATH):
-    clf = RandomForestClassifier(
-        n_estimators=200,
-        random_state=42,
-        n_jobs=-1,
-        min_samples_leaf=2,
-        verbose=1  # <- prints training progress
+def train_model(
+    X,
+    y,
+    model_path: str = MODEL_PATH,
+    tune: bool = False,
+    param_grid: Optional[Dict] = None,
+    test_size: float = 0.2,
+    random_state: int = 42,
+):
+    """Train a classification model.
+
+    Parameters
+    ----------
+    X, y : array-like
+        Training features and labels.
+    model_path : str
+        Where to persist the trained model.
+    tune : bool
+        If True, perform GridSearchCV over ``param_grid`` to tune
+        hyperparameters for higher accuracy.
+    param_grid : dict, optional
+        Parameter grid for GridSearchCV. A reasonable default grid is used
+        when ``None``.
+    test_size : float
+        Fraction of data to use for validation during training.
+    random_state : int
+        Reproducibility seed.
+    """
+
+    X_train, X_val, y_train, y_val = train_test_split(
+        X, y, test_size=test_size, random_state=random_state, stratify=y
     )
-    clf.fit(X, y)
+
+    if tune:
+        param_grid = param_grid or {
+            "n_estimators": [100, 200, 300],
+            "max_depth": [None, 10, 20],
+            "min_samples_split": [2, 5, 10],
+            "min_samples_leaf": [1, 2, 4],
+        }
+        base_clf = RandomForestClassifier(
+            n_jobs=-1, random_state=random_state, class_weight="balanced"
+        )
+        search = GridSearchCV(
+            base_clf,
+            param_grid=param_grid,
+            cv=5,
+            n_jobs=-1,
+            scoring="accuracy",
+            verbose=2,
+        )
+        search.fit(X_train, y_train)
+        clf = search.best_estimator_
+        print("Best params:", search.best_params_)
+    else:
+        clf = RandomForestClassifier(
+            n_estimators=200,
+            random_state=random_state,
+            n_jobs=-1,
+            min_samples_leaf=2,
+            verbose=1,  # <- prints training progress
+        )
+        clf.fit(X_train, y_train)
+
+    # Evaluate on validation data
+    evaluate_model(clf, X_val, y_val)
+
     joblib.dump(clf, model_path)
     print(f"Model saved to {model_path}")
     return clf


### PR DESCRIPTION
## Summary
- add optional GridSearchCV for RandomForest training
- evaluate model with accuracy, F1 score and confusion matrix

## Testing
- `pytest -q`
- `python -m py_compile ml/train.py ml/model_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68adb2567f7c8327b0769aa56bfd9a16