### PR TITLE
Handle list-based difficulty adjustment data

### DIFF
--- a/tests/test_fetch_mining_difficulty.py
+++ b/tests/test_fetch_mining_difficulty.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from api import backfill_onchain_history as mod
+
+
+def test_fetch_mining_difficulty_list(monkeypatch):
+    start = pd.Timestamp('2021-01-01 00:00', tz='UTC')
+    end = start + pd.Timedelta(hours=1)
+    sample = [
+        [start.timestamp(), 100000, 1.0, 1.05],
+        [(start + pd.Timedelta(minutes=30)).timestamp(), 100050, 1.0, 0.95],
+    ]
+    monkeypatch.setattr(mod, '_get_json', lambda sess, url, timeout=30: sample)
+    df = mod.fetch_mining_difficulty(start, end, None)
+    assert len(df) == 2
+    progress_first = (100000 % 2016) / 2016 * 100
+    remaining_first = 2016 - (100000 % 2016)
+    change_second = (0.95 - 1) * 100
+    assert df.iloc[0]['onch_diff_progress_pct'] == progress_first
+    assert df.iloc[1]['onch_diff_change_pct'] == change_second
+    expected_retarget = int((start + pd.Timedelta(seconds=remaining_first * 600)).timestamp() * 1000)
+    assert df.iloc[0]['onch_retarget_ts'] == expected_retarget


### PR DESCRIPTION
## Summary
- support array responses from mempool difficulty-adjustments endpoint
- derive progress, change and remaining blocks from height
- add test for list-based difficulty data

## Testing
- `pytest tests/test_fetch_mining_difficulty.py tests/test_backfill_onchain_history.py`
- `pip install xgboost`
- `pip install psutil`
- `pip install structlog`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68c7fa78593c8327a725ee1fb6b8a7ea