### PR TITLE
refactor price bounds and prediction store

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A modular Python project for **cryptocurrency price analysis and prediction** us
 - Aggregates multiple ML models using usage-based weighting.
 - Forecast loop ensembles all regression models via usage-based weights.
 - Combines signals for final trading decision.
+- Bound-model pipeline outputs price interval `p_low` ≤ `p_hat` ≤ `p_high`.
 - Fully modular and easy to expand.
 
 ---

--- a/crypto_analyzer/schemas.py
+++ b/crypto_analyzer/schemas.py
@@ -15,7 +15,7 @@ class TrainConfig(BaseModel):
     embargo: int = Field(..., ge=0)
     target_kind: Literal["log", "lin"] = "log"
     xgb_params: dict[str, dict[str, Any]]
-    quantiles: dict[str, float]
+    bounds: dict[str, float]
     fees: dict[str, float] | None = None
     features: FeatureConfig
     n_jobs: int = 4

--- a/db/predictions_store.py
+++ b/db/predictions_store.py
@@ -2,7 +2,7 @@ import os
 import sqlite3
 
 DB_PATH = "db/data/crypto_data.sqlite"  # same DB like prices
-TABLE_NAME = "prediction"  # new table for predictions
+TABLE_NAME = "predictions"
 
 
 def _ensure_dir(path):
@@ -13,47 +13,39 @@ def create_predictions_table(db_path=DB_PATH, table_name=TABLE_NAME):
     _ensure_dir(db_path)
     conn = sqlite3.connect(db_path)
     c = conn.cursor()
-    c.execute(
-        f"""
-    CREATE TABLE IF NOT EXISTS {table_name} (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        symbol TEXT NOT NULL,
-        interval TEXT NOT NULL,
-        horizon_steps INTEGER NOT NULL,
-        prediction_time_ms INTEGER NOT NULL,  -- t (time)
-        target_time_ms INTEGER NOT NULL,      -- t+H (time close)
-        prediction_time_cet TEXT,             -- Prague time (human readable)
-        target_time_cet TEXT,                 -- Prague time for target
-        y_pred REAL NOT NULL,                 -- predict price
-        y_pred_low REAL,                      -- min across ensemble
-        y_pred_high REAL,                     -- max across ensemble
-        y_true REAL,                          -- fill up at backfill
-        abs_error REAL,                       -- |y_pred - y_true|
-        model_name TEXT,
-        features_version TEXT,
-        created_at TEXT NOT NULL
-    );
-    """
-    )
-    # Ensure new columns exist if table was created previously without them
     cols = {r[1] for r in c.execute(f"PRAGMA table_info({table_name})")}
-    for col, coltype in (
-        ("prediction_time_cet", "TEXT"),
-        ("target_time_cet", "TEXT"),
-        ("y_pred_low", "REAL"),
-        ("y_pred_high", "REAL"),
-    ):
-        if col not in cols:
-            c.execute(f"ALTER TABLE {table_name} ADD COLUMN {col} {coltype}")
-    # useful indexes
-    c.execute(f"CREATE INDEX IF NOT EXISTS idx_{table_name}_symbol ON {table_name}(symbol)")
-    c.execute(
-        f"CREATE INDEX IF NOT EXISTS idx_{table_name}_target_time ON {table_name}(target_time_ms)"
+    if {"p_hat", "p_low", "p_high"} <= cols:
+        c.execute(
+            f"CREATE UNIQUE INDEX IF NOT EXISTS ux_{table_name} "
+            f"ON {table_name}(symbol, interval, target_time_ms)"
+        )
+        conn.commit()
+        conn.close()
+        return
+    c.executescript(
+        f"""
+CREATE TABLE IF NOT EXISTS {table_name}_new (
+  id INTEGER PRIMARY KEY,
+  symbol TEXT NOT NULL,
+  interval TEXT NOT NULL,
+  target_time_ms INTEGER NOT NULL,
+  p_hat REAL,
+  p_low REAL,
+  p_high REAL,
+  y_true_hat REAL,
+  y_true_low REAL,
+  y_true_high REAL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_{table_name} ON {table_name}_new(symbol, interval, target_time_ms);
+"""
     )
-    c.execute(
-        f"CREATE INDEX IF NOT EXISTS idx_{table_name}_pred_time "
-        f"ON {table_name}(symbol, interval, horizon_steps, prediction_time_ms)"
-    )
+    if cols:
+        c.execute(
+            f"INSERT OR IGNORE INTO {table_name}_new(symbol, interval, target_time_ms, p_hat, p_low, p_high) "
+            f"SELECT symbol, interval, target_time_ms, y_pred, y_pred_low, y_pred_high FROM {table_name}"
+        )
+        c.execute(f"ALTER TABLE {table_name} RENAME TO {table_name}_backup")
+    c.execute(f"ALTER TABLE {table_name}_new RENAME TO {table_name}")
     conn.commit()
     conn.close()
 
@@ -63,53 +55,18 @@ def save_predictions(rows, db_path=DB_PATH, table_name=TABLE_NAME):
         return
     conn = sqlite3.connect(db_path)
     c = conn.cursor()
-    row_len = len(rows[0])
-    if row_len == 11:
-        c.executemany(
-            f"""
-          INSERT INTO {table_name} (
-            symbol, interval, horizon_steps, prediction_time_ms, target_time_ms,
-            y_pred, y_true, abs_error, model_name, features_version, created_at
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    c.executemany(
+        f"""
+        INSERT INTO {table_name} (symbol, interval, target_time_ms, p_hat, p_low, p_high)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(symbol, interval, target_time_ms)
+        DO UPDATE SET
+          p_hat=excluded.p_hat,
+          p_low=excluded.p_low,
+          p_high=excluded.p_high
         """,
-            rows,
-        )
-    elif row_len == 13 and isinstance(rows[0][5], int | float):
-        c.executemany(
-            f"""
-          INSERT INTO {table_name} (
-            symbol, interval, horizon_steps, prediction_time_ms, target_time_ms,
-            y_pred, y_pred_low, y_pred_high,
-            y_true, abs_error, model_name, features_version, created_at
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """,
-            rows,
-        )
-    elif row_len == 13:
-        c.executemany(
-            f"""
-          INSERT INTO {table_name} (
-            symbol, interval, horizon_steps, prediction_time_ms, target_time_ms,
-            prediction_time_cet, target_time_cet,
-            y_pred, y_true, abs_error, model_name, features_version, created_at
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """,
-            rows,
-        )
-    elif row_len == 15:
-        c.executemany(
-            f"""
-          INSERT INTO {table_name} (
-            symbol, interval, horizon_steps, prediction_time_ms, target_time_ms,
-            prediction_time_cet, target_time_cet,
-            y_pred, y_pred_low, y_pred_high,
-            y_true, abs_error, model_name, features_version, created_at
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """,
-            rows,
-        )
-    else:
-        raise ValueError(f"Unexpected row length for save_predictions: {row_len}")
+        rows,
+    )
     conn.commit()
     conn.close()
 
@@ -141,7 +98,7 @@ def delete_unmatched_duplicates(db_path: str = DB_PATH, table_name: str = TABLE_
     c = conn.cursor()
     c.execute(
         f"CREATE INDEX IF NOT EXISTS idx_{table_name}_pred_time "
-        f"ON {table_name}(symbol, interval, horizon_steps, prediction_time_ms)"
+        f"ON {table_name}(symbol, interval, target_time_ms)"
     )
     c.execute(
         f"""
@@ -153,7 +110,7 @@ def delete_unmatched_duplicates(db_path: str = DB_PATH, table_name: str = TABLE_
                     ORDER BY id DESC
                 ) AS rn
             FROM {table_name}
-            WHERE y_true IS NULL
+            WHERE y_true_hat IS NULL
         )
         DELETE FROM {table_name}
         WHERE id IN (

--- a/ml/__init__.py
+++ b/ml/__init__.py
@@ -1,16 +1,9 @@
 """Machine learning package."""
 
-from .xgb_price import (
-    build_bound,
-    build_quantile,
-    build_reg,
-    clip_inside,
-    to_price,
-)
+from .xgb_price import build_bound, build_reg, clip_inside, to_price
 
 __all__ = [
     "build_reg",
-    "build_quantile",
     "build_bound",
     "clip_inside",
     "to_price",

--- a/ml/xgb_price.py
+++ b/ml/xgb_price.py
@@ -11,31 +11,19 @@ except (TypeError, xgb.core.XGBoostError):  # pragma: no cover - older XGBoost
 
 def build_reg() -> tuple[dict[str, float | int | str], int]:
     params: dict[str, float | int | str] = {
+        "tree_method": "hist",
+        "device": "cuda",
         "max_depth": 8,
-        "eta": 0.05,
+        "learning_rate": 0.05,
         "subsample": 0.8,
         "colsample_bytree": 0.8,
-        "tree_method": "hist",
-        "eval_metric": "rmse",
-        "nthread": 4,
-        "seed": 42,
-    }
-    return params, 600
-
-
-def build_bound() -> tuple[dict[str, float | int | str], int]:
-    params: dict[str, float | int | str] = {
-        "max_depth": 8,
-        "eta": 0.04,
-        "subsample": 0.8,
-        "colsample_bytree": 0.8,
-        "tree_method": "hist",
+        "nthread": -1,
+        "random_state": 42,
         "objective": "reg:squarederror",
         "eval_metric": "rmse",
-        "nthread": 4,
-        "seed": 42,
     }
-    return params, 800
+    rounds = 600
+    return params, rounds
 
 
 def build_bound() -> tuple[dict[str, float | int | str], int]:
@@ -71,10 +59,4 @@ def clip_inside(p: np.ndarray, lo: np.ndarray, hi: np.ndarray) -> np.ndarray:
     return np.minimum(np.maximum(p, lo), hi)
 
 
-__all__ = [
-    "build_reg",
-    "build_quantile",
-    "build_bound",
-    "to_price",
-    "clip_inside",
-]
+__all__ = ["build_reg", "build_bound", "to_price", "clip_inside"]

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -77,7 +77,7 @@ def test_api_contract(tmp_path, monkeypatch):
         embargo=24,
         target_kind="log",
         xgb_params={"reg": {}, "bound": {}},
-        quantiles={"low": 0.1, "high": 0.9},
+        bounds={"low": 0.1, "high": 0.9},
         fees={"taker": 0.0004},
         features=FeatureConfig(path=Path("analysis/feature_list.json")),
         n_jobs=1,

--- a/tests/test_feature_extremes.py
+++ b/tests/test_feature_extremes.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pandas as pd
+
+from analysis.feature_engineering import create_features
+
+
+def test_future_extreme_targets_once():
+    n = 60
+    ts = pd.date_range("2024-01-01", periods=n, freq="5min", tz="UTC")
+    close = np.linspace(100, 101, n)
+    high = close + 1
+    low = close - 1
+    volume = np.ones(n)
+    qvol = volume * close
+    tbb = volume * 0.5
+    tbq = qvol * 0.5
+    df = pd.DataFrame(
+        {
+            "timestamp": ts,
+            "close": close,
+            "high": high,
+            "low": low,
+            "volume": volume,
+            "quote_asset_volume": qvol,
+            "taker_buy_base": tbb,
+            "taker_buy_quote": tbq,
+        }
+    )
+
+    out = create_features(df)
+    cols = [c for c in out.columns if c.startswith("delta_low") or c.startswith("delta_high")]
+    assert cols == [
+        "delta_low_log_120m",
+        "delta_low_lin_120m",
+        "delta_high_log_120m",
+        "delta_high_lin_120m",
+    ]
+    for c in cols:
+        assert out[c].dtype == np.float32

--- a/tests/test_historic.py
+++ b/tests/test_historic.py
@@ -3,8 +3,8 @@ import pandas as pd
 import yaml
 
 import ml.train_historic as th
-import ml.xgb_price as xgb_price
 import ml.train_price as tp
+import ml.xgb_price as xgb_price
 
 
 def _small_models():
@@ -75,7 +75,7 @@ def test_train_historic(tmp_path, monkeypatch):
         "embargo": 24,
         "target_kind": "log",
         "xgb_params": {"reg": {}, "bound": {}},
-        "quantiles": {"low": 0.1, "high": 0.9},
+        "bounds": {"low": 0.1, "high": 0.9},
         "fees": {"taker": 0.0004},
         "features": {"path": "analysis/feature_list.json"},
         "n_jobs": 1,

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -69,7 +69,7 @@ def test_model_meta(tmp_path, monkeypatch):
         embargo=24,
         target_kind="log",
         xgb_params={"reg": {}, "bound": {}},
-        quantiles={"low": 0.1, "high": 0.9},
+        bounds={"low": 0.1, "high": 0.9},
         fees={"taker": 0.0004},
         features=FeatureConfig(path=Path("analysis/feature_list.json")),
         n_jobs=1,

--- a/tests/test_meta_models.py
+++ b/tests/test_meta_models.py
@@ -138,7 +138,7 @@ def test_regressor_prediction_intervals(tmp_path: Path) -> None:
             FEATURE_COLUMNS,
             model_path=str(tmp_path / "rpi.joblib"),
             return_pi=True,
-            quantiles=(0.1, 0.5, 0.9),
+            # use default interval settings
         ),
     )
     assert isinstance(preds, np.ndarray)
@@ -201,7 +201,8 @@ def test_integration_small_sample(tmp_path: Path) -> None:
     assert probas.shape[0] == prices.shape[0] == len(train_df)
     # metadata files were saved
     assert (tmp_path / "features.json").exists()
-    assert json.load(open(tmp_path / "ver.json"))
+    with open(tmp_path / "ver.json") as f:
+        assert json.load(f)
     assert (tmp_path / "thr.json").exists()
 
 
@@ -328,5 +329,6 @@ def test_threshold_respected(tmp_path: Path) -> None:
         model_path=str(tmp_path / "th_model.joblib"),
         threshold_path=str(tmp_path / "threshold.json"),
     )
-    thr = json.load(open(tmp_path / "threshold.json"))["threshold"]
+    with open(tmp_path / "threshold.json") as f:
+        thr = json.load(f)["threshold"]
     assert np.array_equal(preds, (probas >= thr).astype(int))

--- a/tests/test_predictions_store.py
+++ b/tests/test_predictions_store.py
@@ -1,0 +1,18 @@
+import sqlite3
+
+from db.predictions_store import create_predictions_table, save_predictions
+
+
+def test_predictions_upsert(tmp_path):
+    db_path = tmp_path / "preds.sqlite"
+    create_predictions_table(db_path=str(db_path))
+    row1 = ("BTC", "5m", 1_000, 10.0, 9.0, 11.0)
+    row2 = ("BTC", "5m", 1_000, 10.5, 9.5, 11.5)
+    save_predictions([row1], db_path=str(db_path))
+    save_predictions([row2], db_path=str(db_path))
+    with sqlite3.connect(db_path) as conn:
+        c = conn.cursor()
+        c.execute("SELECT COUNT(*) FROM predictions")
+        assert c.fetchone()[0] == 1
+        c.execute("SELECT p_hat, p_low, p_high FROM predictions WHERE symbol='BTC'")
+        assert c.fetchone() == (10.5, 9.5, 11.5)

--- a/tests/test_xgb_train_smoke.py
+++ b/tests/test_xgb_train_smoke.py
@@ -69,7 +69,7 @@ def test_xgb_train_smoke(monkeypatch, tmp_path):
         embargo=24,
         target_kind="log",
         xgb_params={"reg": {}, "bound": {}},
-        quantiles={"low": 0.1, "high": 0.9},
+        bounds={"low": 0.1, "high": 0.9},
         fees={"taker": 0.0004},
         features=FeatureConfig(path=Path("analysis/feature_list.json")),
         n_jobs=1,


### PR DESCRIPTION
## Summary
- add future low/high price deltas without duplication and validate targets
- switch XGBoost utilities and training to reg/low/high bound models
- redesign predictions DB with p_low/p_hat/p_high and unique upsert logic

## Testing
- `pre-commit run --files analysis/feature_engineering.py ml/xgb_price.py ml/__init__.py ml/train_price.py db/predictions_store.py tests/test_feature_extremes.py tests/test_predictions_store.py README.md crypto_analyzer/schemas.py tests/test_xgb_train_smoke.py tests/test_api_contract.py tests/test_meta.py tests/test_meta_models.py tests/test_historic.py`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c53938f8988327a4913fd75739093e