### PR TITLE
Deduplicate model feature names for prediction

### DIFF
--- a/tests/test_match_model_features.py
+++ b/tests/test_match_model_features.py
@@ -1,0 +1,23 @@
+import importlib.util
+import pathlib
+import pandas as pd
+
+# Load ml/model_utils.py without importing the ml package, which would require
+# heavy optional dependencies such as xgboost.
+module_path = pathlib.Path(__file__).resolve().parents[1] / "ml" / "model_utils.py"
+spec = importlib.util.spec_from_file_location("model_utils", module_path)
+model_utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(model_utils)
+match_model_features = model_utils.match_model_features
+
+
+class DummyModel:
+    """Model exposing duplicate feature names via scikit-learn API."""
+
+    feature_names_in_ = ["a", "b", "a"]
+
+
+def test_duplicates_are_deduped():
+    df = pd.DataFrame({"a": [1.0], "b": [2.0]})
+    aligned = match_model_features(df, DummyModel())
+    assert list(aligned.columns) == ["a", "b"]


### PR DESCRIPTION
## Summary
- ensure `match_model_features` removes duplicate feature names to prevent pandas returning DataFrames when indexing and breaking XGBoost `predict`
- add test covering duplicate feature name handling without requiring heavy dependencies

## Testing
- `PYTHONPATH=. pytest tests/test_match_model_features.py -q`
- `pytest` *(fails: No module named 'xgboost')*

------
https://chatgpt.com/codex/tasks/task_e_68c81fccc6d483278bd2739433f99925