### PR TITLE
Simplify prediction pipeline and add optional GPU models

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,5 @@
-import json
 import time
 from datetime import datetime, timezone
-from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import pandas as pd
@@ -13,7 +11,6 @@ from db.predictions_store import create_predictions_table, save_predictions
 from deleting_SQL import delete_old_records
 from ml.train import train_model, load_model
 from ml.train_regressor import train_regressor, load_regressor
-from ml.model_utils import match_model_features
 from utils.config import CONFIG
 from utils.helpers import ensure_dir_exists
 from utils.progress import step, timed, p
@@ -39,11 +36,6 @@ INTERVAL_TO_MIN = {
 PRAGUE_TZ = ZoneInfo("Europe/Prague")
 FEATURES_VERSION = "ext_v1"
 
-CLS_MODEL_COUNT = 25
-REG_MODEL_COUNT = 30
-CLS_ACC_PATH = Path("ml/backtest_acc_cls.json")
-REG_ACC_PATH = Path("ml/backtest_acc_reg.json")
-
 
 def _created_at_iso():
     return datetime.now(timezone.utc).isoformat()
@@ -63,29 +55,6 @@ def _delete_future_predictions(db_path: str, symbol: str, from_ms: int, table_na
         cur.execute("PRAGMA optimize;")
         conn.commit()
     return deleted
-
-
-
-def list_model_paths(pattern: str, count: int):
-    paths = []
-    indices = []
-    for i in range(1, count + 1):
-        path = pattern.format(i=i)
-        if Path(path).exists():
-            paths.append(path)
-            indices.append(i)
-        else:
-            p(f"Missing model {path}")
-    return paths, indices
-
-
-def load_accuracy_weights(path: Path, indices):
-    if path.exists():
-        with open(path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-    else:
-        data = {}
-    return [float(data.get(str(i), 1.0)) for i in indices]
 
 
 def prepare_targets(df, forward_steps=1):
@@ -124,13 +93,7 @@ def main(train=True):
     backfill_actuals_and_errors(db_path=DB_PATH, table_pred=TABLE_PRED, symbol=SYMBOL)
     last_ts = full_df["timestamp"].max()
     _delete_future_predictions(DB_PATH, SYMBOL, int(last_ts.value // 1_000_000), TABLE_PRED)
-    # Load base models and their validation weights
-    cls_paths, cls_indices = list_model_paths("ml/model_{i}.joblib", CLS_MODEL_COUNT)
-    reg_paths, reg_indices = list_model_paths("ml/model_reg_{i}.joblib", REG_MODEL_COUNT)
-    cls_weights = load_accuracy_weights(CLS_ACC_PATH, cls_indices)
-    reg_weights = load_accuracy_weights(REG_ACC_PATH, reg_indices)
-
-    # Prepare training data including predictions from base models
+    # Prepare training data for meta models
     horizon_dfs = []
     for horizon in range(1, FORWARD_STEPS + 1):
         df_h = prepare_targets(full_df, forward_steps=horizon)
@@ -138,23 +101,7 @@ def main(train=True):
         horizon_dfs.append(df_h)
     train_df = pd.concat(horizon_dfs, ignore_index=True)
 
-    base_feats = train_df[FEATURE_COLS]
-    for path, idx, w in zip(cls_paths, cls_indices, cls_weights):
-        model = load_model(model_path=path)
-        feats = match_model_features(base_feats, model)
-        preds = model.predict_proba(feats)[:, 1] * w
-        train_df[f"cls_pred_{idx}"] = preds
-        del model
-    for path, idx, w in zip(reg_paths, reg_indices, reg_weights):
-        model = load_regressor(model_path=path)
-        feats = match_model_features(base_feats, model)
-        preds = model.predict(feats) * w
-        train_df[f"reg_pred_{idx}"] = preds
-        del model
-
-    cls_pred_cols = [f"cls_pred_{i}" for i in cls_indices]
-    reg_pred_cols = [f"reg_pred_{i}" for i in reg_indices]
-    feature_cols_meta = FEATURE_COLS + ["horizon"] + cls_pred_cols + reg_pred_cols
+    feature_cols_meta = FEATURE_COLS + ["horizon"]
     X_all = train_df[feature_cols_meta]
     y_cls_all = train_df["target_cls"]
     y_reg_all = train_df["target_reg"]
@@ -177,29 +124,14 @@ def main(train=True):
     pred_time = last_row["timestamp"].iloc[0]
     pred_local = pd.Timestamp(pred_time, tz="UTC").tz_convert(PRAGUE_TZ)
 
-    # Base model predictions for the latest row
+    # Base features for the latest row
     base_last = last_row[FEATURE_COLS]
-    last_base_preds = {}
-    for path, idx, w in zip(cls_paths, cls_indices, cls_weights):
-        model = load_model(model_path=path)
-        feats = match_model_features(base_last, model)
-        last_base_preds[f"cls_pred_{idx}"] = float(
-            model.predict_proba(feats)[:, 1][0] * w
-        )
-        del model
-    for path, idx, w in zip(reg_paths, reg_indices, reg_weights):
-        model = load_regressor(model_path=path)
-        feats = match_model_features(base_last, model)
-        last_base_preds[f"reg_pred_{idx}"] = float(model.predict(feats)[0] * w)
-        del model
 
     step(5, 8, "Predict horizons")
     for horizon in range(1, FORWARD_STEPS + 1):
         with timed("Predict"):
             X_last = base_last.copy()
             X_last["horizon"] = horizon
-            for name, val in last_base_preds.items():
-                X_last[name] = val
             prob_up = float(cls_model.predict_proba(X_last[feature_cols_meta])[:, 1][0])
             reg_pred = float(reg_model.predict(X_last[feature_cols_meta])[0])
             last_close = float(last_row["close"].iloc[0])
@@ -238,5 +170,5 @@ def main(train=True):
     total = time.perf_counter() - start
     p(f"Done in {total:.2f}s")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/ml/predict.py
+++ b/ml/predict.py
@@ -1,21 +1,20 @@
 """Prediction helpers for classification models."""
 
 from .train import load_model
-from .ensemble import predict_weighted
 
 
-def predict_ml(df, feature_cols, model_path="ml/model.joblib"):
-    """Predict class labels (0/1) using a trained classifier."""
+def predict_ml(df, feature_cols, model_path="ml/meta_model_cls.joblib"):
+    """Predict class labels (0/1) using the meta classifier."""
     model = load_model(model_path)
     X = df[feature_cols]
     return model.predict(X)
 
 
-def predict_ml_proba(df, feature_cols, model_path="ml/model.joblib"):
+def predict_ml_proba(df, feature_cols, model_path="ml/meta_model_cls.joblib"):
     """Return probability of the positive class (price up)."""
     model = load_model(model_path)
     X = df[feature_cols]
     return model.predict_proba(X)[:, 1]
 
 
-__all__ = ["predict_ml", "predict_ml_proba", "predict_weighted"]
+__all__ = ["predict_ml", "predict_ml_proba"]

--- a/ml/predict_regressor.py
+++ b/ml/predict_regressor.py
@@ -1,14 +1,13 @@
 """Helpers for making predictions with regression models."""
 
 from .train_regressor import load_regressor
-from .ensemble import predict_weighted as predict_weighted_prices
 
 
-def predict_prices(df, feature_cols, model_path="ml/model_reg.joblib"):
-    """Predict prices using a single regressor model."""
+def predict_prices(df, feature_cols, model_path="ml/meta_model_reg.joblib"):
+    """Predict prices using the meta regressor."""
     model = load_regressor(model_path)
     X = df[feature_cols]
     return model.predict(X)
 
 
-__all__ = ["predict_prices", "predict_weighted_prices"]
+__all__ = ["predict_prices"]

--- a/ml/train.py
+++ b/ml/train.py
@@ -17,6 +17,7 @@ def train_model(
     param_grid: Optional[Dict] = None,
     test_size: float = 0.2,
     random_state: int = 42,
+    use_xgboost: bool = False,
 ):
     """Train a classification model.
 
@@ -36,13 +37,27 @@ def train_model(
         Fraction of data to use for validation during training.
     random_state : int
         Reproducibility seed.
+    use_xgboost : bool
+        If True, train an XGBoost classifier using GPU acceleration.
     """
 
     X_train, X_val, y_train, y_val = train_test_split(
         X, y, test_size=test_size, random_state=random_state, stratify=y
     )
 
-    if tune:
+    if use_xgboost:
+        try:
+            from xgboost import XGBClassifier
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise ImportError("xgboost is required for GPU training") from exc
+
+        clf = XGBClassifier(
+            tree_method="gpu_hist",
+            predictor="gpu_predictor",
+            random_state=random_state,
+        )
+        clf.fit(X_train, y_train)
+    elif tune:
         param_grid = param_grid or {
             "n_estimators": [100, 200, 300],
             "max_depth": [None, 10, 20],

--- a/prediction/predictor.py
+++ b/prediction/predictor.py
@@ -1,31 +1,24 @@
 from analysis.rules import combined_signal
-from ml.predict import predict_ml, predict_weighted
+from ml.predict import predict_ml
 
 
 def combine_predictions(
     df,
     feature_cols,
-    model_paths=None,
     method="majority",
-    usage_path="ml/model_usage.json",
 ):
     """
-    Combines rule-based and ML predictions.
+    Combines rule-based and meta-model predictions.
 
     Parameters
     ----------
     df : pandas.DataFrame
         Data for making predictions.
     feature_cols : list[str]
-        Features used by the ML models.
-    model_paths : list[str] | None
-        Paths to multiple model files. If ``None``, a single model at
-        ``ml/model.joblib`` is used.
+        Features used by the meta model.
     method : str, optional
         - ``"majority"``: 1 if at least one predicts up, else 0
         - ``"strict"``: 1 only if both agree
-    usage_path : str, optional
-        Location of JSON file tracking model usage counts.
 
     Returns
     -------
@@ -33,12 +26,7 @@ def combine_predictions(
         Final combined predictions.
     """
     rule_preds = combined_signal(df)
-    if model_paths is None:
-        ml_preds = predict_ml(df, feature_cols)
-    else:
-        ml_preds = predict_weighted(
-            df, feature_cols, model_paths, usage_path=usage_path
-        )
+    ml_preds = predict_ml(df, feature_cols)
 
     if method == "majority":
         final_pred = ((rule_preds + ml_preds) > 0).astype(int)


### PR DESCRIPTION
## Summary
- streamline main prediction workflow to rely on meta-classifier/regressor only
- enable optional XGBoost GPU training for classifier and regressor helpers
- simplify prediction utilities and rule/ML combination to use meta models

## Testing
- `python -m py_compile main.py ml/predict.py ml/predict_regressor.py ml/train.py ml/train_regressor.py prediction/predictor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c196389b988327a72b525df94ce4c8