### PR TITLE
Switch to 15-minute interval and add change probability

### DIFF
--- a/analysis/compare_predictions.py
+++ b/analysis/compare_predictions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from pathlib import Path
 import sqlite3
+from pathlib import Path
 from typing import Iterable
 
 import pandas as pd

--- a/analysis/feature_engineering.py
+++ b/analysis/feature_engineering.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 import re
+from dataclasses import dataclass
 from typing import Iterable
 
 import numpy as np

--- a/config/app.example.yaml
+++ b/config/app.example.yaml
@@ -6,9 +6,9 @@
 core:
   # Trading pair symbol and candle interval to analyse
   symbol: BTCUSDT
-  interval: 5m
-  # Number of prediction steps (5-minute candles) the meta-model forecasts
-  forward_steps: 24
+  interval: 15m
+  # Number of prediction steps (15-minute candles) the meta-model forecasts
+  forward_steps: 8
   # Historical window (in days) to fetch when preparing datasets
   history_days: 1825
   # Timezone used for time-based features
@@ -20,7 +20,7 @@ database:
   # Table for persisting model predictions
   predictions_table: predictions
   # Table containing on-chain metrics aligned to the candle grid
-  onchain_table: onchain_5m
+  onchain_table: onchain_15m
   # Optional feature store path (set to null to disable)
   feature_store: null
   # Chunk size used when streaming large tables from disk

--- a/db/btc_import.py
+++ b/db/btc_import.py
@@ -1,15 +1,18 @@
-import requests
+import os
 import sqlite3
 import time
-from datetime import datetime, timezone, timedelta
-import os
+from datetime import datetime, timedelta, timezone
+
+import requests
+
+from utils.config import CONFIG
 
 # Database location relative to repository root
 DB_PATH = os.path.join(os.path.dirname(__file__), 'data', 'crypto_data.sqlite')
 os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
 TABLE_NAME = 'prices'
-SYMBOL = "BTCUSDT"
-INTERVAL = "5m"
+SYMBOL = CONFIG.symbol
+INTERVAL = CONFIG.interval
 
 # Kolik dní zpět stáhnout (≈ půl roku)
 LOOKBACK_DAYS = 1880

--- a/ml/retrain_from_errors.py
+++ b/ml/retrain_from_errors.py
@@ -6,10 +6,10 @@ import pandas as pd
 from analysis.feature_engineering import FEATURE_COLUMNS, create_features
 from db.db_connector import get_price_data
 from ml.train_regressor import train_regressor
+from utils.config import CONFIG
 
-DB_PATH = "db/data/crypto_data.sqlite"
-SYMBOL = "BTCUSDT"
-INTERVAL = "5m"
+DB_PATH = CONFIG.db_path
+SYMBOL = CONFIG.symbol
 
 # must match your training features
 FEATURE_COLS = FEATURE_COLUMNS

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -34,10 +34,11 @@ def test_api_contract(tmp_path, monkeypatch):
 
     rng = np.random.default_rng(0)
     n = 300
-    ts = pd.date_range("2024-01-01", periods=n, freq="5min", tz="UTC")
+    ts = pd.date_range("2024-01-01", periods=n, freq="15min", tz="UTC")
     close = 100 + rng.normal(scale=1, size=n).cumsum()
     high = close + rng.random(n)
     low = close - rng.random(n)
+    open_ = (high + low) / 2
     volume = rng.random(n) + 1
     qvol = volume * close
     tbb = volume * 0.5
@@ -45,6 +46,7 @@ def test_api_contract(tmp_path, monkeypatch):
     df = pd.DataFrame(
         {
             "timestamp": ts,
+            "open": open_,
             "close": close,
             "high": high,
             "low": low,

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -6,7 +6,7 @@ from ml.backtest import run_backtest
 def test_backtest_equity_length():
     df = pd.DataFrame(
         {
-            "timestamp": pd.date_range("2024", periods=5, freq="5min"),
+            "timestamp": pd.date_range("2024", periods=5, freq="15min"),
             "p_hat": [101, 102, 103, 104, 105],
             "target": [100, 101, 102, 103, 104],
             "last_price": [100, 101, 102, 103, 104],

--- a/tests/test_compare_predictions.py
+++ b/tests/test_compare_predictions.py
@@ -12,7 +12,7 @@ def test_backfill_updates_predictions(tmp_path):
         conn.execute(
             "INSERT INTO predictions (symbol, interval, target_time_ms, p_hat)"
             " VALUES (?, ?, ?, ?)",
-            ("BTCUSDT", "5m", 123, 10.0),
+            ("BTCUSDT", "15m", 123, 10.0),
         )
         conn.execute(
             "CREATE TABLE prices (symbol TEXT, open_time INTEGER, close REAL)"

--- a/tests/test_feature_extremes.py
+++ b/tests/test_feature_extremes.py
@@ -6,10 +6,11 @@ from analysis.feature_engineering import create_features
 
 def test_future_extreme_targets_once():
     n = 60
-    ts = pd.date_range("2024-01-01", periods=n, freq="5min", tz="UTC")
+    ts = pd.date_range("2024-01-01", periods=n, freq="15min", tz="UTC")
     close = np.linspace(100, 101, n)
     high = close + 1
     low = close - 1
+    open_ = (high + low) / 2
     volume = np.ones(n)
     qvol = volume * close
     tbb = volume * 0.5
@@ -17,6 +18,7 @@ def test_future_extreme_targets_once():
     df = pd.DataFrame(
         {
             "timestamp": ts,
+            "open": open_,
             "close": close,
             "high": high,
             "low": low,

--- a/tests/test_features_types.py
+++ b/tests/test_features_types.py
@@ -14,7 +14,7 @@ from utils.config import FeatureSettings
 def test_features_types():
     rng = np.random.default_rng(0)
     n = 100
-    ts = pd.date_range("2024-01-01", periods=n, freq="5min", tz="UTC")
+    ts = pd.date_range("2024-01-01", periods=n, freq="15min", tz="UTC")
     close = 100 + rng.normal(scale=1, size=n).cumsum()
     open_ = close - rng.random(n)
     high = close + rng.random(n)
@@ -46,7 +46,7 @@ def test_features_types():
 def test_feature_toggles_respected():
     rng = np.random.default_rng(1)
     n = 50
-    ts = pd.date_range("2024-01-01", periods=n, freq="5min", tz="UTC")
+    ts = pd.date_range("2024-01-01", periods=n, freq="15min", tz="UTC")
     close = 100 + rng.normal(scale=1, size=n).cumsum()
     base = pd.DataFrame(
         {
@@ -97,14 +97,14 @@ def test_feature_toggles_respected():
 
 
 def test_create_features_rejects_missing_columns():
-    ts = pd.date_range("2024-01-01", periods=10, freq="5min", tz="UTC")
+    ts = pd.date_range("2024-01-01", periods=10, freq="15min", tz="UTC")
     df = pd.DataFrame({"timestamp": ts, "open": 1.0, "high": 1.0, "low": 1.0, "close": 1.0})
     with pytest.raises(KeyError):
         create_features(df)
 
 
 def test_validate_feature_inputs_checks_onchain_names():
-    ts = pd.date_range("2024-01-01", periods=2, freq="5min", tz="UTC")
+    ts = pd.date_range("2024-01-01", periods=2, freq="15min", tz="UTC")
     df = pd.DataFrame(
         {
             "timestamp": ts,
@@ -133,7 +133,7 @@ def test_validate_feature_inputs_checks_onchain_names():
 
 
 def test_timestamp_localized_to_utc():
-    ts = pd.date_range("2024-01-01", periods=10, freq="5min")  # naive timestamps
+    ts = pd.date_range("2024-01-01", periods=10, freq="15min")  # naive timestamps
     df = pd.DataFrame(
         {
             "timestamp": ts,

--- a/tests/test_historic.py
+++ b/tests/test_historic.py
@@ -31,10 +31,11 @@ def test_train_historic(tmp_path, monkeypatch):
 
     rng = np.random.default_rng(0)
     n = 300
-    ts = pd.date_range("2024-01-01", periods=n, freq="5min", tz="UTC")
+    ts = pd.date_range("2024-01-01", periods=n, freq="15min", tz="UTC")
     close = 100 + rng.normal(scale=1, size=n).cumsum()
     high = close + rng.random(n)
     low = close - rng.random(n)
+    open_ = (high + low) / 2
     volume = rng.random(n) + 1
     qvol = volume * close
     tbb = volume * 0.5
@@ -42,6 +43,7 @@ def test_train_historic(tmp_path, monkeypatch):
     df = pd.DataFrame(
         {
             "timestamp": ts,
+            "open": open_,
             "close": close,
             "high": high,
             "low": low,

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -12,10 +12,11 @@ from crypto_analyzer.schemas import FeatureConfig, TrainConfig
 def test_model_meta(tmp_path, monkeypatch):
     rng = np.random.default_rng(0)
     n = 300
-    ts = pd.date_range("2024-01-01", periods=n, freq="5min", tz="UTC")
+    ts = pd.date_range("2024-01-01", periods=n, freq="15min", tz="UTC")
     close = 100 + rng.normal(scale=1, size=n).cumsum()
     high = close + rng.random(n)
     low = close - rng.random(n)
+    open_ = (high + low) / 2
     volume = rng.random(n) + 1
     qvol = volume * close
     tbb = volume * 0.5
@@ -23,6 +24,7 @@ def test_model_meta(tmp_path, monkeypatch):
     df = pd.DataFrame(
         {
             "timestamp": ts,
+            "open": open_,
             "close": close,
             "high": high,
             "low": low,

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -26,18 +26,18 @@ def _create_synth_db(db_path: Path) -> None:
             number_of_trades INTEGER,
             taker_buy_base REAL,
             taker_buy_quote REAL,
-            onch_dummy REAL
+            onch_fee_fast_satvb REAL
         )
         """
     )
     base_ts = pd.Timestamp("2024-01-01", tz="UTC")
-    periods = 10 * 24 * 12  # 10 days of 5m data
-    ts = base_ts + pd.to_timedelta(np.arange(periods) * 5, unit="m")
+    periods = 10 * 24 * 4  # 10 days of 15m data
+    ts = base_ts + pd.to_timedelta(np.arange(periods) * 15, unit="m")
     df = pd.DataFrame(
         {
             "open_time": (ts.view("int64") // 1_000_000).astype(int),
             "symbol": "BTCUSDT",
-            "interval": "5m",
+            "interval": "15m",
             "open": np.random.rand(periods) + 10000,
             "high": np.random.rand(periods) + 10001,
             "low": np.random.rand(periods) + 9999,
@@ -47,7 +47,7 @@ def _create_synth_db(db_path: Path) -> None:
             "number_of_trades": np.random.randint(1, 100, size=periods),
             "taker_buy_base": np.random.rand(periods),
             "taker_buy_quote": np.random.rand(periods),
-            "onch_dummy": np.random.rand(periods),
+            "onch_fee_fast_satvb": np.random.rand(periods),
         }
     )
     df.to_sql("prices", conn, if_exists="append", index=False)

--- a/tests/test_predictions_store.py
+++ b/tests/test_predictions_store.py
@@ -6,13 +6,13 @@ from db.predictions_store import create_predictions_table, save_predictions
 def test_predictions_upsert(tmp_path):
     db_path = tmp_path / "preds.sqlite"
     create_predictions_table(db_path=str(db_path))
-    row1 = ("BTC", "5m", 1_000, 10.0)
-    row2 = ("BTC", "5m", 1_000, 10.5)
+    row1 = ("BTC", "15m", 1_000, 10.0, 0.25)
+    row2 = ("BTC", "15m", 1_000, 10.5, 0.75)
     save_predictions([row1], db_path=str(db_path))
     save_predictions([row2], db_path=str(db_path))
     with sqlite3.connect(db_path) as conn:
         c = conn.cursor()
         c.execute("SELECT COUNT(*) FROM predictions")
         assert c.fetchone()[0] == 1
-        c.execute("SELECT p_hat FROM predictions WHERE symbol='BTC'")
-        assert c.fetchone() == (10.5,)
+        c.execute("SELECT p_hat, prob_move_ge_05 FROM predictions WHERE symbol='BTC'")
+        assert c.fetchone() == (10.5, 0.75)

--- a/tests/test_smoke_train_price.py
+++ b/tests/test_smoke_train_price.py
@@ -10,10 +10,11 @@ from analysis.feature_engineering import FEATURE_COLUMNS
 def test_smoke_train_price(monkeypatch, tmp_path):
     rng = np.random.default_rng(0)
     n = 1050
-    ts = pd.date_range("2024-01-01", periods=n, freq="5min", tz="UTC")
+    ts = pd.date_range("2024-01-01", periods=n, freq="15min", tz="UTC")
     close = 100 + rng.normal(scale=1, size=n).cumsum()
     high = close + rng.random(n)
     low = close - rng.random(n)
+    open_ = (high + low) / 2
     volume = rng.random(n) + 1
     qvol = volume * close
     tbb = volume * 0.5
@@ -21,6 +22,7 @@ def test_smoke_train_price(monkeypatch, tmp_path):
     df = pd.DataFrame(
         {
             "timestamp": ts,
+            "open": open_,
             "close": close,
             "high": high,
             "low": low,

--- a/tests/test_train_args.py
+++ b/tests/test_train_args.py
@@ -20,7 +20,7 @@ def test_parses_args(module_name):
             "--train-end",
             "2024-01-31",
             "--horizon",
-            "5m",
+            "15m",
             "--step",
             "1m",
             "--eval-frac",

--- a/tests/test_xgb_train_smoke.py
+++ b/tests/test_xgb_train_smoke.py
@@ -11,10 +11,11 @@ from crypto_analyzer.schemas import FeatureConfig, TrainConfig
 def test_xgb_train_smoke(monkeypatch, tmp_path):
     rng = np.random.default_rng(0)
     n = 1050
-    ts = pd.date_range("2024-01-01", periods=n, freq="5min", tz="UTC")
+    ts = pd.date_range("2024-01-01", periods=n, freq="15min", tz="UTC")
     close = 100 + rng.normal(scale=1, size=n).cumsum()
     high = close + rng.random(n)
     low = close - rng.random(n)
+    open_ = (high + low) / 2
     volume = rng.random(n) + 1
     qvol = volume * close
     tbb = volume * 0.5
@@ -22,6 +23,7 @@ def test_xgb_train_smoke(monkeypatch, tmp_path):
     df = pd.DataFrame(
         {
             "timestamp": ts,
+            "open": open_,
             "close": close,
             "high": high,
             "low": low,

--- a/utils/config.py
+++ b/utils/config.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import yaml
 
-
 CONFIG_FILE_ENV = "APP_CONFIG_FILE"
 
 _TRUE_VALUES = {"1", "true", "yes", "on"}
@@ -223,12 +222,12 @@ def _resolve_cpu_limit(value: Any) -> int:
 
 def _build_core_settings(data: dict[str, Any]) -> CoreSettings:
     symbol = os.getenv("SYMBOL") or _as_str(data.get("symbol"), "BTCUSDT")
-    interval = os.getenv("INTERVAL") or _as_str(data.get("interval"), "5m")
+    interval = os.getenv("INTERVAL") or _as_str(data.get("interval"), "15m")
     forward_env = os.getenv("FORWARD_STEPS")
     forward_steps = (
         int(forward_env)
         if forward_env is not None
-        else _as_int(data.get("forward_steps"), 24)
+        else _as_int(data.get("forward_steps"), 8)
     )
     history_days = _as_int(data.get("history_days"), 5 * 365)
     timezone = _as_str(data.get("timezone"), "UTC")
@@ -248,7 +247,7 @@ def _build_database_settings(data: dict[str, Any]) -> DatabaseSettings:
     table_pred = os.getenv("TABLE_PRED") or _as_str(
         data.get("predictions_table"), "predictions"
     )
-    onchain_table = _as_str(data.get("onchain_table"), "onchain_5m")
+    onchain_table = _as_str(data.get("onchain_table"), "onchain_15m")
     feature_store = data.get("feature_store")
     feature_store_str = str(feature_store) if feature_store not in (None, "") else None
     read_chunksize = _as_int(data.get("read_chunksize"), 100_000)

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from contextlib import suppress
 import logging
+from contextlib import suppress
 from pathlib import Path
 
 logging.basicConfig(

--- a/utils/timeframes.py
+++ b/utils/timeframes.py
@@ -1,0 +1,68 @@
+"""Utilities for working with Binance-style interval strings."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class IntervalSpec:
+    """Metadata describing a supported candle interval."""
+
+    label: str
+    minutes: int
+
+
+_INTERVAL_SPECS: dict[str, IntervalSpec] = {
+    "1m": IntervalSpec("1m", 1),
+    "3m": IntervalSpec("3m", 3),
+    "5m": IntervalSpec("5m", 5),
+    "15m": IntervalSpec("15m", 15),
+    "30m": IntervalSpec("30m", 30),
+    "1h": IntervalSpec("1h", 60),
+    "2h": IntervalSpec("2h", 120),
+    "4h": IntervalSpec("4h", 240),
+    "1d": IntervalSpec("1d", 1440),
+}
+
+
+def interval_to_minutes(interval: str) -> int:
+    """Return the number of minutes represented by *interval*."""
+
+    key = interval.lower()
+    try:
+        return _INTERVAL_SPECS[key].minutes
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        raise ValueError(f"Unsupported interval: {interval!r}") from exc
+
+
+def interval_to_pandas_freq(interval: str) -> str:
+    """Convert *interval* to a pandas frequency string."""
+
+    minutes = interval_to_minutes(interval)
+    if minutes % 1440 == 0:
+        days = minutes // 1440
+        return f"{days}D"
+    if minutes % 60 == 0:
+        hours = minutes // 60
+        return f"{hours}H"
+    return f"{minutes}T"
+
+
+def steps_for_minutes(minutes: int, interval: str) -> int:
+    """Return the number of candles covering *minutes* for *interval*."""
+
+    base = interval_to_minutes(interval)
+    if minutes % base != 0:
+        raise ValueError(
+            "Interval must evenly divide the requested minutes: "
+            f"{minutes}m mod {interval} != 0",
+        )
+    return minutes // base
+
+
+__all__ = [
+    "IntervalSpec",
+    "interval_to_minutes",
+    "interval_to_pandas_freq",
+    "steps_for_minutes",
+]


### PR DESCRIPTION
## Summary
- update configuration, data ingestion, and on-chain tooling to use the 15-minute interval via a shared timeframe helper
- add a probability estimator for ≥0.5% price moves and persist the value alongside predictions
- refresh auxiliary scripts and tests for the new interval and tidy imports/SQL formatting

## Testing
- pytest *(fails: missing optional dependencies fastapi and xgboost)*
- ruff check

------
https://chatgpt.com/codex/tasks/task_e_68cc3758db288327ab8da9f5a8bec005