### PR TITLE
Prevent duplicate feature names in feature engineering

### DIFF
--- a/tests/test_features_types.py
+++ b/tests/test_features_types.py
@@ -29,5 +29,6 @@ def test_features_types():
     )
     feat_df = create_features(df)
     X = feat_df[FEATURE_COLUMNS]
+    assert feat_df.columns.is_unique
     assert X.dtypes.eq("float32").all()
     assert not X.isna().any().any()


### PR DESCRIPTION
## Summary
- guard against reusing existing feature names when deriving long-horizon deltas so the training matrix keeps unique labels
- switch on-chain hourly grouping to use lowercase `h` to silence the FutureWarning in pandas
- assert that feature engineering yields unique columns in the feature type test

## Checklist
- [x] tests pass
- [ ] typing ok
- [ ] doc updated
- [ ] perf note

## Import-time artifact
Link: -

## Before vs After
| Metric | Before | After |
|---|---|---|
| Import time (ms) | | |
| RSS (MB) | | |
| Imported modules | | |
| Inference throughput (rows/min) | | |

## Removed symbols / packages
-


------
https://chatgpt.com/codex/tasks/task_e_68c83e9c3648832798aed7619cb23d2a