### PR TITLE
Add on-chain data hooks and GPU-ready dependencies

### DIFF
--- a/api/onchain.py
+++ b/api/onchain.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+import requests
+from pydantic import BaseModel
+from requests.adapters import HTTPAdapter, Retry
+
+
+class OnChainConfig(BaseModel):
+    use_mempool: bool = True
+    use_exchange_flows: bool = True
+    use_usdt_events: bool = True
+    cache_dir: str = "data/cache"
+    glassnode_api_key: str | None = None
+    whale_api_key: str | None = None
+
+
+CONFIG = OnChainConfig()
+
+
+def _session() -> requests.Session:
+    retries = Retry(total=3, backoff_factor=1, status_forcelist=[429, 500, 502, 503, 504])
+    s = requests.Session()
+    s.mount("https://", HTTPAdapter(max_retries=retries))
+    return s
+
+
+def _cache_path(prefix: str, start: datetime | None = None, end: datetime | None = None) -> Path:
+    cache_dir = Path(CONFIG.cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    if start and end:
+        key = f"{prefix}_{start:%Y%m%d%H%M}_{end:%Y%m%d%H%M}.parquet"
+    else:
+        key = f"{prefix}.parquet"
+    return cache_dir / key
+
+
+def fetch_mempool_5m(start: datetime, end: datetime) -> pd.DataFrame:
+    start = pd.to_datetime(start, utc=True)
+    end = pd.to_datetime(end, utc=True)
+    cache_file = _cache_path("mempool5m", start, end)
+    if cache_file.exists():
+        return pd.read_parquet(cache_file)
+
+    sess = _session()
+    params = {"start": int(start.timestamp()), "end": int(end.timestamp())}
+    tx = sess.get("https://mempool.space/api/v1/statistics/transactions", params=params, timeout=10)
+    fee = sess.get("https://mempool.space/api/v1/statistics/fees/median", params=params, timeout=10)
+    tx.raise_for_status()
+    fee.raise_for_status()
+    df_tx = pd.DataFrame(tx.json())
+    df_fee = pd.DataFrame(fee.json())
+    df = pd.merge(df_tx, df_fee, on="time", how="outer")
+    df["time"] = pd.to_datetime(df["time"], unit="s", utc=True)
+    df = df.set_index("time").sort_index()
+    df = df.resample("5T").agg({"tx_count": "sum", "median_fee": "median"})
+    df.to_parquet(cache_file)
+    return df
+
+
+def load_exchange_flows_1h(
+    source: str = "csv",
+    path: str | None = None,
+    glassnode_api_key: str | None = None,
+) -> pd.DataFrame:
+    cache_file = _cache_path(f"exchange_flows_{source}")
+    if cache_file.exists():
+        return pd.read_parquet(cache_file)
+
+    if source == "csv":
+        if not path:
+            raise ValueError("CSV source requires `path`")
+        df = pd.read_csv(path, parse_dates=[0])
+        df = df.set_index(df.columns[0]).sort_index()
+    elif source == "glassnode":
+        key = glassnode_api_key or CONFIG.glassnode_api_key
+        if not key:
+            raise ValueError("glassnode_api_key required")
+        sess = _session()
+        base = "https://api.glassnode.com/v1/metrics/exchanges"
+        params = {"a": "BTC", "i": "1h", "api_key": key}
+        inflow = sess.get(f"{base}/inflow_sum", params=params, timeout=10)
+        outflow = sess.get(f"{base}/outflow_sum", params=params, timeout=10)
+        inflow.raise_for_status()
+        outflow.raise_for_status()
+        df_in = pd.DataFrame(inflow.json())
+        df_out = pd.DataFrame(outflow.json())
+        df = pd.merge(df_in, df_out, on="t", how="outer", suffixes=("_in", "_out"))
+        df["time"] = pd.to_datetime(df["t"], unit="s", utc=True)
+        df = df.set_index("time").drop(columns=["t_in", "t_out"], errors="ignore")
+        df.rename(columns={"v_in": "inflow", "v_out": "outflow"}, inplace=True)
+        df["netflow"] = df["inflow"] - df["outflow"]
+    else:
+        raise ValueError("source must be 'csv' or 'glassnode'")
+
+    df = df.resample("1H").sum(min_count=1)
+    df.to_parquet(cache_file)
+    return df
+
+
+def fetch_usdt_events(start: datetime, end: datetime, api_key: str | None = None) -> pd.DataFrame:
+    start = pd.to_datetime(start, utc=True)
+    end = pd.to_datetime(end, utc=True)
+    cache_file = _cache_path("usdt_events", start, end)
+    if cache_file.exists():
+        return pd.read_parquet(cache_file)
+
+    key = api_key or CONFIG.whale_api_key
+    if not key:
+        raise ValueError("api_key required for Whale Alert")
+    sess = _session()
+    params = {
+        "start": int(start.timestamp()),
+        "end": int(end.timestamp()),
+        "currency": "usdt",
+        "api_key": key,
+    }
+    resp = sess.get("https://api.whale-alert.io/v1/transactions", params=params, timeout=10)
+    resp.raise_for_status()
+    data = resp.json().get("transactions", [])
+    records: list[dict[str, float]] = []
+    for tx in data:
+        ts = pd.to_datetime(tx.get("timestamp"), unit="s", utc=True)
+        usd = float(tx.get("amount_usd", 0.0))
+        records.append({"timestamp": ts, "usd": usd})
+    df = pd.DataFrame(records)
+    if not df.empty:
+        df = df.set_index("timestamp").sort_index()
+        df["count"] = 1
+        df = df.resample("5T").agg({"count": "sum", "usd": "sum"})
+    else:
+        idx = pd.DatetimeIndex([], tz="UTC")
+        df = pd.DataFrame(columns=["count", "usd"], index=idx)
+    df.to_parquet(cache_file)
+    return df
+
+
+__all__ = [
+    "OnChainConfig",
+    "fetch_mempool_5m",
+    "load_exchange_flows_1h",
+    "fetch_usdt_events",
+]
+

--- a/ml/train.py
+++ b/ml/train.py
@@ -48,7 +48,7 @@ def train_model(
     """
     Trénuje meta-klasifikátor pomocí XGBoost (pandas+numpy only).
     - float32 vstupy
-    - GPU akcelerace přes device="cuda" s fallbackem na CPU
+    - GPU akcelerace přes tree_method="gpu_hist" a predictor="gpu_predictor" s fallbackem na CPU
     - early stopping (callbacks nebo early_stopping_rounds dle verze)
     """
     # Train/val split
@@ -71,8 +71,8 @@ def train_model(
         learning_rate=0.08,
         subsample=0.8,
         colsample_bytree=0.8,
-        tree_method="hist",
-        device=("cuda" if use_gpu else "cpu"),
+        tree_method=("gpu_hist" if use_gpu else "hist"),
+        predictor=("gpu_predictor" if use_gpu else "cpu_predictor"),
         n_jobs=-1,
         eval_metric="logloss",
         random_state=random_state,
@@ -86,7 +86,7 @@ def train_model(
         _fit_no_es(clf, X_train, y_train, X_val, y_val)
     except xgb.core.XGBoostError:
         logger.warning("CUDA not available or failed. Falling back to CPU.")
-        clf.set_params(device="cpu")
+        clf.set_params(tree_method="hist", predictor="cpu_predictor")
         _fit_no_es(clf, X_train, y_train, X_val, y_val)
 
     # Vyhodnocení a uložení

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,19 +8,26 @@ version = "0.1.0"
 description = "Utilities for crypto market analysis"
 requires-python = ">=3.13"
 dependencies = [
-    "pandas>=2.2",
-    "numpy>=1.26",
-    "scikit-learn~=1.7.1",
-    "scipy~=1.16.2",
-    "requests~=2.32.5",
-    "joblib~=1.5.1",
-    "PyYAML~=6.0.2",
-    "tqdm~=4.67.1",
-    "xgboost>=2.0",
-    "shap",
+    "numpy",
+    "pandas",
+    "scipy",
+    "scikit-learn",
+    "xgboost>=2.1,<4",
+    "shap>=0.46",
+    "numba",
+    "requests",
+    "pydantic",
+    "python-dateutil",
+    "tqdm",
+    "pyarrow",
+    "matplotlib",
+    "joblib",
+    "PyYAML",
     "fastapi",
     "uvicorn",
     "httpx",
+    "ta",
+    "torch",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,23 @@
 python-dotenv
-pandas>=2.2
-numpy>=1.26
-scikit-learn~=1.7.1
-scipy~=1.16.2
+numpy
+pandas
+scipy
+scikit-learn
+xgboost>=2.1,<4
+shap>=0.46
+numba
+requests
+pydantic
+python-dateutil
+tqdm
+pyarrow
 matplotlib
 ta
 # PyTorch:
 torch
 
-requests~=2.32.5
-joblib~=1.5.1
-PyYAML~=6.0.2
-tqdm~=4.67.1
-xgboost>=2.0
-shap
+joblib
+PyYAML
 fastapi
 uvicorn
 httpx

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Python version: $(python --version 2>&1)"
+
+if command -v nvidia-smi >/dev/null 2>&1; then
+  echo "CUDA detected"
+  nvidia-smi || true
+else
+  echo "CUDA not detected"
+fi
+
+python - <<'PY'
+import importlib, json
+
+def log_pkg(name):
+    try:
+        mod = importlib.import_module(name)
+        ver = getattr(mod, '__version__', 'unknown')
+        print(f"{name} {ver}")
+        if name == 'xgboost':
+            info = getattr(mod, 'build_info', lambda: {})()
+            cuda = info.get('USE_CUDA') or info.get('CUDA')
+            print(f"  CUDA support: {cuda}")
+    except Exception as exc:  # pragma: no cover
+        print(f"{name} not available: {exc}")
+
+for pkg in [
+    'numpy',
+    'pandas',
+    'scipy',
+    'sklearn',
+    'xgboost',
+    'shap',
+    'numba',
+    'requests',
+    'pydantic',
+    'dateutil',
+    'tqdm',
+    'pyarrow',
+    'matplotlib',
+]:
+    log_pkg(pkg)
+PY
+


### PR DESCRIPTION
## Summary
- update requirements for Python 3.13 and GPU-enabled XGBoost
- add environment setup script with CUDA/wheel checks
- introduce on-chain data API utilities

## Testing
- `scripts/setup_env.sh`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c70867a4c08327bf56fe55eb486748