### PR TITLE
Add CLI training pipeline with on-chain option and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ python db/btc_import.py
 
 This creates the `db/data/crypto_data.sqlite` file with price data.
 
+### 4. Optional on-chain data
+
+On-chain metrics can be merged from public APIs:
+
+* [mempool.space](https://mempool.space/api/) – mempool stats (no key required)
+* [Glassnode](https://glassnode.com/) – exchange flows (API key optional)
+* [Whale Alert](https://developer.whale-alert.io/) – large transfers/mints (API key optional)
+
+Store the resulting metrics alongside price data in the SQLite `prices` table
+with column names prefixed by `onch_`.
+
 ### 4. Run analysis and prediction
 
 ```bash
@@ -80,6 +91,25 @@ python main.py
 ```
 
 By default, this trains a RandomForest model and outputs the latest signals.
+
+### 5. Run the training pipeline
+
+Example commands for 120‑minute horizon:
+
+```bash
+# Classification
+python main.py --task clf --horizon 120 --split_params '{"test_size":0.2}' --out_dir outputs --use_onchain
+
+# Regression
+python main.py --task reg --horizon 120 --split_params '{"test_size":0.2}' --out_dir outputs --use_onchain
+```
+
+The pipeline writes metrics and predictions to CSV files and a simple PNG plot
+into the chosen `outputs/` directory.  Run configuration is logged as
+`outputs/run_config.json`.
+
+> **Note:** When adding on-chain signals, resample them to the candle interval
+> (5 min) before merging to prevent look‑ahead leakage.
 
 ---
 

--- a/scripts/run_demo.sh
+++ b/scripts/run_demo.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+python main.py --task clf --horizon 120 --use_onchain --split_params '{"test_size":0.2}' --out_dir outputs/demo_clf
+python main.py --task reg --horizon 120 --use_onchain --split_params '{"test_size":0.2}' --out_dir outputs/demo_reg

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -1,0 +1,84 @@
+import json
+import os
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+def _create_synth_db(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE prices (
+            open_time INTEGER PRIMARY KEY,
+            symbol TEXT,
+            interval TEXT,
+            open REAL,
+            high REAL,
+            low REAL,
+            close REAL,
+            volume REAL,
+            quote_asset_volume REAL,
+            number_of_trades INTEGER,
+            taker_buy_base REAL,
+            taker_buy_quote REAL,
+            onch_dummy REAL
+        )
+        """
+    )
+    base_ts = pd.Timestamp("2024-01-01", tz="UTC")
+    periods = 10 * 24 * 12  # 10 days of 5m data
+    ts = base_ts + pd.to_timedelta(np.arange(periods) * 5, unit="m")
+    df = pd.DataFrame(
+        {
+            "open_time": (ts.view("int64") // 1_000_000).astype(int),
+            "symbol": "BTCUSDT",
+            "interval": "5m",
+            "open": np.random.rand(periods) + 10000,
+            "high": np.random.rand(periods) + 10001,
+            "low": np.random.rand(periods) + 9999,
+            "close": np.random.rand(periods) + 10000,
+            "volume": np.random.rand(periods),
+            "quote_asset_volume": np.random.rand(periods),
+            "number_of_trades": np.random.randint(1, 100, size=periods),
+            "taker_buy_base": np.random.rand(periods),
+            "taker_buy_quote": np.random.rand(periods),
+            "onch_dummy": np.random.rand(periods),
+        }
+    )
+    df.to_sql("prices", conn, if_exists="append", index=False)
+    conn.close()
+
+
+def _run_pipeline(tmp_path: Path, task: str) -> None:
+    db_path = tmp_path / "data.sqlite"
+    if not db_path.exists():
+        _create_synth_db(db_path)
+    out_dir = tmp_path / "outputs"
+    env = os.environ.copy()
+    env["DB_PATH"] = str(db_path)
+    cmd = [
+        "python",
+        "main.py",
+        "--task",
+        task,
+        "--horizon",
+        "120",
+        "--split_params",
+        json.dumps({"test_size": 0.2}),
+        "--out_dir",
+        str(out_dir),
+        "--use_onchain",
+    ]
+    subprocess.run(cmd, check=True, cwd=Path(__file__).resolve().parent.parent, env=env)
+    assert (out_dir / "run_config.json").exists()
+    assert (out_dir / f"{task}_model.json").exists()
+
+
+def test_pipeline_smoke(tmp_path):
+    _run_pipeline(tmp_path, "clf")
+    _run_pipeline(tmp_path, "reg")


### PR DESCRIPTION
## Summary
- add run_pipeline in `main.py` with CLI options for classification/regression, on-chain features and config logging
- extend SQLite loader to pull all columns including `onch_*`
- document data sources and pipeline usage, add demo script and smoke test

## Testing
- `pre-commit run --files README.md db/db_connector.py main.py scripts/run_demo.sh tests/test_pipeline_smoke.py`
- `pytest tests/test_pipeline_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c71a11699c832783e499515ea13156