### PR TITLE
Handle mempool difficulty list format and reduce pandas fragmentation

### DIFF
--- a/api/mempool_ws_logger.py
+++ b/api/mempool_ws_logger.py
@@ -24,23 +24,22 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute(
         """
-        CREATE TABLE IF NOT EXISTS onchain_5m (
-            ts_utc INTEGER PRIMARY KEY,
-            onch_fee_fast_satvb REAL,
-            onch_fee_30m_satvb REAL,
-            onch_fee_60m_satvb REAL,
-            onch_fee_min_satvb REAL,
-            onch_mempool_count REAL,
-            onch_mempool_vsize_vB REAL,
-            onch_mempool_total_fee_sat REAL,
-            onch_fee_wavg_satvb REAL,
-            onch_fee_p50_satvb REAL,
-            onch_fee_p90_satvb REAL,
-            onch_diff_progress_pct REAL,
-            onch_diff_change_pct REAL,
-            onch_blocks_remaining REAL,
-            onch_retarget_ts INTEGER
-        )
+            CREATE TABLE IF NOT EXISTS onchain_5m (
+                ts_utc INTEGER PRIMARY KEY,
+                onch_fee_fast_satvb REAL,
+                onch_fee_30m_satvb REAL,
+                onch_fee_60m_satvb REAL,
+                onch_fee_min_satvb REAL,
+                onch_mempool_count REAL,
+                onch_mempool_vsize_vB REAL,
+                onch_mempool_total_fee_sat REAL,
+                onch_fee_wavg_satvb REAL,
+                onch_fee_p50_satvb REAL,
+                onch_fee_p90_satvb REAL,
+                onch_difficulty REAL,
+                onch_height REAL,
+                onch_diff_change_pct REAL
+            )
         """
     )
     conn.execute("CREATE INDEX IF NOT EXISTS ix_onchain_ts ON onchain_5m(ts_utc)")

--- a/tests/test_backfill_onchain_history.py
+++ b/tests/test_backfill_onchain_history.py
@@ -31,10 +31,9 @@ def _make_df(idx: pd.DatetimeIndex) -> tuple[pd.DataFrame, pd.DataFrame, pd.Data
     )
     diff = pd.DataFrame(
         {
-            "onch_diff_progress_pct": [0.1, 0.2, 0.3],
+            "onch_difficulty": [1.0, 2.0, 3.0],
+            "onch_height": [100, 101, 102],
             "onch_diff_change_pct": [1.0, 1.0, 1.0],
-            "onch_blocks_remaining": [100, 99, 98],
-            "onch_retarget_ts": [1609459200000, 1609462500000, 1609465800000],
         },
         index=idx,
     )

--- a/tests/test_feature_extremes.py
+++ b/tests/test_feature_extremes.py
@@ -34,6 +34,14 @@ def test_future_extreme_targets_once():
         "delta_low_lin_120m",
         "delta_high_log_120m",
         "delta_high_lin_120m",
+        "delta_low_log_60m",
+        "delta_low_lin_60m",
+        "delta_high_log_60m",
+        "delta_high_lin_60m",
+        "delta_low_log_240m",
+        "delta_low_lin_240m",
+        "delta_high_log_240m",
+        "delta_high_lin_240m",
     ]
     for c in cols:
         assert out[c].dtype == np.float32

--- a/tests/test_fetch_mining_difficulty.py
+++ b/tests/test_fetch_mining_difficulty.py
@@ -7,20 +7,35 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from api import backfill_onchain_history as mod
 
 
-def test_fetch_mining_difficulty_list(monkeypatch):
-    start = pd.Timestamp('2021-01-01 00:00', tz='UTC')
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._data
+
+
+class DummySession:
+    def __init__(self, data):
+        self.data = data
+
+    def get(self, url, timeout=15):
+        return DummyResp(self.data)
+
+
+def test_fetch_mining_difficulty_list():
+    start = pd.Timestamp("2021-01-01 00:00", tz="UTC")
     end = start + pd.Timedelta(hours=1)
     sample = [
         [start.timestamp(), 100000, 1.0, 1.05],
         [(start + pd.Timedelta(minutes=30)).timestamp(), 100050, 1.0, 0.95],
     ]
-    monkeypatch.setattr(mod, '_get_json', lambda sess, url, timeout=30: sample)
-    df = mod.fetch_mining_difficulty(start, end, None)
+    session = DummySession(sample)
+    df = mod.fetch_mining_difficulty(start, end, session)
     assert len(df) == 2
-    progress_first = (100000 % 2016) / 2016 * 100
-    remaining_first = 2016 - (100000 % 2016)
-    change_second = (0.95 - 1) * 100
-    assert df.iloc[0]['onch_diff_progress_pct'] == progress_first
-    assert df.iloc[1]['onch_diff_change_pct'] == change_second
-    expected_retarget = int((start + pd.Timedelta(seconds=remaining_first * 600)).timestamp() * 1000)
-    assert df.iloc[0]['onch_retarget_ts'] == expected_retarget
+    assert df.iloc[0]["onch_height"] == 100000
+    change_second = (0.95 - 1.0) * 100.0
+    assert df.iloc[1]["onch_diff_change_pct"] == change_second


### PR DESCRIPTION
## Summary
- parse difficulty adjustment API's list-of-lists and store difficulty, height, and percentage change
- enable SQLite WAL mode and log inserted row counts when backfilling on-chain data
- batch-add feature-engineering columns via `pd.concat` to mitigate pandas fragmentation

## Testing
- `pytest tests/test_fetch_mining_difficulty.py tests/test_backfill_onchain_history.py tests/test_feature_extremes.py tests/test_features_types.py`
- `python -m api.backfill_onchain_history --start 2020-07-22 --end 2025-09-15 --db db/data/crypto_data.sqlite` *(fails: HTTPSConnectionPool proxy 403)*
- `python main.py --task clf --horizon 120` *(fails: no such table: prices)*

------
https://chatgpt.com/codex/tasks/task_e_68c8078128f48327a1ec5afa574b3eb8