### PR TITLE
feat: xgboost price interval prediction

### DIFF
--- a/analysis/feature_engineering.py
+++ b/analysis/feature_engineering.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pandas as pd
 
 # Only a minimal subset of indicators is required for the Core-18 feature set.
 # Keeping the imports explicit makes the dependency surface obvious and helps
@@ -67,6 +66,15 @@ def create_features(df):
     df["tod_cos"] = np.cos(2 * np.pi * minute / 1440)
 
     df = df.fillna(0)
+
+    # --- Targets -------------------------------------------------------------
+    horizon = 24  # 120 minutes at 5-minute bars
+    df["delta_log_120m"] = np.log(df["close"].shift(-horizon) / df["close"])
+    df["delta_lin_120m"] = df["close"].shift(-horizon) - df["close"]
+
+    # Downcast all float columns to float32 to save memory
+    float_cols = df.select_dtypes(include="float64").columns
+    df[float_cols] = df[float_cols].astype(np.float32)
 
     return df
 

--- a/crypto_analyzer/model_manager.py
+++ b/crypto_analyzer/model_manager.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import argparse
 import os
+from collections.abc import Sequence
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Iterable, Sequence
 
-PROJECT_ROOT = Path(os.environ.get("CRYPTO_ANALYZER_PROJECT_ROOT", Path(__file__).resolve().parents[1]))
+PROJECT_ROOT = Path(
+    os.environ.get("CRYPTO_ANALYZER_PROJECT_ROOT", Path(__file__).resolve().parents[1])
+)
 MODELS_ROOT = PROJECT_ROOT / "models"
 
 
@@ -20,7 +22,9 @@ def _ensure_models_dir(dir: Path) -> Path:
     return resolved
 
 
-def list_artifacts(stem: str, dir: Path, patterns: Sequence[str] = ("*.joblib", "*.pkl", "*.npy", "*.bin")) -> list[Path]:
+def list_artifacts(
+    stem: str, dir: Path, patterns: Sequence[str] = ("*.joblib", "*.pkl", "*.npy", "*.bin")
+) -> list[Path]:
     """List model artifacts matching stem within a directory.
 
     Parameters
@@ -75,7 +79,8 @@ def atomic_write(path: Path, data: bytes) -> None:
 # CLI
 # ----------------------------------------------------------------------------
 
-def _parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Manage model artifacts")
     action = parser.add_mutually_exclusive_group(required=True)
     action.add_argument("--list", action="store_true", help="List artifacts")
@@ -88,7 +93,7 @@ def _parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def main(argv: Iterable[str] | None = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
     if args.list:
         files = list_artifacts(args.stem, args.dir)

--- a/ml/time_cv.py
+++ b/ml/time_cv.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+
+def time_folds(n_samples, n_splits=5, embargo=24):
+    indices = np.arange(n_samples)
+    fold_size = n_samples // (n_splits + 1)
+    folds = []
+    for i in range(1, n_splits + 1):
+        test_start = i * fold_size
+        test_end = min((i + 1) * fold_size, n_samples)
+        train_end = max(0, test_start - embargo)
+        train_idx = indices[:train_end]
+        test_idx = indices[test_start:test_end]
+        if len(test_idx) == 0:
+            break
+        folds.append((train_idx, test_idx))
+    return folds

--- a/ml/train_price.py
+++ b/ml/train_price.py
@@ -1,0 +1,121 @@
+import argparse
+import json
+from pathlib import Path
+
+import joblib
+import numpy as np
+import pandas as pd
+
+from analysis.feature_engineering import create_features
+
+from .time_cv import time_folds
+from .xgb_price import build_quantile, build_reg, clip_inside, to_price
+
+
+def train_price(df, feature_cols, target_kind="log", outdir="models/xgb_price"):
+    df = create_features(df)
+    target_col = "delta_log_120m" if target_kind == "log" else "delta_lin_120m"
+    df = df.dropna(subset=[target_col])
+    X = df[feature_cols].astype("float32")
+    y = df[target_col].astype("float32")
+
+    preds = []
+    metrics = []
+
+    for train_idx, test_idx in time_folds(len(df), embargo=24):
+        X_train, y_train = X.iloc[train_idx], y.iloc[train_idx]
+        X_test, y_test = X.iloc[test_idx], y.iloc[test_idx]
+        reg = build_reg()
+        q10 = build_quantile(0.10)
+        q90 = build_quantile(0.90)
+        reg.fit(
+            X_train,
+            y_train,
+            eval_set=[(X_test, y_test)],
+            verbose=False,
+        )
+        q10.fit(
+            X_train,
+            y_train,
+            eval_set=[(X_test, y_test)],
+            verbose=False,
+        )
+        q90.fit(
+            X_train,
+            y_train,
+            eval_set=[(X_test, y_test)],
+            verbose=False,
+        )
+        last_price = df["close"].iloc[test_idx].values
+        delta_hat = reg.predict(X_test)
+        low_hat = q10.predict(X_test)
+        high_hat = q90.predict(X_test)
+        p_hat = to_price(last_price, delta_hat, kind=target_kind)
+        p_low = to_price(last_price, low_hat, kind=target_kind)
+        p_high = to_price(last_price, high_hat, kind=target_kind)
+        p_low, p_high = np.minimum(p_low, p_high), np.maximum(p_low, p_high)
+        p_hat = clip_inside(p_hat, p_low, p_high)
+        target_price = df["close"].shift(-24).iloc[test_idx].values
+        preds.append(
+            pd.DataFrame(
+                {
+                    "timestamp": df["timestamp"].iloc[test_idx].values,
+                    "p_low": p_low,
+                    "p_hat": p_hat,
+                    "p_high": p_high,
+                    "target": target_price,
+                }
+            )
+        )
+        rmse = float(np.sqrt(np.mean((p_hat - target_price) ** 2)))
+        mae = float(np.mean(np.abs(p_hat - target_price)))
+        coverage = float(np.mean((target_price >= p_low) & (target_price <= p_high)))
+        width = float(np.mean(p_high - p_low))
+        metrics.append(dict(rmse=rmse, mae=mae, coverage=coverage, width=width))
+
+    avg_metrics = {
+        "rmse": float(np.mean([m["rmse"] for m in metrics])),
+        "mae": float(np.mean([m["mae"] for m in metrics])),
+        "coverage": float(np.mean([m["coverage"] for m in metrics])),
+        "width": float(np.mean([m["width"] for m in metrics])),
+    }
+
+    out_path = Path(outdir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    reg_final = build_reg()
+    q10_final = build_quantile(0.10)
+    q90_final = build_quantile(0.90)
+    reg_final.fit(X, y, verbose=False)
+    q10_final.fit(X, y, verbose=False)
+    q90_final.fit(X, y, verbose=False)
+    joblib.dump(reg_final, out_path / "reg.joblib")
+    joblib.dump(q10_final, out_path / "q10.joblib")
+    joblib.dump(q90_final, out_path / "q90.joblib")
+    with open(out_path / "metrics.json", "w", encoding="utf-8") as f:
+        json.dump(avg_metrics, f)
+
+    pred_df = pd.concat(preds, ignore_index=True).sort_values("timestamp")
+    return avg_metrics, pred_df
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Train XGBoost price models")
+    parser.add_argument("--horizon-min", type=int, default=120)
+    parser.add_argument("--features", required=True)
+    parser.add_argument("--target-kind", choices=["log", "lin"], default="log")
+    parser.add_argument("--outdir", default="models/xgb_price")
+    parser.add_argument("--data")
+    args = parser.parse_args(argv)
+
+    if args.data is None:
+        raise SystemExit("--data path required")
+    df = pd.read_parquet(args.data) if args.data.endswith(".parquet") else pd.read_csv(args.data)
+    with open(args.features, encoding="utf-8") as f:
+        feature_cols = json.load(f)
+    metrics, _ = train_price(df, feature_cols, target_kind=args.target_kind, outdir=args.outdir)
+    print(json.dumps(metrics))
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/train_regressor.py
+++ b/ml/train_regressor.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from collections.abc import Sequence
 from io import BytesIO
 from pathlib import Path
 from typing import Any
@@ -7,9 +8,10 @@ from typing import Any
 import joblib
 from sklearn.ensemble import RandomForestRegressor
 
+from crypto_analyzer.model_manager import atomic_write
+
 from .oob import fit_incremental_forest, halving_random_search
 from .train import _gpu_available
-from crypto_analyzer.model_manager import atomic_write
 
 MODEL_PATH = "ml/meta_model_reg.joblib"
 MAX_MODEL_BYTES = 100 * 1024**3  # 200 GB guard
@@ -165,7 +167,6 @@ import argparse
 import json
 import traceback
 from datetime import datetime
-from typing import Iterable
 
 from crypto_analyzer.model_manager import MODELS_ROOT, PROJECT_ROOT
 
@@ -185,7 +186,7 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = _build_parser()
     args = parser.parse_args(argv)
     if args.train_start and not args.train_end:
@@ -227,7 +228,7 @@ def _log_failure(stem: str, exc: BaseException) -> None:
         f.write(json.dumps(entry) + "\n")
 
 
-def main(argv: Iterable[str] | None = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
     if args.reset_metadata:
         _reset_metadata()

--- a/ml/xgb_price.py
+++ b/ml/xgb_price.py
@@ -1,0 +1,45 @@
+import numpy as np
+import xgboost as xgb
+
+
+def build_reg():
+    return xgb.XGBRegressor(
+        n_estimators=600,
+        max_depth=8,
+        learning_rate=0.05,
+        subsample=0.8,
+        colsample_bytree=0.8,
+        tree_method="hist",
+        n_jobs=4,
+        eval_metric="rmse",
+        random_state=42,
+    )
+
+
+def build_quantile(alpha):
+    return xgb.XGBRegressor(
+        n_estimators=800,
+        max_depth=8,
+        learning_rate=0.04,
+        subsample=0.8,
+        colsample_bytree=0.8,
+        tree_method="hist",
+        n_jobs=4,
+        objective="reg:quantileerror",
+        quantile_alpha=alpha,
+        random_state=42,
+    )
+
+
+def to_price(last_price, delta, kind="log"):
+    last_price = np.asarray(last_price, dtype=np.float32)
+    delta = np.asarray(delta, dtype=np.float32)
+    if kind == "log":
+        return last_price * np.exp(delta)
+    if kind == "lin":
+        return last_price + delta
+    raise ValueError("kind must be 'log' or 'lin'")
+
+
+def clip_inside(p, lo, hi):
+    return np.minimum(np.maximum(p, lo), hi)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "joblib~=1.5.1",
     "PyYAML~=6.0.2",
     "tqdm~=4.67.1",
+    "xgboost>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ requests~=2.32.5
 joblib~=1.5.1
 PyYAML~=6.0.2
 tqdm~=4.67.1
+xgboost>=2.0
 
 # Type stubs for static analysis
 pandas-stubs
@@ -19,4 +20,3 @@ joblib-stubs
 scikit-learn-stubs
 types-tqdm
 types-PyYAML
-

--- a/tests/test_interval_coverage.py
+++ b/tests/test_interval_coverage.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from ml.xgb_price import build_quantile, build_reg
+
+
+def test_interval_coverage():
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(2000, 5))
+    beta = rng.normal(size=5)
+    noise = rng.normal(scale=1.0, size=2000)
+    y = X @ beta + noise
+    X_train, X_test = X[:1500], X[1500:]
+    y_train, y_test = y[:1500], y[1500:]
+
+    reg = build_reg()
+    q10 = build_quantile(0.10)
+    q90 = build_quantile(0.90)
+    reg.set_params(n_estimators=50, max_depth=3, n_jobs=1)
+    q10.set_params(n_estimators=50, max_depth=3, n_jobs=1)
+    q90.set_params(n_estimators=50, max_depth=3, n_jobs=1)
+    reg.fit(X_train, y_train, verbose=False)
+    q10.fit(X_train, y_train, verbose=False)
+    q90.fit(X_train, y_train, verbose=False)
+    last_price = 100.0
+    low = q10.predict(X_test)
+    high = q90.predict(X_test)
+    p_low = last_price + low
+    p_high = last_price + high
+    target = last_price + y_test
+    coverage = np.mean((target >= p_low) & (target <= p_high))
+    assert 0.75 < coverage < 0.9

--- a/tests/test_price_targets.py
+++ b/tests/test_price_targets.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+from ml.xgb_price import to_price
+
+
+def test_to_price_consistency():
+    last = 100.0
+    delta_lin = 5.0
+    delta_log = np.log((last + delta_lin) / last)
+    assert np.isclose(to_price(last, delta_log, "log"), last + delta_lin)
+    assert np.isclose(to_price(last, delta_lin, "lin"), last + delta_lin)

--- a/tests/test_smoke_train_price.py
+++ b/tests/test_smoke_train_price.py
@@ -1,0 +1,72 @@
+import numpy as np
+import pandas as pd
+
+import ml.time_cv as time_cv
+import ml.train_price as tp
+import ml.xgb_price as xgb_price
+from analysis.feature_engineering import FEATURE_COLUMNS
+
+
+def test_smoke_train_price(monkeypatch, tmp_path):
+    rng = np.random.default_rng(0)
+    n = 1050
+    ts = pd.date_range("2024-01-01", periods=n, freq="5min", tz="UTC")
+    close = 100 + rng.normal(scale=1, size=n).cumsum()
+    high = close + rng.random(n)
+    low = close - rng.random(n)
+    volume = rng.random(n) + 1
+    qvol = volume * close
+    tbb = volume * 0.5
+    tbq = qvol * 0.5
+    df = pd.DataFrame(
+        {
+            "timestamp": ts,
+            "close": close,
+            "high": high,
+            "low": low,
+            "volume": volume,
+            "quote_asset_volume": qvol,
+            "taker_buy_base": tbb,
+            "taker_buy_quote": tbq,
+        }
+    )
+
+    def small_reg():
+        model = xgb_price.xgb.XGBRegressor(
+            n_estimators=10,
+            max_depth=3,
+            learning_rate=0.1,
+            subsample=0.8,
+            colsample_bytree=0.8,
+            tree_method="hist",
+            n_jobs=1,
+            eval_metric="rmse",
+            random_state=42,
+        )
+        return model
+
+    def small_quant(alpha):
+        model = xgb_price.xgb.XGBRegressor(
+            n_estimators=10,
+            max_depth=3,
+            learning_rate=0.1,
+            subsample=0.8,
+            colsample_bytree=0.8,
+            tree_method="hist",
+            n_jobs=1,
+            objective="reg:quantileerror",
+            quantile_alpha=alpha,
+            random_state=42,
+        )
+        return model
+
+    monkeypatch.setattr(xgb_price, "build_reg", small_reg)
+    monkeypatch.setattr(xgb_price, "build_quantile", small_quant)
+
+    def small_folds(n_samples, embargo=24):
+        return time_cv.time_folds(n_samples, n_splits=2, embargo=embargo)
+
+    monkeypatch.setattr(tp, "time_folds", small_folds)
+
+    _, preds = tp.train_price(df, FEATURE_COLUMNS, outdir=tmp_path)
+    assert ((preds["p_hat"] >= preds["p_low"]) & (preds["p_hat"] <= preds["p_high"])).all()

--- a/tests/test_time_cv.py
+++ b/tests/test_time_cv.py
@@ -1,0 +1,10 @@
+from ml.time_cv import time_folds
+
+
+def test_time_folds_embargo():
+    n = 200
+    folds = time_folds(n, n_splits=3, embargo=24)
+    for train_idx, test_idx in folds:
+        if len(train_idx) == 0:
+            continue
+        assert train_idx.max() <= test_idx.min() - 24

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -28,7 +28,7 @@ def timestamp_to_datetime(ts):
     return datetime.fromtimestamp(ts / 1000.0)
 
 
-def set_cpu_limit(cores: int) -> 20:
+def set_cpu_limit(cores: int) -> None:
     """Limit the process to ``cores`` CPU cores if possible.
 
     If ``psutil`` or CPU affinity is not available, the function silently


### PR DESCRIPTION
## Summary
- add xgboost models for point and quantile BTC price forecasts
- generate 2h price delta targets and downcast features to float32
- provide training pipeline, time-based CV with embargo and basic tests

## Testing
- `pre-commit run --files analysis/feature_engineering.py main.py pyproject.toml requirements.txt ml/time_cv.py ml/train_price.py ml/xgb_price.py tests/test_interval_coverage.py tests/test_price_targets.py tests/test_smoke_train_price.py tests/test_time_cv.py crypto_analyzer/model_manager.py ml/train_regressor.py utils/helpers.py`
- `PYTHONPATH=. pytest tests/test_price_targets.py tests/test_interval_coverage.py tests/test_time_cv.py tests/test_smoke_train_price.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3e24d626c8327a898fa1f2b5de7d4