### PR TITLE
Refactor price predictions to point forecasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A modular Python project for **cryptocurrency price analysis and prediction** us
 - Aggregates multiple ML models using usage-based weighting.
 - Forecast loop ensembles all regression models via usage-based weights.
 - Combines signals for final trading decision.
-- Bound-model pipeline outputs price interval `p_low` ≤ `p_hat` ≤ `p_high`.
+- Price model outputs point forecasts `p_hat` for future prices.
 - Fully modular and easy to expand.
 
 ---

--- a/api/server.py
+++ b/api/server.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI
 
 from analysis.feature_engineering import FEATURE_COLUMNS, create_features
 from crypto_analyzer.schemas import PredictionResponse
-from ml.xgb_price import clip_inside, to_price
+from ml.xgb_price import to_price
 
 MODEL_DIR = Path(os.getenv("MODEL_DIR", "models/xgb_price"))
 DATA_PATH = os.getenv("DATA_PATH", "data/latest.parquet")
@@ -19,8 +19,6 @@ FEATURE_LIST_PATH = Path(os.getenv("FEATURE_LIST_PATH", "analysis/feature_list.j
 app = FastAPI()
 
 reg = joblib.load(MODEL_DIR / "reg.joblib", mmap_mode="r")
-lowm = joblib.load(MODEL_DIR / "low.joblib", mmap_mode="r")
-highm = joblib.load(MODEL_DIR / "high.joblib", mmap_mode="r")
 
 
 def _feature_names() -> list[str]:
@@ -57,20 +55,5 @@ def predict() -> PredictionResponse:  # pragma: no cover - FastAPI handles respo
     ts, last_price, X_last = _load_last_row()
     dlast = xgb.DMatrix(np.asarray(X_last, dtype=np.float32))
     delta = float(reg.predict(dlast)[0])
-    low = float(lowm.predict(dlast)[0])
-    high = float(highm.predict(dlast)[0])
     p_hat = float(to_price(last_price, delta))
-    p_low = float(to_price(last_price, low))
-    p_high = float(to_price(last_price, high))
-    p_low, p_high = (min(p_low, p_high), max(p_low, p_high))
-    p_hat = clip_inside(
-        np.array([p_hat], dtype=np.float32),
-        np.array([p_low], dtype=np.float32),
-        np.array([p_high], dtype=np.float32),
-    )[0]
-    return PredictionResponse(
-        timestamp=str(ts),
-        p_low=float(p_low),
-        p_hat=float(p_hat),
-        p_high=float(p_high),
-    )
+    return PredictionResponse(timestamp=str(ts), p_hat=p_hat)

--- a/crypto_analyzer/schemas.py
+++ b/crypto_analyzer/schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field
 
 
 class FeatureConfig(BaseModel):
@@ -27,14 +27,6 @@ class PredictionRequest(BaseModel):
 
 class PredictionResponse(BaseModel):
     timestamp: str
-    p_low: float
     p_hat: float
-    p_high: float
-
-    @model_validator(mode="after")
-    def check_order(self) -> PredictionResponse:
-        if not (self.p_low <= self.p_hat <= self.p_high):
-            raise ValueError("p_low <= p_hat <= p_high must hold")
-        return self
 
     model_config = {"validate_assignment": True}

--- a/loop_w12m_daily.py
+++ b/loop_w12m_daily.py
@@ -1,10 +1,9 @@
 import sqlite3
 import time
 from collections import deque
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 from glob import glob
 from typing import Any
-from zoneinfo import ZoneInfo
 
 import numpy as np
 import pandas as pd
@@ -46,7 +45,6 @@ FORWARD_STEPS = 1
 PREDICT_HOURS = 2
 # Features available when rolling forward without full re-computation
 FEATURE_COLS = ["return_1d", "sma_7", "sma_14", "ema_7", "ema_14", "rsi_14"]
-PRAGUE_TZ = ZoneInfo("Europe/Prague")
 INTERVAL_TO_MIN = {
     "1m": 1,
     "3m": 3,
@@ -58,14 +56,7 @@ INTERVAL_TO_MIN = {
     "4h": 240,
     "1d": 1440,
 }
-FEATURES_VERSION_FWD = "wf5yD1_future"
 REPEAT_COUNT = CONFIG.repeat_count
-
-
-def _created_at_iso():
-    return datetime.now(UTC).isoformat()
-
-
 def _ensure_indexes(table_name: str):
     conn = sqlite3.connect(DB_PATH)
     cur = conn.cursor()
@@ -248,23 +239,12 @@ def _predict_forward_steps(model_paths, state, steps, usage_path="ml/model_usage
         new_close = float(
             predict_weighted_prices(feats_df, FEATURE_COLS, model_paths, usage_path=usage_path)[0]
         )
-        pred_local = pd.Timestamp(pred_time, tz="UTC").tz_convert(PRAGUE_TZ)
-        target_local = pd.Timestamp(target_time, tz="UTC").tz_convert(PRAGUE_TZ)
         rows.append(
             (
                 SYMBOL,
                 INTERVAL,
-                FORWARD_STEPS,
-                int(pd.Timestamp(pred_time).value // 1_000_000),
                 int(pd.Timestamp(target_time).value // 1_000_000),
-                pred_local.strftime("%Y-%m-%d %H:%M:%S"),
-                target_local.strftime("%Y-%m-%d %H:%M:%S"),
                 new_close,
-                None,
-                None,
-                "RandomForestRegressor",
-                FEATURES_VERSION_FWD,
-                _created_at_iso(),
             )
         )
         _update_state_with_pred(state, new_close)

--- a/ml/__init__.py
+++ b/ml/__init__.py
@@ -1,10 +1,5 @@
 """Machine learning package."""
 
-from .xgb_price import build_bound, build_reg, clip_inside, to_price
+from .xgb_price import build_reg, to_price
 
-__all__ = [
-    "build_reg",
-    "build_bound",
-    "clip_inside",
-    "to_price",
-]
+__all__ = ["build_reg", "to_price"]

--- a/ml/backtest.py
+++ b/ml/backtest.py
@@ -17,8 +17,7 @@ def run_backtest(df: pd.DataFrame, fee: float = 0.0004) -> BacktestResult:
     Parameters
     ----------
     df : DataFrame
-        Must contain columns ``timestamp``, ``p_hat``, ``p_low``, ``p_high``,
-        ``target`` and ``last_price``.
+        Must contain columns ``timestamp``, ``p_hat``, ``target`` and ``last_price``.
     fee : float, optional
         Proportional transaction cost per trade.
     """

--- a/ml/train_price.py
+++ b/ml/train_price.py
@@ -20,7 +20,7 @@ from crypto_analyzer.schemas import TrainConfig
 
 from .backtest import run_backtest
 from .time_cv import time_folds
-from .xgb_price import build_bound, build_reg, clip_inside, to_price
+from .xgb_price import build_reg, to_price
 
 structlog.configure(
     processors=[
@@ -107,40 +107,28 @@ def train_price(
         n_jobs = config.n_jobs
 
     target_mid = "delta_log_120m" if target_kind == "log" else "delta_lin_120m"
-    target_low = "delta_low_log_120m" if target_kind == "log" else "delta_low_lin_120m"
-    target_high = "delta_high_log_120m" if target_kind == "log" else "delta_high_lin_120m"
-    df = df.dropna(subset=[target_mid, target_low, target_high])
+    df = df.dropna(subset=[target_mid])
     X = _validate_features(df, feature_cols)
     y_mid = df[target_mid].astype("float32")
-    y_low = df[target_low].astype("float32")
-    y_high = df[target_high].astype("float32")
 
     zero_ratio = float((X == 0).sum().sum() / X.size)
     X_matrix = sparse.csr_matrix(X.values) if zero_ratio > 0.6 else X.values
 
     preds = []
     metrics = []
-    reg_models, low_models, high_models = [], [], []
+    reg_models = []
     start_time = time.monotonic()
     steps = horizon_min // 5
 
     for fold, (train_idx, test_idx) in enumerate(time_folds(len(df), embargo=embargo)):
         X_train, X_test = X_matrix[train_idx], X_matrix[test_idx]
         y_mid_train, y_mid_test = y_mid.iloc[train_idx], y_mid.iloc[test_idx]
-        y_low_train, y_low_test = y_low.iloc[train_idx], y_low.iloc[test_idx]
-        y_high_train, y_high_test = y_high.iloc[train_idx], y_high.iloc[test_idx]
 
         dtrain_mid = xgb.DMatrix(_to_f32(X_train), label=_to_f32(y_mid_train))
         dtest_mid = xgb.DMatrix(_to_f32(X_test), label=_to_f32(y_mid_test))
-        dtrain_lo = xgb.DMatrix(_to_f32(X_train), label=_to_f32(y_low_train))
-        dtest_lo = xgb.DMatrix(_to_f32(X_test), label=_to_f32(y_low_test))
-        dtrain_hi = xgb.DMatrix(_to_f32(X_train), label=_to_f32(y_high_train))
-        dtest_hi = xgb.DMatrix(_to_f32(X_test), label=_to_f32(y_high_test))
 
         reg_params, reg_rounds = build_reg()
-        b_params, b_rounds = build_bound()
-        for p in (reg_params, b_params):
-            p["nthread"] = n_jobs
+        reg_params["nthread"] = n_jobs
 
         reg = xgb.train(
             reg_params,
@@ -150,46 +138,16 @@ def train_price(
             early_stopping_rounds=50,
             verbose_eval=False,
         )
-        lowm = xgb.train(
-            b_params,
-            dtrain_lo,
-            b_rounds,
-            evals=[(dtest_lo, "test")],
-            early_stopping_rounds=50,
-            verbose_eval=False,
-        )
-        highm = xgb.train(
-            b_params,
-            dtrain_hi,
-            b_rounds,
-            evals=[(dtest_hi, "test")],
-            early_stopping_rounds=50,
-            verbose_eval=False,
-        )
         reg_models.append(reg)
-        low_models.append(lowm)
-        high_models.append(highm)
         last_price = np.asarray(df["close"].iloc[test_idx].values, dtype=np.float32)
         delta_hat = reg.predict(dtest_mid)
-        low_hat = lowm.predict(dtest_lo)
-        high_hat = highm.predict(dtest_hi)
         p_hat = to_price(last_price, delta_hat, kind=target_kind)
-        p_low = to_price(last_price, low_hat, kind=target_kind)
-        p_high = to_price(last_price, high_hat, kind=target_kind)
-        p_low, p_high = np.minimum(p_low, p_high), np.maximum(p_low, p_high)
-        p_hat = clip_inside(p_hat, p_low, p_high)
         target_price = df["close"].shift(-steps).iloc[test_idx].values
-        real_low = to_price(last_price, y_low_test.values, kind=target_kind)
-        real_high = to_price(last_price, y_high_test.values, kind=target_kind)
         fold_df = pd.DataFrame(
             {
                 "timestamp": df["timestamp"].iloc[test_idx].values,
-                "p_low": p_low,
                 "p_hat": p_hat,
-                "p_high": p_high,
                 "target": target_price,
-                "real_low": real_low,
-                "real_high": real_high,
                 "last_price": last_price,
                 "fold": fold,
             }
@@ -197,18 +155,10 @@ def train_price(
         preds.append(fold_df)
         rmse = float(np.sqrt(np.mean((p_hat - target_price) ** 2)))
         mid_mae = float(np.mean(np.abs(p_hat - target_price)))
-        coverage = float(np.mean((target_price >= p_low) & (target_price <= p_high)))
-        width = float(np.mean(p_high - p_low))
-        low_mae = float(np.mean(np.abs(p_low - real_low)))
-        high_mae = float(np.mean(np.abs(p_high - real_high)))
         metrics.append(
             {
                 "rmse": rmse,
                 "mid_mae": mid_mae,
-                "coverage": coverage,
-                "width": width,
-                "low_mae": low_mae,
-                "high_mae": high_mae,
             }
         )
         _log(
@@ -216,39 +166,22 @@ def train_price(
             fold=fold,
             rmse=rmse,
             mid_mae=mid_mae,
-            coverage=coverage,
-            low_mae=low_mae,
-            high_mae=high_mae,
         )
 
     avg_metrics = {
         "rmse": float(np.mean([m["rmse"] for m in metrics])),
         "mid_mae": float(np.mean([m["mid_mae"] for m in metrics])),
-        "coverage": float(np.mean([m["coverage"] for m in metrics])),
-        "width": float(np.mean([m["width"] for m in metrics])),
-        "low_mae": float(np.mean([m["low_mae"] for m in metrics])),
-        "high_mae": float(np.mean([m["high_mae"] for m in metrics])),
     }
 
     out_path = Path(outdir)
     out_path.mkdir(parents=True, exist_ok=True)
 
     reg_params, reg_rounds = build_reg()
-    b_params, b_rounds = build_bound()
-    for p in (reg_params, b_params):
-        p["nthread"] = n_jobs
+    reg_params["nthread"] = n_jobs
     dall_mid = xgb.DMatrix(_to_f32(X_matrix), label=_to_f32(y_mid))
-    dall_lo = xgb.DMatrix(_to_f32(X_matrix), label=_to_f32(y_low))
-    dall_hi = xgb.DMatrix(_to_f32(X_matrix), label=_to_f32(y_high))
     reg_final = xgb.train(reg_params, dall_mid, reg_rounds, verbose_eval=False)
-    low_final = xgb.train(b_params, dall_lo, b_rounds, verbose_eval=False)
-    high_final = xgb.train(b_params, dall_hi, b_rounds, verbose_eval=False)
     joblib.dump(reg_final, out_path / "reg.joblib")
-    joblib.dump(low_final, out_path / "low.joblib")
-    joblib.dump(high_final, out_path / "high.joblib")
-    joblib.dump(
-        {"reg": reg_models, "low": low_models, "high": high_models}, out_path / "ensemble.joblib"
-    )
+    joblib.dump({"reg": reg_models}, out_path / "ensemble.joblib")
 
     pred_df = pd.concat(preds, ignore_index=True).sort_values("timestamp")
     pred_df.to_csv(out_path / "cv_preds.csv", index=False)
@@ -278,7 +211,6 @@ def train_price(
         n_samples=len(df),
         rmse=avg_metrics["rmse"],
         mid_mae=avg_metrics["mid_mae"],
-        coverage=avg_metrics["coverage"],
         pnl=bt["metrics"]["pnl"],
         sharpe=bt["metrics"]["sharpe"],
         runtime_sec=elapsed,

--- a/ml/xgb_price.py
+++ b/ml/xgb_price.py
@@ -26,23 +26,6 @@ def build_reg() -> tuple[dict[str, float | int | str], int]:
     return params, rounds
 
 
-def build_bound() -> tuple[dict[str, float | int | str], int]:
-    params: dict[str, float | int | str] = {
-        "tree_method": "hist",
-        "device": "cuda",
-        "max_depth": 8,
-        "learning_rate": 0.05,
-        "subsample": 0.8,
-        "colsample_bytree": 0.8,
-        "nthread": -1,
-        "random_state": 42,
-        "objective": "reg:squarederror",
-        "eval_metric": "rmse",
-    }
-    rounds = 800
-    return params, rounds
-
-
 def to_price(
     last_price: np.ndarray | float, delta: np.ndarray | float, kind: str = "log"
 ) -> np.ndarray:
@@ -55,8 +38,4 @@ def to_price(
     raise ValueError("kind must be 'log' or 'lin'")
 
 
-def clip_inside(p: np.ndarray, lo: np.ndarray, hi: np.ndarray) -> np.ndarray:
-    return np.minimum(np.maximum(p, lo), hi)
-
-
-__all__ = ["build_reg", "build_bound", "to_price", "clip_inside"]
+__all__ = ["build_reg", "to_price"]

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -24,29 +24,13 @@ def _small_models():
         }
         return params, 5
 
-    def small_bound():
-        params = {
-            "max_depth": 2,
-            "eta": 0.1,
-            "subsample": 0.8,
-            "colsample_bytree": 0.8,
-            "tree_method": "hist",
-            "objective": "reg:squarederror",
-            "eval_metric": "rmse",
-            "nthread": 1,
-            "seed": 42,
-        }
-        return params, 5
-
-    return small_reg, small_bound
+    return small_reg
 
 
 def test_api_contract(tmp_path, monkeypatch):
-    small_reg, small_bound = _small_models()
+    small_reg = _small_models()
     monkeypatch.setattr(xgb_price, "build_reg", small_reg)
-    monkeypatch.setattr(xgb_price, "build_bound", small_bound)
     monkeypatch.setattr(tp, "build_reg", small_reg)
-    monkeypatch.setattr(tp, "build_bound", small_bound)
 
     rng = np.random.default_rng(0)
     n = 300
@@ -95,5 +79,4 @@ def test_api_contract(tmp_path, monkeypatch):
     res = client.get("/predict")
     assert res.status_code == 200
     j = res.json()
-    assert {"timestamp", "p_low", "p_hat", "p_high"} <= j.keys()
-    assert j["p_low"] <= j["p_hat"] <= j["p_high"]
+    assert {"timestamp", "p_hat"} <= j.keys()

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -7,9 +7,7 @@ def test_backtest_equity_length():
     df = pd.DataFrame(
         {
             "timestamp": pd.date_range("2024", periods=5, freq="5min"),
-            "p_low": [90, 91, 92, 93, 94],
             "p_hat": [101, 102, 103, 104, 105],
-            "p_high": [110, 111, 112, 113, 114],
             "target": [100, 101, 102, 103, 104],
             "last_price": [100, 101, 102, 103, 104],
         }

--- a/tests/test_historic.py
+++ b/tests/test_historic.py
@@ -21,29 +21,13 @@ def _small_models():
         }
         return params, 5
 
-    def small_bound():
-        params = {
-            "max_depth": 2,
-            "eta": 0.1,
-            "subsample": 0.8,
-            "colsample_bytree": 0.8,
-            "tree_method": "hist",
-            "objective": "reg:squarederror",
-            "eval_metric": "rmse",
-            "nthread": 1,
-            "seed": 42,
-        }
-        return params, 5
-
-    return small_reg, small_bound
+    return small_reg
 
 
 def test_train_historic(tmp_path, monkeypatch):
-    small_reg, small_bound = _small_models()
+    small_reg = _small_models()
     monkeypatch.setattr(xgb_price, "build_reg", small_reg)
-    monkeypatch.setattr(xgb_price, "build_bound", small_bound)
     monkeypatch.setattr(tp, "build_reg", small_reg)
-    monkeypatch.setattr(tp, "build_bound", small_bound)
 
     rng = np.random.default_rng(0)
     n = 300

--- a/tests/test_interval_coverage.py
+++ b/tests/test_interval_coverage.py
@@ -1,49 +1,17 @@
 import numpy as np
-import xgboost as xgb
 
-from ml.xgb_price import build_bound, build_reg
+from ml.xgb_price import build_reg, to_price
 
 
-def test_interval_coverage():
-    rng = np.random.default_rng(0)
-    X = rng.normal(size=(2000, 5))
-    beta = rng.normal(size=5)
-    y_mid = X @ beta
-    y_low = y_mid - 2.0
-    y_high = y_mid + 2.0
-    X_train, X_test = X[:1500], X[1500:]
-    y_mid_train, y_mid_test = y_mid[:1500], y_mid[1500:]
-    y_low_train, _ = y_low[:1500], y_low[1500:]
-    y_high_train, _ = y_high[:1500], y_high[1500:]
+def test_to_price_conversions():
+    params, rounds = build_reg()
+    assert params["tree_method"] == "hist"
+    assert rounds > 0
 
-    reg_params, reg_rounds = build_reg()
-    lo_params, lo_rounds = build_bound()
-    hi_params, hi_rounds = build_bound()
-    for p in (reg_params, lo_params, hi_params):
-        p.update({"max_depth": 3, "nthread": 1})
-    reg_rounds = lo_rounds = hi_rounds = 50
-    dtrain_mid = xgb.DMatrix(
-        np.asarray(X_train, dtype=np.float32),
-        label=np.asarray(y_mid_train, dtype=np.float32),
-    )
-    dtrain_lo = xgb.DMatrix(
-        np.asarray(X_train, dtype=np.float32),
-        label=np.asarray(y_low_train, dtype=np.float32),
-    )
-    dtrain_hi = xgb.DMatrix(
-        np.asarray(X_train, dtype=np.float32),
-        label=np.asarray(y_high_train, dtype=np.float32),
-    )
-    dtest_lo = xgb.DMatrix(np.asarray(X_test, dtype=np.float32))
-    dtest_hi = xgb.DMatrix(np.asarray(X_test, dtype=np.float32))
-    _ = xgb.train(reg_params, dtrain_mid, reg_rounds, verbose_eval=False)
-    lo_model = xgb.train(lo_params, dtrain_lo, lo_rounds, verbose_eval=False)
-    hi_model = xgb.train(hi_params, dtrain_hi, hi_rounds, verbose_eval=False)
-    last_price = 100.0
-    low = lo_model.predict(dtest_lo)
-    high = hi_model.predict(dtest_hi)
-    p_low = last_price + low
-    p_high = last_price + high
-    target = last_price + y_mid_test
-    coverage = np.mean((target >= p_low) & (target <= p_high))
-    assert coverage > 0.7
+    last_price = np.array([100.0, 200.0], dtype=np.float32)
+    delta_lin = np.array([5.0, -10.0], dtype=np.float32)
+    assert np.allclose(to_price(last_price, delta_lin, kind="lin"), last_price + delta_lin)
+
+    target_price = np.array([110.0, 190.0], dtype=np.float32)
+    delta_log = np.log(target_price / last_price)
+    assert np.allclose(to_price(last_price, delta_log, kind="log"), target_price)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -46,24 +46,8 @@ def test_model_meta(tmp_path, monkeypatch):
         }
         return params, 10
 
-    def small_bound():
-        params = {
-            "max_depth": 3,
-            "eta": 0.1,
-            "subsample": 0.8,
-            "colsample_bytree": 0.8,
-            "tree_method": "hist",
-            "objective": "reg:squarederror",
-            "eval_metric": "rmse",
-            "nthread": 1,
-            "seed": 42,
-        }
-        return params, 10
-
     monkeypatch.setattr(xgb_price, "build_reg", small_reg)
-    monkeypatch.setattr(xgb_price, "build_bound", small_bound)
     monkeypatch.setattr(tp, "build_reg", small_reg)
-    monkeypatch.setattr(tp, "build_bound", small_bound)
     config = TrainConfig(
         horizon_min=120,
         embargo=24,

--- a/tests/test_predictions_store.py
+++ b/tests/test_predictions_store.py
@@ -6,13 +6,13 @@ from db.predictions_store import create_predictions_table, save_predictions
 def test_predictions_upsert(tmp_path):
     db_path = tmp_path / "preds.sqlite"
     create_predictions_table(db_path=str(db_path))
-    row1 = ("BTC", "5m", 1_000, 10.0, 9.0, 11.0)
-    row2 = ("BTC", "5m", 1_000, 10.5, 9.5, 11.5)
+    row1 = ("BTC", "5m", 1_000, 10.0)
+    row2 = ("BTC", "5m", 1_000, 10.5)
     save_predictions([row1], db_path=str(db_path))
     save_predictions([row2], db_path=str(db_path))
     with sqlite3.connect(db_path) as conn:
         c = conn.cursor()
         c.execute("SELECT COUNT(*) FROM predictions")
         assert c.fetchone()[0] == 1
-        c.execute("SELECT p_hat, p_low, p_high FROM predictions WHERE symbol='BTC'")
-        assert c.fetchone() == (10.5, 9.5, 11.5)
+        c.execute("SELECT p_hat FROM predictions WHERE symbol='BTC'")
+        assert c.fetchone() == (10.5,)

--- a/tests/test_smoke_train_price.py
+++ b/tests/test_smoke_train_price.py
@@ -44,24 +44,8 @@ def test_smoke_train_price(monkeypatch, tmp_path):
         }
         return params, 10
 
-    def small_bound():
-        params = {
-            "max_depth": 3,
-            "eta": 0.1,
-            "subsample": 0.8,
-            "colsample_bytree": 0.8,
-            "tree_method": "hist",
-            "objective": "reg:squarederror",
-            "eval_metric": "rmse",
-            "nthread": 1,
-            "seed": 42,
-        }
-        return params, 10
-
     monkeypatch.setattr(xgb_price, "build_reg", small_reg)
-    monkeypatch.setattr(xgb_price, "build_bound", small_bound)
     monkeypatch.setattr(tp, "build_reg", small_reg)
-    monkeypatch.setattr(tp, "build_bound", small_bound)
 
     def small_folds(n_samples, embargo=24):
         return time_cv.time_folds(n_samples, n_splits=2, embargo=embargo)
@@ -69,4 +53,5 @@ def test_smoke_train_price(monkeypatch, tmp_path):
     monkeypatch.setattr(tp, "time_folds", small_folds)
 
     _, preds = tp.train_price(df, FEATURE_COLUMNS, outdir=tmp_path)
-    assert ((preds["p_hat"] >= preds["p_low"]) & (preds["p_hat"] <= preds["p_high"])).all()
+    assert {"timestamp", "p_hat", "target", "last_price"} <= set(preds.columns)
+    assert preds["p_hat"].notna().all()

--- a/tests/test_xgb_train_smoke.py
+++ b/tests/test_xgb_train_smoke.py
@@ -45,24 +45,8 @@ def test_xgb_train_smoke(monkeypatch, tmp_path):
         }
         return params, 5
 
-    def small_bound():
-        params = {
-            "max_depth": 2,
-            "eta": 0.1,
-            "subsample": 0.8,
-            "colsample_bytree": 0.8,
-            "tree_method": "hist",
-            "objective": "reg:squarederror",
-            "eval_metric": "rmse",
-            "nthread": 1,
-            "seed": 42,
-        }
-        return params, 5
-
     monkeypatch.setattr(xgb_price, "build_reg", small_reg)
-    monkeypatch.setattr(xgb_price, "build_bound", small_bound)
     monkeypatch.setattr(tp, "build_reg", small_reg)
-    monkeypatch.setattr(tp, "build_bound", small_bound)
 
     config = TrainConfig(
         horizon_min=120,
@@ -76,5 +60,5 @@ def test_xgb_train_smoke(monkeypatch, tmp_path):
     )
 
     metrics, preds = tp.train_price(df, config, outdir=tmp_path)
-    assert ((preds["p_hat"] >= preds["p_low"]) & (preds["p_hat"] <= preds["p_high"])).all()
+    assert preds["p_hat"].notna().all()
     assert "rmse" in metrics


### PR DESCRIPTION
## Summary
- remove interval bound calculations in the price training pipeline and API, keeping only point forecasts
- simplify the predictions store schema and update saving logic and forward prediction loop accordingly
- refresh documentation and tests to align with the point-forecast behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca87dc90448327ad39dbbf8a3bb15e