### PR TITLE
feat: integrate on-chain metrics and live logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ On-chain metrics can be merged from public APIs:
 Store the resulting metrics alongside price data in the SQLite `prices` table
 with column names prefixed by `onch_`.
 
+### On-chain backfill + live logging
+
+Historical mempool and difficulty data can be imported into a dedicated table
+and continuously updated:
+
+```bash
+python api/backfill_onchain_history.py --start 2020-07-22 --end 2020-07-23 --db db/data/crypto_data.sqlite
+python -m api.mempool_ws_logger --db db/data/crypto_data.sqlite
+```
+
+The backfill aligns snapshots to a 5‑minute UTC grid and uses Jochen Hoenicke
+and Blockchain.com datasets as the mempool.space REST API does not expose
+historical mempool snapshots. The WebSocket logger keeps the table current and
+is intended to be scheduled via `cron`.
+
 ### 4. Run analysis and prediction
 
 ```bash

--- a/analysis/feature_engineering.py
+++ b/analysis/feature_engineering.py
@@ -9,6 +9,23 @@ import pandas as pd
 
 H = 24  # 120min horizon in 5m candles
 
+ONCHAIN_FEATURES = [
+    "onch_fee_fast_satvb",
+    "onch_fee_30m_satvb",
+    "onch_fee_60m_satvb",
+    "onch_fee_min_satvb",
+    "onch_mempool_count",
+    "onch_mempool_vsize_vB",
+    "onch_mempool_total_fee_sat",
+    "onch_fee_wavg_satvb",
+    "onch_fee_p50_satvb",
+    "onch_fee_p90_satvb",
+    "onch_diff_progress_pct",
+    "onch_diff_change_pct",
+    "onch_blocks_remaining",
+    "onch_retarget_ts",
+]
+
 
 def create_features(df: pd.DataFrame) -> pd.DataFrame:
     """Add technical and time-series features to ``df``.
@@ -25,6 +42,9 @@ def create_features(df: pd.DataFrame) -> pd.DataFrame:
     """
 
     df = df.copy(deep=False)
+    for col in ONCHAIN_FEATURES:
+        if col not in df.columns:
+            df[col] = np.float32(0.0)
 
     # --- základní numerika ---------------------------------------------------
     # nech timestamp beze změny, ostatní numerické sloupce konvertuj na float32
@@ -257,7 +277,8 @@ def create_features(df: pd.DataFrame) -> pd.DataFrame:
         ],
         errors="ignore",
     )
-    if feature_only.isna().any().any():
+    onch_cols = [c for c in feature_only.columns if c.startswith("onch_")]
+    if feature_only.drop(columns=onch_cols, errors="ignore").isna().any().any():
         raise ValueError("NaN values present after feature engineering")
     obj_cols = feature_only.select_dtypes(include="object").columns
     if len(obj_cols) > 0:
@@ -295,7 +316,7 @@ FEATURE_COLUMNS: list[str] = [
     "wall_bid_size_rel",
     "wall_ask_dist_bps",
     "wall_ask_size_rel",
-]
+] + ONCHAIN_FEATURES
 
 
 # Feature groups for Group-SHAP -------------------------------------------------

--- a/api/backfill_onchain_history.py
+++ b/api/backfill_onchain_history.py
@@ -1,0 +1,317 @@
+import argparse
+import sqlite3
+import time
+from typing import Iterable, Iterator, Tuple
+
+import pandas as pd
+import requests
+from requests.adapters import HTTPAdapter, Retry
+
+COLUMNS = [
+    "onch_fee_fast_satvb",
+    "onch_fee_30m_satvb",
+    "onch_fee_60m_satvb",
+    "onch_fee_min_satvb",
+    "onch_mempool_count",
+    "onch_mempool_vsize_vB",
+    "onch_mempool_total_fee_sat",
+    "onch_fee_wavg_satvb",
+    "onch_fee_p50_satvb",
+    "onch_fee_p90_satvb",
+    "onch_diff_progress_pct",
+    "onch_diff_change_pct",
+    "onch_blocks_remaining",
+    "onch_retarget_ts",
+]
+
+USER_AGENT = "CryptoAnalyzer/1.0"
+
+
+def _session() -> requests.Session:
+    s = requests.Session()
+    retries = Retry(total=3, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
+    s.mount("https://", HTTPAdapter(max_retries=retries))
+    s.headers.update({"User-Agent": USER_AGENT})
+    return s
+
+
+def _get_json(
+    session: requests.Session, url: str, *, params: dict | None = None, timeout: int = 30
+) -> dict:
+    delay = 1.0
+    for attempt in range(5):
+        try:
+            resp = session.get(url, params=params, timeout=timeout)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception:
+            if attempt == 4:
+                return {}
+            time.sleep(delay)
+            delay *= 2
+
+
+def _weighted_avg(histogram: Iterable[Iterable[float]]) -> float | None:
+    """Compute weighted average feerate from a histogram.
+
+    The histogram is expected to be an iterable of ``(fee, vsize)`` pairs.
+    Returns ``None`` when no weights are present.
+    """
+
+    total = 0.0
+    weighted = 0.0
+    for fee, vsize in histogram:
+        total += vsize
+        weighted += fee * vsize
+    if total == 0:
+        return None
+    return weighted / total
+
+
+def _percentile(histogram: Iterable[Iterable[float]], pct: float) -> float | None:
+    """Compute the percentile of a fee histogram.
+
+    Parameters
+    ----------
+    histogram:
+        Iterable of ``(fee, vsize)`` pairs sorted by ``fee``.
+    pct:
+        Desired percentile in the range ``0``--``1``.
+    """
+
+    hist = list(histogram)
+    if not hist:
+        return None
+    total = sum(v for _, v in hist)
+    if total == 0:
+        return None
+    cutoff = total * pct
+    acc = 0.0
+    for fee, vsize in hist:
+        acc += vsize
+        if acc >= cutoff:
+            return fee
+    return hist[-1][0]
+
+
+def _reindex_5m(df: pd.DataFrame, idx: pd.DatetimeIndex) -> pd.DataFrame:
+    if df.empty:
+        return pd.DataFrame(index=idx)
+    return df.sort_index().reindex(idx, method="nearest", tolerance=pd.Timedelta("5min"))
+
+
+def fetch_hoenicke_fees(
+    start: pd.Timestamp, end: pd.Timestamp, session: requests.Session
+) -> pd.DataFrame:
+    """Fetch historical fee histogram data from Jochen Hoenicke's dataset.
+
+    The dataset contains snapshots of the mempool fee histogram.  From this we
+    derive weighted average fee and percentiles.  The function gracefully
+    handles network failures by returning an empty DataFrame.
+    """
+
+    url = "https://mempool.jhoenicke.de/api/v1/fees/mempool.json"
+    raw = _get_json(session, url, timeout=30).get("data", [])
+
+    records = []
+    for entry in raw:
+        ts, hist = entry[0], entry[1]
+        ts = pd.to_datetime(ts, unit="s", utc=True)
+        if ts < start or ts > end:
+            continue
+        wavg = _weighted_avg(hist)
+        p50 = _percentile(hist, 0.5)
+        p90 = _percentile(hist, 0.9)
+        vsize = sum(v for _, v in hist)
+        records.append(
+            {
+                "ts": ts,
+                "onch_fee_wavg_satvb": wavg,
+                "onch_fee_p50_satvb": p50,
+                "onch_fee_p90_satvb": p90,
+                "onch_mempool_vsize_vB": vsize,
+            }
+        )
+    if not records:
+        return pd.DataFrame()
+    return pd.DataFrame.from_records(records).set_index("ts")
+
+
+def fetch_blockchain_mempool(
+    start: pd.Timestamp, end: pd.Timestamp, session: requests.Session
+) -> pd.DataFrame:
+    """Fetch mempool statistics from the Blockchain.com Charts API."""
+
+    url = "https://api.blockchain.info/charts/mempool-size"
+    params = {
+        "format": "json",
+        "start": int(start.timestamp()),
+        "end": int(end.timestamp()),
+    }
+    data = _get_json(session, url, params=params, timeout=30).get("values", [])
+
+    # Blockchain.com does not expose count/fees directly; we map size to
+    # ``onch_mempool_vsize_vB`` for validation.  Additional fields can be
+    # joined from other sources if available.
+    records = [
+        {
+            "ts": pd.to_datetime(item["x"], unit="s", utc=True),
+            "onch_mempool_vsize_vB": item["y"],
+        }
+        for item in data
+        if start <= pd.to_datetime(item["x"], unit="s", utc=True) <= end
+    ]
+    if not records:
+        return pd.DataFrame()
+    return pd.DataFrame.from_records(records).set_index("ts")
+
+
+def fetch_mining_difficulty(
+    start: pd.Timestamp, end: pd.Timestamp, session: requests.Session
+) -> pd.DataFrame:
+    """Fetch historical difficulty adjustment data from mempool.space."""
+
+    url = "https://mempool.space/api/v1/mining/difficulty-adjustments/1y"
+    data = _get_json(session, url, timeout=30)
+
+    records = []
+    for item in data:
+        ts = pd.to_datetime(item.get("time"), unit="s", utc=True)
+        if ts < start or ts > end:
+            continue
+        records.append(
+            {
+                "ts": ts,
+                "onch_diff_progress_pct": item.get("progressPercent"),
+                "onch_diff_change_pct": item.get("difficultyChange"),
+                "onch_blocks_remaining": item.get("remainingBlocks"),
+                "onch_retarget_ts": item.get("estimatedRetargetDate"),
+            }
+        )
+    if not records:
+        return pd.DataFrame()
+    return pd.DataFrame.from_records(records).set_index("ts")
+
+
+def fetch_current_snapshot(ts: pd.Timestamp, session: requests.Session) -> pd.DataFrame:
+    """Fetch current mempool snapshot for nowcasting missing data."""
+
+    fees = _get_json(session, "https://mempool.space/api/v1/fees/recommended", timeout=30)
+    mempool = _get_json(session, "https://mempool.space/api/mempool", timeout=30)
+    hist = mempool.get("fee_histogram", []) if isinstance(mempool, dict) else []
+
+    record = {
+        "ts": ts,
+        "onch_fee_fast_satvb": fees.get("fastestFee"),
+        "onch_fee_30m_satvb": fees.get("halfHourFee"),
+        "onch_fee_60m_satvb": fees.get("hourFee"),
+        "onch_fee_min_satvb": fees.get("minimumFee"),
+        "onch_mempool_count": mempool.get("count"),
+        "onch_mempool_vsize_vB": mempool.get("vsize"),
+        "onch_mempool_total_fee_sat": mempool.get("total_fee"),
+    }
+    if hist:
+        record["onch_fee_wavg_satvb"] = _weighted_avg(hist)
+        record["onch_fee_p50_satvb"] = _percentile(hist, 0.5)
+        record["onch_fee_p90_satvb"] = _percentile(hist, 0.9)
+    df = pd.DataFrame([record]).set_index("ts")
+    return df
+
+
+def _date_chunks(
+    start: pd.Timestamp, end: pd.Timestamp
+) -> Iterator[Tuple[pd.Timestamp, pd.Timestamp]]:
+    cur = start
+    step = pd.Timedelta(days=1)
+    while cur <= end:
+        nxt = min(cur + step - pd.Timedelta(minutes=5), end)
+        yield cur, nxt
+        cur = nxt + pd.Timedelta(minutes=5)
+
+
+def backfill_onchain_history(start: str, end: str, db_path: str) -> None:
+    """Backfill on-chain history into a SQLite database."""
+
+    start_ts = pd.to_datetime(start, utc=True).floor("5min")
+    end_ts = pd.to_datetime(end, utc=True).ceil("5min")
+    idx = pd.date_range(start_ts, end_ts, freq="5min")
+    base = pd.DataFrame(index=idx)
+
+    session = _session()
+    fee_parts = []
+    bc_parts = []
+    diff_parts = []
+    for s, e in _date_chunks(start_ts, end_ts):
+        fee_parts.append(fetch_hoenicke_fees(s, e, session))
+        bc_parts.append(fetch_blockchain_mempool(s, e, session))
+        diff_parts.append(fetch_mining_difficulty(s, e, session))
+    fee_df = _reindex_5m(pd.concat(fee_parts) if fee_parts else pd.DataFrame(), idx)
+    bc_df = _reindex_5m(pd.concat(bc_parts) if bc_parts else pd.DataFrame(), idx)
+    diff_df = _reindex_5m(pd.concat(diff_parts) if diff_parts else pd.DataFrame(), idx)
+    df = base.join([fee_df, bc_df, diff_df])
+
+    # Fill last point with current snapshot if empty
+    if df.iloc[-1].isna().all():
+        snap = _reindex_5m(fetch_current_snapshot(idx[-1], session), idx)
+        df.update(snap)
+
+    if not df.index.is_monotonic_increasing:
+        raise ValueError("non-monotonic index")
+    if len(df) != len(idx):
+        raise ValueError("unexpected number of rows")
+
+    df.index = df.index.view("int64") // 10**9
+    df.index.name = "ts_utc"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS onchain_5m (
+                ts_utc INTEGER PRIMARY KEY,
+                onch_fee_fast_satvb REAL,
+                onch_fee_30m_satvb REAL,
+                onch_fee_60m_satvb REAL,
+                onch_fee_min_satvb REAL,
+                onch_mempool_count REAL,
+                onch_mempool_vsize_vB REAL,
+                onch_mempool_total_fee_sat REAL,
+                onch_fee_wavg_satvb REAL,
+                onch_fee_p50_satvb REAL,
+                onch_fee_p90_satvb REAL,
+                onch_diff_progress_pct REAL,
+                onch_diff_change_pct REAL,
+                onch_blocks_remaining REAL,
+                onch_retarget_ts INTEGER
+            )
+            """
+        )
+        conn.execute("CREATE INDEX IF NOT EXISTS ix_onchain_ts ON onchain_5m(ts_utc)")
+        cols = ["ts_utc"] + COLUMNS
+        placeholders = ",".join(["?"] * len(cols))
+        rows = []
+        for ts, row in df.iterrows():
+            values = [ts] + [row.get(c) if pd.notna(row.get(c)) else None for c in COLUMNS]
+            rows.append(values)
+        for i in range(0, len(rows), 1000):
+            conn.executemany(
+                f"INSERT OR REPLACE INTO onchain_5m ({','.join(cols)}) VALUES ({placeholders})",
+                rows[i : i + 1000],
+            )
+        conn.commit()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Backfill on-chain history")
+    parser.add_argument("--start", default="2020-07-22", help="start date (UTC)")
+    parser.add_argument("--end", required=True, help="end date (UTC)")
+    parser.add_argument("--db", required=True, help="SQLite database path")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    backfill_onchain_history(args.start, args.end, args.db)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/api/mempool_ws_logger.py
+++ b/api/mempool_ws_logger.py
@@ -1,0 +1,96 @@
+"""Live mempool WebSocket logger.
+
+Connects to mempool.space WebSocket API and appends five-minute aggregated
+snapshots into the ``onchain_5m`` table. This module is intended to be run via
+``cron`` after the historical backfill to keep the dataset up to date.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime
+from typing import Any
+
+import pandas as pd
+import websocket
+
+from .backfill_onchain_history import COLUMNS, _percentile, _weighted_avg
+
+WS_URL = "wss://mempool.space/api/v1/ws"
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS onchain_5m (
+            ts_utc INTEGER PRIMARY KEY,
+            onch_fee_fast_satvb REAL,
+            onch_fee_30m_satvb REAL,
+            onch_fee_60m_satvb REAL,
+            onch_fee_min_satvb REAL,
+            onch_mempool_count REAL,
+            onch_mempool_vsize_vB REAL,
+            onch_mempool_total_fee_sat REAL,
+            onch_fee_wavg_satvb REAL,
+            onch_fee_p50_satvb REAL,
+            onch_fee_p90_satvb REAL,
+            onch_diff_progress_pct REAL,
+            onch_diff_change_pct REAL,
+            onch_blocks_remaining REAL,
+            onch_retarget_ts INTEGER
+        )
+        """
+    )
+    conn.execute("CREATE INDEX IF NOT EXISTS ix_onchain_ts ON onchain_5m(ts_utc)")
+    conn.commit()
+
+
+def log_mempool_ws(db_path: str) -> None:  # pragma: no cover - network
+    conn = sqlite3.connect(db_path)
+    _ensure_schema(conn)
+
+    def on_message(_ws: websocket.WebSocketApp, message: str) -> None:
+        try:
+            msg = json.loads(message)
+        except json.JSONDecodeError:
+            return
+        mempool: dict[str, Any] | None = msg.get("mempool")
+        if not isinstance(mempool, dict):
+            return
+        ts = pd.Timestamp(datetime.now(UTC)).floor("5min")
+        hist = mempool.get("fee_histogram", [])
+        record = {
+            "ts_utc": int(ts.timestamp()),
+            "onch_mempool_count": mempool.get("count"),
+            "onch_mempool_vsize_vB": mempool.get("vsize"),
+            "onch_mempool_total_fee_sat": mempool.get("total_fee"),
+        }
+        if hist:
+            record["onch_fee_wavg_satvb"] = _weighted_avg(hist)
+            record["onch_fee_p50_satvb"] = _percentile(hist, 0.5)
+            record["onch_fee_p90_satvb"] = _percentile(hist, 0.9)
+        cols = ["ts_utc"] + [c for c in COLUMNS if c in record]
+        placeholders = ",".join(["?"] * len(cols))
+        values = [record.get(c) for c in cols]
+        conn.execute(
+            f"INSERT OR REPLACE INTO onchain_5m ({','.join(cols)}) VALUES ({placeholders})",
+            values,
+        )
+        conn.commit()
+
+    ws = websocket.WebSocketApp(WS_URL, on_message=on_message)
+    ws.run_forever()
+
+
+__all__ = ["log_mempool_ws"]
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Live mempool WebSocket logger")
+    parser.add_argument("--db", required=True, help="SQLite database path")
+    args = parser.parse_args()
+    log_mempool_ws(args.db)

--- a/tests/test_backfill_onchain_history.py
+++ b/tests/test_backfill_onchain_history.py
@@ -1,0 +1,69 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from api import backfill_onchain_history as mod
+
+
+def _make_df(idx: pd.DatetimeIndex) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    fee = pd.DataFrame(
+        {
+            "onch_fee_wavg_satvb": [1.0, 2.0, 3.0],
+            "onch_fee_p50_satvb": [1.0, 2.0, 3.0],
+            "onch_fee_p90_satvb": [2.0, 3.0, 4.0],
+            "onch_mempool_vsize_vB": [100.0, 200.0, 300.0],
+        },
+        index=idx,
+    )
+    bc = pd.DataFrame(
+        {
+            "onch_fee_fast_satvb": [10.0, 20.0, 30.0],
+            "onch_fee_30m_satvb": [11.0, 21.0, 31.0],
+            "onch_fee_60m_satvb": [12.0, 22.0, 32.0],
+            "onch_fee_min_satvb": [9.0, 19.0, 29.0],
+            "onch_mempool_count": [1, 2, 3],
+            "onch_mempool_total_fee_sat": [1000, 2000, 3000],
+        },
+        index=idx,
+    )
+    diff = pd.DataFrame(
+        {
+            "onch_diff_progress_pct": [0.1, 0.2, 0.3],
+            "onch_diff_change_pct": [1.0, 1.0, 1.0],
+            "onch_blocks_remaining": [100, 99, 98],
+            "onch_retarget_ts": [1609459200000, 1609462500000, 1609465800000],
+        },
+        index=idx,
+    )
+    return fee, bc, diff
+
+
+def test_backfill_onchain_history(tmp_path, monkeypatch):
+    start = "2021-01-01 00:02"
+    end = "2021-01-01 00:12"
+    idx = pd.date_range("2021-01-01 00:00", periods=3, freq="5min", tz="UTC")
+    fee, bc, diff = _make_df(idx)
+    bc = bc.iloc[0:0]
+
+    monkeypatch.setattr(mod, "fetch_hoenicke_fees", lambda s, e, sess: fee)
+    monkeypatch.setattr(mod, "fetch_blockchain_mempool", lambda s, e, sess: bc)
+    monkeypatch.setattr(mod, "fetch_mining_difficulty", lambda s, e, sess: diff)
+    monkeypatch.setattr(
+        mod,
+        "fetch_current_snapshot",
+        lambda ts, sess: pd.DataFrame(index=pd.DatetimeIndex([], tz="UTC")),
+    )
+
+    db_path = tmp_path / "test.sqlite"
+    mod.backfill_onchain_history(start, end, str(db_path))
+
+    conn = sqlite3.connect(db_path)
+    df = pd.read_sql_query("SELECT * FROM onchain_5m ORDER BY ts_utc", conn)
+    conn.close()
+
+    assert list(df["ts_utc"]) == [1609459200, 1609459500, 1609459800, 1609460100]
+    assert df["onch_fee_fast_satvb"].isna().iloc[:2].all()
+    assert df.loc[0, "onch_fee_wavg_satvb"] == 1.0


### PR DESCRIPTION
## Summary
- enrich on-chain backfill with retry/backoff, QC checks, WAL upserts and default start date
- expose on-chain columns throughout the feature pipeline and load from SQLite instead of REST
- add mempool WebSocket logger and docs for historical backfill and live logging

## Testing
- `pre-commit run --files api/backfill_onchain_history.py api/mempool_ws_logger.py analysis/feature_engineering.py main.py README.md tests/test_backfill_onchain_history.py`
- `pytest tests/test_backfill_onchain_history.py tests/test_features_types.py tests/test_smoke_train_price.py tests/test_meta_models.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7e7ea45808327a4516450d2f1986a