### PR TITLE
feat: add mempool on-chain data and improve tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
       - run: pip install -e .[dev]
       - run: ruff check .
       - run: black --check .

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ cache/
 models/
 *.joblib
 .env
+*.parquet
 
 ml/*.pkl
 ml/*.joblib

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     rev: v2.2.6
     hooks:
       - id: codespell
-        args: ["-L", "onchain,taker,Defaulty"]
+        args: ["-L", "onchain,taker,mempool,USDT,Binance,basis,bps,SHAP,Defaulty"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.11.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This creates the `db/data/crypto_data.sqlite` file with price data.
 
 On-chain metrics can be merged from public APIs:
 
-* [mempool.space](https://mempool.space/api/) – mempool stats (no key required)
+* [mempool.space](https://mempool.space/api/) – mempool stats (no key required; fetched automatically with `--use_onchain`)
 * [Glassnode](https://glassnode.com/) – exchange flows (API key optional)
 * [Whale Alert](https://developer.whale-alert.io/) – large transfers/mints (API key optional)
 
@@ -128,9 +128,10 @@ typical workflow for a 2‑hour classification horizon:
    python db/btc_import.py
    ```
 
-2. **(Optional) Merge on‑chain metrics** – fetch data via `api/onchain.py` and
-   store the resulting columns with the `onch_` prefix into the SQLite
-   `prices` table.
+2. **(Optional) Merge additional on‑chain metrics** – mempool stats are
+   fetched automatically, but other metrics (e.g. exchange flows) can be
+   retrieved via `api/onchain.py` and stored with the `onch_` prefix in the
+   SQLite `prices` table.
 
 3. **Feature engineering & target creation** – invoke the training pipeline
    which automatically builds all features and targets:
@@ -166,9 +167,9 @@ typical workflow for a 2‑hour classification horizon:
 
 ## Determinism & Repro
 
-Training pipelines use a fixed ``random_state`` (default ``42``) which is logged
-to ``run_config.json`` along with all other parameters to ensure runs are
-repeatable.
+Training routines default to ``random_state=42`` as defined in
+``ml/train.py``. The chosen value, together with other parameters, is logged to
+``outputs/run_config.json`` to ensure runs are repeatable.
 
 ## Troubleshooting
 
@@ -181,6 +182,7 @@ Install hooks and run them locally before committing:
 
 ```bash
 pip install pre-commit
+pre-commit install
 pre-commit run -a
 ```
 

--- a/loop_w12m_daily.py
+++ b/loop_w12m_daily.py
@@ -1,8 +1,8 @@
 import sqlite3
+import time
 from collections import deque
 from datetime import UTC, datetime, timedelta
 from glob import glob
-import time
 from typing import Any
 from zoneinfo import ZoneInfo
 

--- a/ml/ensemble.py
+++ b/ml/ensemble.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import joblib
 import numpy as np
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+
 from crypto_analyzer.model_manager import atomic_write
 
 try:

--- a/ml/model_utils.py
+++ b/ml/model_utils.py
@@ -8,10 +8,10 @@ import numpy as np
 import pandas as pd
 from sklearn.metrics import accuracy_score, classification_report, confusion_matrix, f1_score
 
-
 # ---------------------------------------------------------------------
 # Persistence
 # ---------------------------------------------------------------------
+
 
 def save_model(model: Any, path: str) -> None:
     """Persist model to path using joblib."""
@@ -29,6 +29,7 @@ def load_model(path: str) -> Any:
 # ---------------------------------------------------------------------
 # Feature alignment
 # ---------------------------------------------------------------------
+
 
 def _expected_feature_names(model: Any) -> List[str]:
     """
@@ -98,6 +99,7 @@ def match_model_features(
 # ---------------------------------------------------------------------
 # Evaluation
 # ---------------------------------------------------------------------
+
 
 def evaluate_model(
     model: Any,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,8 +84,11 @@ DEP002 = [
 select = ["E", "F", "I", "D"]
 line-length = 100
 target-version = "py313"
-extend-exclude = ["tests/**/*", "db/**/*", "crypto_analyzer/legacy/**/*"]
+extend-exclude = ["db/**/*", "crypto_analyzer/legacy/**/*"]
 extend-ignore = ["D1", "D2", "D4"]
+
+[tool.ruff.per-file-ignores]
+"tests/**/*" = ["D1", "I"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
@@ -103,7 +106,7 @@ disallow_untyped_calls = false
 allow_subclassing_any = true
 
 [[tool.mypy.overrides]]
-module = ["xgboost.*", "matplotlib.*", "fastapi.*"]
+module = ["xgboost.*", "matplotlib.*", "fastapi.*", "structlog.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+
 root = Path(__file__).resolve().parent
 if str(root) not in sys.path:
     sys.path.insert(0, str(root))

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import importlib
 import threading
 

--- a/tests/test_dead_code_smoke.py
+++ b/tests/test_dead_code_smoke.py
@@ -1,7 +1,6 @@
 import shutil
 import subprocess
 import sys
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_interval_coverage.py
+++ b/tests/test_interval_coverage.py
@@ -13,8 +13,8 @@ def test_interval_coverage():
     y_high = y_mid + 2.0
     X_train, X_test = X[:1500], X[1500:]
     y_mid_train, y_mid_test = y_mid[:1500], y_mid[1500:]
-    y_low_train, y_low_test = y_low[:1500], y_low[1500:]
-    y_high_train, y_high_test = y_high[:1500], y_high[1500:]
+    y_low_train, _ = y_low[:1500], y_low[1500:]
+    y_high_train, _ = y_high[:1500], y_high[1500:]
 
     reg_params, reg_rounds = build_reg()
     lo_params, lo_rounds = build_bound()
@@ -34,7 +34,6 @@ def test_interval_coverage():
         np.asarray(X_train, dtype=np.float32),
         label=np.asarray(y_high_train, dtype=np.float32),
     )
-    dtest_mid = xgb.DMatrix(np.asarray(X_test, dtype=np.float32))
     dtest_lo = xgb.DMatrix(np.asarray(X_test, dtype=np.float32))
     dtest_hi = xgb.DMatrix(np.asarray(X_test, dtype=np.float32))
     _ = xgb.train(reg_params, dtrain_mid, reg_rounds, verbose_eval=False)

--- a/tests/test_manual_purge.py
+++ b/tests/test_manual_purge.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import importlib
 
 

--- a/utils/splitting.py
+++ b/utils/splitting.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from collections.abc import Iterator
+from dataclasses import dataclass
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
## Summary
- fetch mempool 5m stats when `--use_onchain` is set and tolerate network failures
- expand codespell whitelist and relax style/type rules for tests
- cache pip packages in CI and document determinism & pre-commit workflow

## Testing
- `pre-commit run --files .github/workflows/ci.yml .gitignore .pre-commit-config.yaml README.md loop_w12m_daily.py main.py ml/ensemble.py ml/model_utils.py pyproject.toml sitecustomize.py tests/test_atomic_write.py tests/test_dead_code_smoke.py tests/test_interval_coverage.py tests/test_manual_purge.py utils/splitting.py`
- `pre-commit run mypy --hook-stage manual --files main.py` *(fails: Function is missing a type annotation for one or more arguments [no-untyped-def])* 
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c73f334b508327a17133a9b7b90091