### PR TITLE
Handle mempool hashrate API schema variations

### DIFF
--- a/tests/test_backfill_onchain_history.py
+++ b/tests/test_backfill_onchain_history.py
@@ -45,11 +45,13 @@ def test_backfill_onchain_history(tmp_path, monkeypatch):
     end = "2021-01-01 00:12"
     idx = pd.date_range("2021-01-01 00:00", periods=3, freq="5min", tz="UTC")
     fee, bc, diff = _make_df(idx)
+    hash_df = pd.DataFrame({"onch_hashrate_ehs": [10.0, 11.0, 12.0]}, index=idx)
     bc = bc.iloc[0:0]
 
     monkeypatch.setattr(mod, "fetch_hoenicke_fees", lambda s, e, sess: fee)
     monkeypatch.setattr(mod, "fetch_blockchain_mempool", lambda s, e, sess: bc)
     monkeypatch.setattr(mod, "fetch_mining_difficulty", lambda s, e, sess: diff)
+    monkeypatch.setattr(mod, "fetch_hashrate", lambda s, e, sess: hash_df)
     monkeypatch.setattr(
         mod,
         "fetch_current_snapshot",

--- a/tests/test_fetch_hashrate.py
+++ b/tests/test_fetch_hashrate.py
@@ -1,0 +1,75 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from api import backfill_onchain_history as mod
+
+
+class _DummyResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _DummySession:
+    def __init__(self, payload):
+        self._payload = payload
+        self.calls: list[tuple[str, int]] = []
+
+    def get(self, url, timeout=0):
+        self.calls.append((url, timeout))
+        return _DummyResponse(self._payload)
+
+
+def test_fetch_hashrate_nested_lists():
+    start = pd.Timestamp("2024-01-01", tz="UTC")
+    end = pd.Timestamp("2024-01-02", tz="UTC")
+    payload = {
+        "hashrate": {
+            "data": [
+                [start.timestamp(), "101.5"],
+                [end.timestamp(), 98.0],
+                [end.timestamp() + 86400, 5.0],
+            ]
+        }
+    }
+    session = _DummySession(payload)
+    df = mod.fetch_hashrate(start, end, session)
+    assert not df.empty
+    assert list(df.index) == [start, end]
+    assert list(df["onch_hashrate_ehs"]) == [101.5, 98.0]
+
+
+def test_fetch_hashrate_dict_series():
+    start = pd.Timestamp("2024-03-01", tz="UTC")
+    end = pd.Timestamp("2024-03-01 02:00", tz="UTC")
+    payload = {
+        "hashrate": {
+            "series": [
+                {"time": "2024-03-01T00:00:00Z", "hashrate": "75.1"},
+                {"time": "2024-03-01T01:00:00Z", "hashrate": "77.3"},
+                {"time": "2024-03-01T03:00:00Z", "hashrate": "999"},
+            ]
+        }
+    }
+    session = _DummySession(payload)
+    df = mod.fetch_hashrate(start, end, session)
+    assert list(df.index) == [pd.Timestamp("2024-03-01T00:00Z"), pd.Timestamp("2024-03-01T01:00Z")]
+    assert df["onch_hashrate_ehs"].tolist() == [75.1, 77.3]
+
+
+def test_fetch_hashrate_invalid_payload():
+    start = pd.Timestamp("2024-01-01", tz="UTC")
+    end = pd.Timestamp("2024-01-02", tz="UTC")
+    payload = {"status": "ok", "data": ["n/a", None]}
+    session = _DummySession(payload)
+    df = mod.fetch_hashrate(start, end, session)
+    assert df.empty
+    assert list(df.columns) == ["onch_hashrate_ehs"]


### PR DESCRIPTION
## Summary
- make hashrate backfill tolerant to the latest mempool.space payload formats and varied timestamp encodings
- ensure the backfill process always initialises the nowcast flag even when mempool data is missing
- add unit tests that exercise the new hashrate parsing paths and stub hashrate data in the backfill integration test

## Testing
- pytest tests/test_fetch_hashrate.py tests/test_backfill_onchain_history.py


------
https://chatgpt.com/codex/tasks/task_e_68c877d65c08832797c85dda34860a5a