### PR TITLE
Handle empty mining difficulty and hashrate responses

### DIFF
--- a/api/backfill_onchain_history.py
+++ b/api/backfill_onchain_history.py
@@ -270,6 +270,11 @@ def fetch_mining_difficulty(start: pd.Timestamp, end: pd.Timestamp, session) -> 
                 "onch_diff_change_pct": change_pct,
             }
         )
+    if not rows:
+        return pd.DataFrame(
+            columns=["onch_difficulty", "onch_height", "onch_diff_change_pct"],
+            index=pd.DatetimeIndex([], name="timestamp"),
+        )
     df = pd.DataFrame(rows).set_index("timestamp").sort_index()
     return df
 
@@ -289,6 +294,11 @@ def fetch_hashrate(start: pd.Timestamp, end: pd.Timestamp, session) -> pd.DataFr
             continue
         hashrate = float(item[1])
         rows.append({"timestamp": ts, "onch_hashrate_ehs": hashrate})
+    if not rows:
+        return pd.DataFrame(
+            columns=["onch_hashrate_ehs"],
+            index=pd.DatetimeIndex([], name="timestamp"),
+        )
     df = pd.DataFrame(rows).set_index("timestamp").sort_index()
     return df
 


### PR DESCRIPTION
## Summary
- guard the mining difficulty fetcher against empty API responses by returning an empty, indexed DataFrame with the expected columns
- apply the same empty-response handling to the hashrate fetcher so future ranges don't trigger KeyErrors

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'ml'; ModuleNotFoundError: No module named 'structlog')*


------
https://chatgpt.com/codex/tasks/task_e_68c872431dfc832798f13aba6776d7de