### PR TITLE
Harden feature inputs and expand validation coverage

### DIFF
--- a/tests/test_features_types.py
+++ b/tests/test_features_types.py
@@ -1,7 +1,14 @@
 import numpy as np
 import pandas as pd
+import pytest
 
-from analysis.feature_engineering import FEATURE_COLUMNS, create_features
+from analysis.feature_engineering import (
+    FEATURE_COLUMNS,
+    create_features,
+    get_feature_columns,
+    validate_feature_inputs,
+)
+from utils.config import FeatureSettings
 
 
 def test_features_types():
@@ -9,6 +16,7 @@ def test_features_types():
     n = 100
     ts = pd.date_range("2024-01-01", periods=n, freq="5min", tz="UTC")
     close = 100 + rng.normal(scale=1, size=n).cumsum()
+    open_ = close - rng.random(n)
     high = close + rng.random(n)
     low = close - rng.random(n)
     volume = rng.random(n) + 1
@@ -18,6 +26,7 @@ def test_features_types():
     df = pd.DataFrame(
         {
             "timestamp": ts,
+            "open": open_,
             "close": close,
             "high": high,
             "low": low,
@@ -32,3 +41,113 @@ def test_features_types():
     assert feat_df.columns.is_unique
     assert X.dtypes.eq("float32").all()
     assert not X.isna().any().any()
+
+
+def test_feature_toggles_respected():
+    rng = np.random.default_rng(1)
+    n = 50
+    ts = pd.date_range("2024-01-01", periods=n, freq="5min", tz="UTC")
+    close = 100 + rng.normal(scale=1, size=n).cumsum()
+    base = pd.DataFrame(
+        {
+            "timestamp": ts,
+            "open": close + 0.1,
+            "high": close + 0.5,
+            "low": close - 0.5,
+            "close": close,
+            "volume": rng.random(n) + 1,
+            "quote_asset_volume": rng.random(n) + 1,
+            "taker_buy_base": rng.random(n),
+            "taker_buy_quote": rng.random(n),
+            "number_of_trades": rng.integers(1, 100, size=n),
+            "basis_annualized": rng.random(n),
+            "open_interest": rng.random(n) * 1000,
+            "lob_bid_L1": rng.random(n),
+            "lob_ask_L1": rng.random(n),
+            "lob_bid_price_1": rng.random(n) + 100,
+            "lob_bid_size_1": rng.random(n),
+            "lob_ask_price_1": rng.random(n) + 101,
+            "lob_ask_size_1": rng.random(n),
+            "onch_fee_fast_satvb": rng.random(n),
+        }
+    )
+
+    settings = FeatureSettings(
+        include_onchain=False,
+        include_orderbook=False,
+        include_derivatives=False,
+        forward_fill_limit=0,
+        fillna_value=-1.0,
+    )
+    feat_df = create_features(base, settings=settings)
+
+    assert not any(col.startswith("onch_") for col in feat_df.columns)
+    assert not any(col.startswith("lob_") or col.startswith("wall_") for col in feat_df.columns)
+    assert {"basis_annualized", "oi_delta_15m"}.isdisjoint(feat_df.columns)
+
+    active_cols = get_feature_columns(settings)
+    assert all(col in feat_df.columns for col in active_cols)
+    assert "basis_annualized" not in active_cols
+    assert "lob_imbalance_L1" not in active_cols
+    assert all(not col.startswith("onch_") for col in active_cols)
+
+    numeric_cols = feat_df.select_dtypes(include=[np.number]).columns
+    assert not feat_df[numeric_cols].isna().any().any()
+    assert np.isclose(float(feat_df["ret3"].iloc[0]), settings.fillna_value)
+
+
+def test_create_features_rejects_missing_columns():
+    ts = pd.date_range("2024-01-01", periods=10, freq="5min", tz="UTC")
+    df = pd.DataFrame({"timestamp": ts, "open": 1.0, "high": 1.0, "low": 1.0, "close": 1.0})
+    with pytest.raises(KeyError):
+        create_features(df)
+
+
+def test_validate_feature_inputs_checks_onchain_names():
+    ts = pd.date_range("2024-01-01", periods=2, freq="5min", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "timestamp": ts,
+            "open": 1.0,
+            "high": 1.0,
+            "low": 1.0,
+            "close": 1.0,
+            "volume": 1.0,
+            "quote_asset_volume": 1.0,
+            "taker_buy_base": 0.5,
+            "taker_buy_quote": 0.5,
+            "onch_unknown": 1.0,
+        }
+    )
+
+    settings = FeatureSettings(
+        include_onchain=True,
+        include_orderbook=False,
+        include_derivatives=False,
+        forward_fill_limit=1,
+        fillna_value=0.0,
+    )
+
+    with pytest.raises(ValueError):
+        validate_feature_inputs(df, settings)
+
+
+def test_timestamp_localized_to_utc():
+    ts = pd.date_range("2024-01-01", periods=10, freq="5min")  # naive timestamps
+    df = pd.DataFrame(
+        {
+            "timestamp": ts,
+            "open": 1.0,
+            "high": 1.0,
+            "low": 1.0,
+            "close": 1.0,
+            "volume": 1.0,
+            "quote_asset_volume": 1.0,
+            "taker_buy_base": 0.5,
+            "taker_buy_quote": 0.5,
+        }
+    )
+
+    feat_df = create_features(df)
+    assert feat_df["timestamp"].dt.tz is not None
+    assert str(feat_df["timestamp"].dt.tz) == "UTC"

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
@@ -389,6 +389,34 @@ def _build_config() -> AppConfig:
 
 CONFIG = _build_config()
 
+ 
+def override_feature_settings(
+    settings: FeatureSettings,
+    *,
+    include_onchain: bool | None = None,
+    include_orderbook: bool | None = None,
+    include_derivatives: bool | None = None,
+    forward_fill_limit: int | None = None,
+    fillna_value: float | None = None,
+) -> FeatureSettings:
+    """Return updated feature settings with selected fields overridden."""
+
+    updates: dict[str, object] = {}
+    if include_onchain is not None:
+        updates["include_onchain"] = bool(include_onchain)
+    if include_orderbook is not None:
+        updates["include_orderbook"] = bool(include_orderbook)
+    if include_derivatives is not None:
+        updates["include_derivatives"] = bool(include_derivatives)
+    if forward_fill_limit is not None:
+        updates["forward_fill_limit"] = int(forward_fill_limit)
+    if fillna_value is not None:
+        updates["fillna_value"] = float(fillna_value)
+    if not updates:
+        return settings
+    return replace(settings, **updates)
+
+
 __all__ = [
     "AppConfig",
     "BacktestSettings",
@@ -399,4 +427,5 @@ __all__ = [
     "ModelSettings",
     "OnChainSettings",
     "RuntimeSettings",
+    "override_feature_settings",
 ]


### PR DESCRIPTION
## Summary
- centralize feature column groups in an immutable registry and reuse it for toggle resolution
- validate incoming data frames before feature engineering, enforcing required numeric inputs and UTC timestamps
- extend feature tests to cover error handling for missing data, bad on-chain inputs, and timestamp normalization

## Testing
- `pytest tests/test_features_types.py`


------
https://chatgpt.com/codex/tasks/task_e_68cc2a5397fc8327967f3195499ecede