### PR TITLE
Export feature diagnostics and prefix on-chain metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,41 @@ into the chosen `outputs/` directory.  Run configuration is logged as
 
 ---
 
+## Training on Historical Data
+
+The project can be trained end‑to‑end on past data to evaluate strategies or to
+produce models for later inference.  The following example demonstrates a
+typical workflow for a 2‑hour classification horizon:
+
+1. **Download candles** – adjust the symbol and date range in
+   `db/btc_import.py` and run:
+
+   ```bash
+   python db/btc_import.py
+   ```
+
+2. **(Optional) Merge on‑chain metrics** – fetch data via `api/onchain.py` and
+   store the resulting columns with the `onch_` prefix into the SQLite
+   `prices` table.
+
+3. **Feature engineering & target creation** – invoke the training pipeline
+   which automatically builds all features and targets:
+
+   ```bash
+   python main.py --task clf --horizon 120 --out_dir outputs --use_onchain
+   ```
+
+   The command writes predictions, metrics and diagnostic plots into the
+   `outputs/` directory.  Additional artefacts such as permutation and SHAP
+   importances are also exported for further analysis.
+
+4. **Inspect results** – review the generated CSV files and graphs in
+   `outputs/` to understand model performance and feature behaviour.  The file
+   `run_config.json` captures the exact parameters used for the run, ensuring
+   full reproducibility.
+
+---
+
 ## Customization
 
 * Add or change features in `analysis/feature_engineering.py`.

--- a/analysis/feature_list.json
+++ b/analysis/feature_list.json
@@ -22,5 +22,9 @@
   "is_day",
   "is_night",
   "is_weekend",
-  "is_weekday"
+  "is_weekday",
+  "wall_bid_dist_bps",
+  "wall_bid_size_rel",
+  "wall_ask_dist_bps",
+  "wall_ask_size_rel"
 ]

--- a/ml/feature_list.json
+++ b/ml/feature_list.json
@@ -22,5 +22,9 @@
   "is_day",
   "is_night",
   "is_weekend",
-  "is_weekday"
+  "is_weekday",
+  "wall_bid_dist_bps",
+  "wall_bid_size_rel",
+  "wall_ask_dist_bps",
+  "wall_ask_size_rel"
 ]


### PR DESCRIPTION
## Summary
- add exponential backoff for on-chain API requests
- guard against on-chain leakage by forward filling only within the hour
- compute LOB wall distance and relative size
- run prediction/training in a 7-step loop with a 20 minute pause

## Testing
- `pip install "xgboost>=2.1,<4"`
- `pip install psutil>=5.9`
- `pip install structlog`
- `pip install pydantic`
- `pip install fastapi`
- `pip install httpx`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c731d42e048327b21b2462f06b7e90