### PR TITLE
Add feature grouping, targets, and walk-forward split

### DIFF
--- a/analysis/targets.py
+++ b/analysis/targets.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def _infer_step_minutes(ts: pd.Series) -> int:
+    """Infer sampling period in minutes from a timestamp series."""
+    if len(ts) < 2:
+        return 1
+    delta = ts.diff().dropna().median()
+    if isinstance(delta, pd.Timedelta):
+        step = int(delta.total_seconds() // 60)
+        return max(step, 1)
+    return 1
+
+
+def make_targets(
+    df: pd.DataFrame,
+    horizons_min: list[int] | None = None,
+    txn_cost_bps: float = 1.0,
+    use_three_class: bool = False,
+) -> pd.DataFrame:
+    """Create regression and classification targets for future price moves.
+
+    Parameters
+    ----------
+    df:
+        Input dataframe containing at least ``close``, ``high``, ``low`` and
+        ``timestamp`` columns.
+    horizons_min:
+        List of horizons in minutes for which targets will be generated.
+        Defaults to ``[120]``.
+    txn_cost_bps:
+        Transaction cost threshold in basis points used for the
+        ``beyond_costs`` classification label.
+    use_three_class:
+        If ``True`` the ``beyond_costs`` label returns three classes ``-1``,
+        ``0`` and ``1``. Otherwise it is a binary ``0/1`` label.
+    """
+
+    if horizons_min is None:
+        horizons_min = [120]
+
+    df = df.copy(deep=False)
+    ts = pd.to_datetime(df["timestamp"])
+    step_minutes = _infer_step_minutes(ts)
+
+    for horizon in horizons_min:
+        periods = max(1, int(round(horizon / step_minutes)))
+
+        fut_close = df["close"].shift(-periods)
+        delta_log = np.log(fut_close / df["close"]).astype(np.float32)
+        delta_lin = (fut_close - df["close"]).astype(np.float32)
+        df[f"delta_log_{horizon}m"] = delta_log
+        df[f"delta_lin_{horizon}m"] = delta_lin
+
+        fut_high = df["high"].shift(-periods + 1).rolling(periods).max()
+        fut_low = df["low"].shift(-periods + 1).rolling(periods).min()
+        df[f"delta_high_{horizon}m"] = (fut_high - df["close"]).astype(np.float32)
+        df[f"delta_low_{horizon}m"] = (fut_low - df["close"]).astype(np.float32)
+
+        df[f"cls_sign_{horizon}m"] = (delta_log > 0).astype(np.int8)
+
+        thresh = df["close"] * (txn_cost_bps / 10_000)
+        bc = np.where(delta_lin > thresh, 1, np.where(delta_lin < -thresh, -1, 0))
+        if not use_three_class:
+            bc = np.where(bc == 1, 1, 0)
+        df[f"beyond_costs_{horizon}m"] = bc.astype(np.int8)
+
+    return df

--- a/ml/train.py
+++ b/ml/train.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 from sklearn.model_selection import train_test_split
 import xgboost as xgb
+from utils.splitting import WalkForwardSplit
 
 from ml.model_utils import evaluate_model
 from crypto_analyzer.model_manager import atomic_write
@@ -44,6 +45,8 @@ def train_model(
     oob_step: int = 50,              # nevyužito u XGBoost, ponecháno pro signaturu
     max_estimators: int = 400,       # nevyužito u XGBoost, ponecháno pro signaturu
     log_path: str = "ml/oob_cls.json",
+    split: str = "holdout",
+    wfs_params: dict[str, int] | None = None,
 ):
     """
     Trénuje meta-klasifikátor pomocí XGBoost (pandas+numpy only).
@@ -51,20 +54,6 @@ def train_model(
     - GPU akcelerace přes tree_method="gpu_hist" a predictor="gpu_predictor" s fallbackem na CPU
     - early stopping (callbacks nebo early_stopping_rounds dle verze)
     """
-    # Train/val split
-    X_train, X_val, y_train, y_val = train_test_split(
-        X, y, test_size=test_size, random_state=random_state, stratify=y
-    )
-
-    # float32 a zachování DataFrame kvůli feature_names_in_
-    if isinstance(X_train, pd.DataFrame):
-        X_train = _to_f32(X_train)
-        X_val = _to_f32(X_val)
-    else:
-        X_train = _to_f32(X_train)
-        X_val = _to_f32(X_val)
-
-    # Parametry zvolené pro rychlý a stabilní meta-model
     base_params: dict[str, Any] = dict(
         n_estimators=400,
         max_depth=6,
@@ -78,6 +67,93 @@ def train_model(
         random_state=random_state,
         verbosity=0,
     )
+
+    if split == "walkforward":
+        if not isinstance(X, pd.DataFrame) or "timestamp" not in X.columns:
+            raise ValueError("Walkforward split vyžaduje DataFrame s 'timestamp'")
+        df = X.reset_index(drop=True)
+        features = df.drop(columns=["timestamp"])  # training features
+        y_series = pd.Series(y).reset_index(drop=True)
+
+        params = wfs_params or {
+            "train_span_days": 30,
+            "test_span_days": 7,
+            "step_days": 7,
+            "min_train_days": 30,
+        }
+        splitter = WalkForwardSplit(**params)
+
+        fold_metrics: list[dict[str, float]] = []
+        preds_frames: list[pd.DataFrame] = []
+
+        for fold, (train_idx, test_idx) in enumerate(splitter.split(df)):
+            X_train = _to_f32(features.iloc[train_idx])
+            y_train = y_series.iloc[train_idx]
+            X_val = _to_f32(features.iloc[test_idx])
+            y_val = y_series.iloc[test_idx]
+
+            clf = xgb.XGBClassifier(**base_params)
+            try:
+                _fit_no_es(clf, X_train, y_train, X_val, y_val)
+            except xgb.core.XGBoostError:
+                logger.warning("CUDA not available or failed. Falling back to CPU.")
+                clf.set_params(tree_method="hist", predictor="cpu_predictor")
+                _fit_no_es(clf, X_train, y_train, X_val, y_val)
+
+            acc, f1 = evaluate_model(clf, X_val, y_val)
+            fold_metrics.append({"fold": fold, "accuracy": acc, "f1": f1})
+
+            preds = clf.predict(X_val)
+            preds_frames.append(
+                pd.DataFrame(
+                    {"fold": fold, "y_true": y_val, "y_pred": preds},
+                    index=test_idx,
+                )
+            )
+
+        # uložit metriky
+        metrics_data = {"folds": fold_metrics}
+        atomic_write(Path(log_path), json.dumps(metrics_data, indent=2).encode("utf-8"))
+
+        # uložit predikce
+        if preds_frames:
+            preds_df = pd.concat(preds_frames).sort_index()
+            pred_path = Path(log_path).with_suffix(".preds.csv")
+            preds_df.to_csv(pred_path, index_label="index")
+
+        # finální model natrénujeme na všech datech
+        X_full = _to_f32(features)
+        y_full = y_series
+        clf = xgb.XGBClassifier(**base_params)
+        try:
+            _fit_no_es(clf, X_full, y_full, X_full, y_full)
+        except xgb.core.XGBoostError:
+            logger.warning("CUDA not available or failed. Falling back to CPU.")
+            clf.set_params(tree_method="hist", predictor="cpu_predictor")
+            _fit_no_es(clf, X_full, y_full, X_full, y_full)
+
+        buffer = BytesIO()
+        joblib.dump(clf, buffer)
+        atomic_write(Path(model_path), buffer.getvalue())
+        print(f"Model saved to {model_path}")
+        return clf
+
+    # --- defaultní holdout split ---------------------------------------------
+
+    if isinstance(X, pd.DataFrame) and "timestamp" in X.columns:
+        X = X.drop(columns=["timestamp"])
+
+    X_train, X_val, y_train, y_val = train_test_split(
+        X, y, test_size=test_size, random_state=random_state, stratify=y
+    )
+
+    # float32 a zachování DataFrame kvůli feature_names_in_
+    if isinstance(X_train, pd.DataFrame):
+        X_train = _to_f32(X_train)
+        X_val = _to_f32(X_val)
+    else:
+        X_train = _to_f32(X_train)
+        X_val = _to_f32(X_val)
 
     clf = xgb.XGBClassifier(**base_params)
 

--- a/utils/splitting.py
+++ b/utils/splitting.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from collections.abc import Iterator
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class WalkForwardSplit:
+    """Generate walk-forward time splits without leakage.
+
+    Parameters
+    ----------
+    train_span_days:
+        Number of days used for the training window.
+    test_span_days:
+        Number of days used for the test window following each training span.
+    step_days:
+        Number of days the window is moved forward after each fold.
+    min_train_days:
+        Minimal amount of days required before the first split is produced.
+    """
+
+    train_span_days: int
+    test_span_days: int
+    step_days: int
+    min_train_days: int
+
+    def split(self, df: pd.DataFrame) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+        """Yield train and test indices for each fold.
+
+        The dataframe must contain a ``timestamp`` column with timezone aware
+        ``datetime64`` values.  Returned indices refer to the original order of
+        ``df``.
+        """
+
+        if "timestamp" not in df.columns:
+            raise ValueError("DataFrame must contain 'timestamp' column")
+
+        ts = pd.to_datetime(df["timestamp"]).reset_index(drop=True)
+
+        start_time = ts.min() + pd.Timedelta(days=self.min_train_days)
+        test_start = start_time
+        end_time = ts.max()
+
+        while True:
+            train_end = test_start
+            train_start = train_end - pd.Timedelta(days=self.train_span_days)
+            test_end = train_end + pd.Timedelta(days=self.test_span_days)
+            if test_end > end_time:
+                break
+
+            train_mask = (ts >= train_start) & (ts < train_end)
+            test_mask = (ts >= train_end) & (ts < test_end)
+            train_idx = np.where(train_mask)[0]
+            test_idx = np.where(test_mask)[0]
+            if len(train_idx) == 0 or len(test_idx) == 0:
+                break
+            yield train_idx, test_idx
+
+            test_start = test_start + pd.Timedelta(days=self.step_days)


### PR DESCRIPTION
## Summary
- group features for SHAP analysis and helper to assign groups
- provide target generation utilities for 2h horizons with transaction cost labels
- implement walk-forward splitting and integrate into training pipeline

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c711d95250832792d4eb9b2fd4f480