### PR TITLE
Add explicit low/high bound models for price prediction

### DIFF
--- a/analysis/feature_engineering.py
+++ b/analysis/feature_engineering.py
@@ -102,6 +102,14 @@ def create_features(df: pd.DataFrame) -> pd.DataFrame:
     horizon = 24  # 120 min při 5m svících
     df["delta_log_120m"] = np.log(df["close"].shift(-horizon) / df["close"]).astype(np.float32)
     df["delta_lin_120m"] = (df["close"].shift(-horizon) - df["close"]).astype(np.float32)
+    future_lows = pd.concat([df["low"].shift(-i) for i in range(1, horizon + 1)], axis=1)
+    future_highs = pd.concat([df["high"].shift(-i) for i in range(1, horizon + 1)], axis=1)
+    fmin = future_lows.min(axis=1)
+    fmax = future_highs.max(axis=1)
+    df["delta_low_log_120m"] = np.log(fmin / df["close"]).astype(np.float32)
+    df["delta_low_lin_120m"] = (fmin - df["close"]).astype(np.float32)
+    df["delta_high_log_120m"] = np.log(fmax / df["close"]).astype(np.float32)
+    df["delta_high_lin_120m"] = (fmax - df["close"]).astype(np.float32)
 
     df["delta_log_60m"] = np.log(df["close"].shift(-12) / df["close"]).astype(np.float32)
     df["delta_lin_60m"] = (df["close"].shift(-12) - df["close"]).astype(np.float32)
@@ -114,6 +122,10 @@ def create_features(df: pd.DataFrame) -> pd.DataFrame:
         columns=[
             "delta_log_120m",
             "delta_lin_120m",
+            "delta_low_log_120m",
+            "delta_low_lin_120m",
+            "delta_high_log_120m",
+            "delta_high_lin_120m",
             "delta_log_60m",
             "delta_lin_60m",
             "delta_log_240m",

--- a/api/server.py
+++ b/api/server.py
@@ -17,8 +17,8 @@ DATA_PATH = os.getenv("DATA_PATH", "data/latest.parquet")
 app = FastAPI()
 
 reg = joblib.load(MODEL_DIR / "reg.joblib", mmap_mode="r")
-q10 = joblib.load(MODEL_DIR / "q10.joblib", mmap_mode="r")
-q90 = joblib.load(MODEL_DIR / "q90.joblib", mmap_mode="r")
+lo = joblib.load(MODEL_DIR / "low.joblib", mmap_mode="r")
+hi = joblib.load(MODEL_DIR / "high.joblib", mmap_mode="r")
 
 
 def _load_last_row() -> tuple[pd.Timestamp, float, pd.DataFrame]:
@@ -40,8 +40,8 @@ def predict() -> PredictionResponse:  # pragma: no cover - FastAPI handles respo
     ts, last_price, X_last = _load_last_row()
     dlast = xgb.DMatrix(np.asarray(X_last, dtype=np.float32))
     delta = float(reg.predict(dlast)[0])
-    low = float(q10.predict(dlast)[0])
-    high = float(q90.predict(dlast)[0])
+    low = float(lo.predict(dlast)[0])
+    high = float(hi.predict(dlast)[0])
     p_hat = float(to_price(last_price, delta))
     p_low = float(to_price(last_price, low))
     p_high = float(to_price(last_price, high))

--- a/main.py
+++ b/main.py
@@ -107,11 +107,11 @@ def predict_price(model_dir="models/xgb_price", target_kind="log"):
     last_close = float(last_row["close"].iloc[0])
     X_last = last_row[FEATURE_COLS].astype("float32")
     reg = joblib.load(Path(model_dir) / "reg.joblib", mmap_mode="r")
-    q10 = joblib.load(Path(model_dir) / "q10.joblib", mmap_mode="r")
-    q90 = joblib.load(Path(model_dir) / "q90.joblib", mmap_mode="r")
+    lo = joblib.load(Path(model_dir) / "low.joblib", mmap_mode="r")
+    hi = joblib.load(Path(model_dir) / "high.joblib", mmap_mode="r")
     delta = reg.predict(X_last)[0]
-    low = q10.predict(X_last)[0]
-    high = q90.predict(X_last)[0]
+    low = lo.predict(X_last)[0]
+    high = hi.predict(X_last)[0]
     p_hat = to_price(last_close, delta, kind=target_kind)
     p_low = to_price(last_close, low, kind=target_kind)
     p_high = to_price(last_close, high, kind=target_kind)

--- a/ml/xgb_price.py
+++ b/ml/xgb_price.py
@@ -23,15 +23,15 @@ def build_reg() -> tuple[dict[str, float | int | str], int]:
     return params, 600
 
 
-def build_quantile(alpha: float) -> tuple[dict[str, float | int | str], int]:
+def build_bound() -> tuple[dict[str, float | int | str], int]:
     params: dict[str, float | int | str] = {
         "max_depth": 8,
         "eta": 0.04,
         "subsample": 0.8,
         "colsample_bytree": 0.8,
         "tree_method": "hist",
-        "objective": "reg:quantileerror",
-        "quantile_alpha": alpha,
+        "objective": "reg:squarederror",
+        "eval_metric": "rmse",
         "nthread": 4,
         "seed": 42,
     }

--- a/prediction/predictor.py
+++ b/prediction/predictor.py
@@ -27,7 +27,7 @@ def combine_predictions(
     feature_cols: list[str],
     *,
     model_paths: list[str] | None = None,
-    method: str = "weighted",
+    method: str = "majority",
     use_meta_only: bool = True,
     usage_path: str = "ml/model_usage.json",
     # Ladění pro BTCUSDT 2h:
@@ -56,9 +56,9 @@ def combine_predictions(
         ml_prob = pd.Series(np.asarray(ml_cls, dtype=np.float32), index=df.index)
 
     if method == "majority":
-        return ((rule_preds + (ml_prob >= 0.5).astype("float32")) > 0).astype("int8")
+        return ((rule_preds + (ml_prob >= 0.5).astype("float32")) > 0).astype("int64")
     if method == "strict":
-        return ((rule_preds + (ml_prob >= 0.5).astype("float32")) == 2).astype("int8")
+        return ((rule_preds + (ml_prob >= 0.5).astype("float32")) == 2).astype("int64")
     if method != "weighted":
         raise ValueError("Unknown combination method")
 
@@ -78,4 +78,4 @@ def combine_predictions(
         elif state == 1 and p <= lo:
             state = 0
         up[i] = state
-    return pd.Series(up, index=df.index)
+    return pd.Series(up, index=df.index, dtype="int64")

--- a/tests/test_historic.py
+++ b/tests/test_historic.py
@@ -4,6 +4,7 @@ import yaml
 
 import ml.train_historic as th
 import ml.xgb_price as xgb_price
+import ml.train_price as tp
 
 
 def _small_models():
@@ -20,27 +21,29 @@ def _small_models():
         }
         return params, 5
 
-    def small_quant(alpha):
+    def small_bound():
         params = {
             "max_depth": 2,
             "eta": 0.1,
             "subsample": 0.8,
             "colsample_bytree": 0.8,
             "tree_method": "hist",
-            "objective": "reg:quantileerror",
-            "quantile_alpha": alpha,
+            "objective": "reg:squarederror",
+            "eval_metric": "rmse",
             "nthread": 1,
             "seed": 42,
         }
         return params, 5
 
-    return small_reg, small_quant
+    return small_reg, small_bound
 
 
 def test_train_historic(tmp_path, monkeypatch):
-    small_reg, small_quant = _small_models()
+    small_reg, small_bound = _small_models()
     monkeypatch.setattr(xgb_price, "build_reg", small_reg)
-    monkeypatch.setattr(xgb_price, "build_quantile", small_quant)
+    monkeypatch.setattr(xgb_price, "build_bound", small_bound)
+    monkeypatch.setattr(tp, "build_reg", small_reg)
+    monkeypatch.setattr(tp, "build_bound", small_bound)
 
     rng = np.random.default_rng(0)
     n = 300
@@ -71,7 +74,7 @@ def test_train_historic(tmp_path, monkeypatch):
         "horizon_min": 120,
         "embargo": 24,
         "target_kind": "log",
-        "xgb_params": {"reg": {}, "quantile": {}},
+        "xgb_params": {"reg": {}, "bound": {}},
         "quantiles": {"low": 0.1, "high": 0.9},
         "fees": {"taker": 0.0004},
         "features": {"path": "analysis/feature_list.json"},

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -46,27 +46,29 @@ def test_model_meta(tmp_path, monkeypatch):
         }
         return params, 10
 
-    def small_quant(alpha):
+    def small_bound():
         params = {
             "max_depth": 3,
             "eta": 0.1,
             "subsample": 0.8,
             "colsample_bytree": 0.8,
             "tree_method": "hist",
-            "objective": "reg:quantileerror",
-            "quantile_alpha": alpha,
+            "objective": "reg:squarederror",
+            "eval_metric": "rmse",
             "nthread": 1,
             "seed": 42,
         }
         return params, 10
 
     monkeypatch.setattr(xgb_price, "build_reg", small_reg)
-    monkeypatch.setattr(xgb_price, "build_quantile", small_quant)
+    monkeypatch.setattr(xgb_price, "build_bound", small_bound)
+    monkeypatch.setattr(tp, "build_reg", small_reg)
+    monkeypatch.setattr(tp, "build_bound", small_bound)
     config = TrainConfig(
         horizon_min=120,
         embargo=24,
         target_kind="log",
-        xgb_params={"reg": {}, "quantile": {}},
+        xgb_params={"reg": {}, "bound": {}},
         quantiles={"low": 0.1, "high": 0.9},
         fees={"taker": 0.0004},
         features=FeatureConfig(path=Path("analysis/feature_list.json")),

--- a/tests/test_smoke_train_price.py
+++ b/tests/test_smoke_train_price.py
@@ -32,36 +32,36 @@ def test_smoke_train_price(monkeypatch, tmp_path):
     )
 
     def small_reg():
-        model = xgb_price.xgb.XGBRegressor(
-            n_estimators=10,
-            max_depth=3,
-            learning_rate=0.1,
-            subsample=0.8,
-            colsample_bytree=0.8,
-            tree_method="hist",
-            n_jobs=1,
-            eval_metric="rmse",
-            random_state=42,
-        )
-        return model
+        params = {
+            "max_depth": 3,
+            "eta": 0.1,
+            "subsample": 0.8,
+            "colsample_bytree": 0.8,
+            "tree_method": "hist",
+            "eval_metric": "rmse",
+            "nthread": 1,
+            "seed": 42,
+        }
+        return params, 10
 
-    def small_quant(alpha):
-        model = xgb_price.xgb.XGBRegressor(
-            n_estimators=10,
-            max_depth=3,
-            learning_rate=0.1,
-            subsample=0.8,
-            colsample_bytree=0.8,
-            tree_method="hist",
-            n_jobs=1,
-            objective="reg:quantileerror",
-            quantile_alpha=alpha,
-            random_state=42,
-        )
-        return model
+    def small_bound():
+        params = {
+            "max_depth": 3,
+            "eta": 0.1,
+            "subsample": 0.8,
+            "colsample_bytree": 0.8,
+            "tree_method": "hist",
+            "objective": "reg:squarederror",
+            "eval_metric": "rmse",
+            "nthread": 1,
+            "seed": 42,
+        }
+        return params, 10
 
     monkeypatch.setattr(xgb_price, "build_reg", small_reg)
-    monkeypatch.setattr(xgb_price, "build_quantile", small_quant)
+    monkeypatch.setattr(xgb_price, "build_bound", small_bound)
+    monkeypatch.setattr(tp, "build_reg", small_reg)
+    monkeypatch.setattr(tp, "build_bound", small_bound)
 
     def small_folds(n_samples, embargo=24):
         return time_cv.time_folds(n_samples, n_splits=2, embargo=embargo)

--- a/tests/test_xgb_train_smoke.py
+++ b/tests/test_xgb_train_smoke.py
@@ -45,28 +45,30 @@ def test_xgb_train_smoke(monkeypatch, tmp_path):
         }
         return params, 5
 
-    def small_quant(alpha: float):
+    def small_bound():
         params = {
             "max_depth": 2,
             "eta": 0.1,
             "subsample": 0.8,
             "colsample_bytree": 0.8,
             "tree_method": "hist",
-            "objective": "reg:quantileerror",
-            "quantile_alpha": alpha,
+            "objective": "reg:squarederror",
+            "eval_metric": "rmse",
             "nthread": 1,
             "seed": 42,
         }
         return params, 5
 
     monkeypatch.setattr(xgb_price, "build_reg", small_reg)
-    monkeypatch.setattr(xgb_price, "build_quantile", small_quant)
+    monkeypatch.setattr(xgb_price, "build_bound", small_bound)
+    monkeypatch.setattr(tp, "build_reg", small_reg)
+    monkeypatch.setattr(tp, "build_bound", small_bound)
 
     config = TrainConfig(
         horizon_min=120,
         embargo=24,
         target_kind="log",
-        xgb_params={"reg": {}, "quantile": {}},
+        xgb_params={"reg": {}, "bound": {}},
         quantiles={"low": 0.1, "high": 0.9},
         fees={"taker": 0.0004},
         features=FeatureConfig(path=Path("analysis/feature_list.json")),


### PR DESCRIPTION
## Summary
- compute future low/high deltas and targets
- train and save separate low/high bound models alongside midpoint regressor
- update inference pipeline and API to use low/high bounds and return int64 combined predictions

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c53d4a315883279167e34d3228f7fc