### PR TITLE
Refactor CLI into package and remove legacy scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ env/
 *.iml
 .DS_Store
 
-data/
+/data/
 datasets/
 outputs/
 models/

--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@ test:
 
 # simple demo entrypoint
 demo:
->python main.py
+>PYTHONPATH=src python -m crypto_analyzer.cli

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ are no longer wired into the default command sequence above.
 Example commands for 120‑minute horizon:
 
 ```bash
-python main.py --task clf --horizon 120 --split_params '{"test_size":0.2}' --out_dir outputs --use_onchain
+PYTHONPATH=src python -m crypto_analyzer.cli --task clf --horizon 120 --split_params '{"test_size":0.2}' --out_dir outputs --use_onchain
 ```
 
 The pipeline writes metrics, predictions, explainability artefacts and trained

--- a/archive/run_demo.sh
+++ b/archive/run_demo.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -e
 
-python main.py --task clf --horizon 120 --use_onchain --split_params '{"test_size":0.2}' --out_dir outputs/demo_clf
-python main.py --task reg --horizon 120 --use_onchain --split_params '{"test_size":0.2}' --out_dir outputs/demo_reg
+PYTHONPATH=src python -m crypto_analyzer.cli --task clf --horizon 120 --use_onchain --split_params '{"test_size":0.2}' --out_dir outputs/demo_clf
+# Legacy regression demo removed; classification CLI is the supported entry point.

--- a/src/crypto_analyzer/__init__.py
+++ b/src/crypto_analyzer/__init__.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
-__all__ = ["data", "features", "labeling", "models", "eval", "utils", "legacy"]
+__all__ = ["data", "features", "labeling", "models", "eval", "utils", "legacy", "pipelines"]
 
 _SUBMODULES = {name: f"{__name__}.{name}" for name in __all__}
 _ALIAS_MAP = {

--- a/src/crypto_analyzer/cli.py
+++ b/src/crypto_analyzer/cli.py
@@ -1,0 +1,54 @@
+"""Command line entry points for Crypto Analyzer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+
+from crypto_analyzer.pipelines import run_classification_pipeline
+from crypto_analyzer.utils.config import CONFIG
+from crypto_analyzer.utils.helpers import set_cpu_limit
+from crypto_analyzer.utils.progress import timed
+
+CPU_LIMIT = CONFIG.cpu_limit
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train the classification pipeline")
+    parser.add_argument("--task", default="clf")
+    parser.add_argument("--horizon", type=int, default=120)
+    parser.add_argument("--use_onchain", action="store_true")
+    parser.add_argument("--txn_cost_bps", type=float, default=1.0)
+    parser.add_argument("--split_params", type=str, default="{}")
+    parser.add_argument("--gpu", action="store_true")
+    parser.add_argument("--out_dir", type=str, default="outputs")
+    parser.add_argument("--cpu_limit", type=int, default=CPU_LIMIT)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if args.cpu_limit:
+        set_cpu_limit(args.cpu_limit)
+
+    try:
+        split_params = json.loads(args.split_params)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise SystemExit(f"Invalid --split_params JSON: {exc}") from exc
+
+    with timed("train_pipeline"):
+        run_classification_pipeline(
+            task=args.task,
+            horizon=args.horizon,
+            use_onchain=True if args.use_onchain else None,
+            txn_cost_bps=args.txn_cost_bps,
+            split_params=split_params,
+            gpu=args.gpu,
+            out_dir=args.out_dir,
+        )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/src/crypto_analyzer/data/maintenance.py
+++ b/src/crypto_analyzer/data/maintenance.py
@@ -1,24 +1,19 @@
-"""Utility for purging old data from the SQLite database."""
+"""Utilities for maintaining the SQLite dataset."""
 
 from __future__ import annotations
 
 import sqlite3
 import time
+from pathlib import Path
 
 from crypto_analyzer.utils.config import CONFIG
 
-TWO_YEARS_MS = 2 * 365 * 24 * 60 * 60 * 1000
-ONE_YEAR_MS = 1 * 365 * 24 * 60 * 60 * 1000
-HALF_YEAR_MS = 0.5 * 365 * 24 * 60 * 60 * 1000
+ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000
 SIX_HOURS_MS = 6 * 60 * 60 * 1000
 
 
-def delete_old_records(db_path: str = CONFIG.db_path) -> tuple[int, int]:
-    """Delete stale rows from the prices and prediction tables.
-
-    Returns:
-        Tuple[int, int]: counts of deleted rows from prices and prediction.
-    """
+def delete_old_records(db_path: str | Path = CONFIG.db_path) -> tuple[int, int]:
+    """Delete stale rows from the prices and prediction tables."""
 
     now_ms = int(time.time() * 1000)
     prices_before = now_ms - ONE_YEAR_MS

--- a/src/crypto_analyzer/pipelines/__init__.py
+++ b/src/crypto_analyzer/pipelines/__init__.py
@@ -1,0 +1,5 @@
+"""Pipeline helpers for orchestrating training routines."""
+
+from .classification import prepare_targets, run_classification_pipeline
+
+__all__ = ["prepare_targets", "run_classification_pipeline"]

--- a/tests/test_meta_models.py
+++ b/tests/test_meta_models.py
@@ -1,8 +1,3 @@
-import os
-import sys
-
-sys.path.append(os.getcwd())
-
 from pathlib import Path
 
 import numpy as np
@@ -12,7 +7,7 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import brier_score_loss
 
 from crypto_analyzer.features.engineering import FEATURE_COLUMNS, create_features
-from main import prepare_targets
+from crypto_analyzer.pipelines import prepare_targets
 from crypto_analyzer.models.meta import fit_meta_classifier, predict_meta
 
 

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -2,6 +2,7 @@ import json
 import os
 import sqlite3
 import subprocess
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -62,9 +63,15 @@ def _run_pipeline(tmp_path: Path, task: str) -> None:
     out_dir = tmp_path / "outputs"
     env = os.environ.copy()
     env["DB_PATH"] = str(db_path)
+    src_path = Path(__file__).resolve().parent.parent / "src"
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{src_path}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else str(src_path)
+    )
     cmd = [
-        "python",
-        "main.py",
+        sys.executable,
+        "-m",
+        "crypto_analyzer.cli",
         "--task",
         task,
         "--horizon",


### PR DESCRIPTION
## Summary
- replace the top-level training script with a package CLI and pipeline module
- move the SQLite maintenance helper into the data package and document the new entry point
- update smoke tests, tooling, and ignores to work with the refactored layout

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cd51f2014483279cdaad6f65da43d5