### PR TITLE
Add triple-barrier labels for 2h/4h/6h horizons

### DIFF
--- a/src/crypto_analyzer/labeling/targets.py
+++ b/src/crypto_analyzer/labeling/targets.py
@@ -4,6 +4,73 @@ import numpy as np
 import pandas as pd
 
 
+def _triple_barrier_labels(
+    df: pd.DataFrame,
+    periods: int,
+    *,
+    upper_mult: float,
+    lower_mult: float,
+) -> pd.Series:
+    """Compute triple-barrier labels for the given forward ``periods``.
+
+    The implementation follows the common definition popularised by
+    López de Prado where an observation is labelled ``1`` if the price
+    first touches the upper barrier, ``-1`` if it touches the lower
+    barrier, and otherwise the sign of the return when the vertical
+    barrier is reached. Observations without enough look-ahead data keep
+    the ``pd.NA`` placeholder so callers can drop them explicitly.
+    """
+
+    if periods <= 0:
+        raise ValueError("Triple-barrier periods must be a positive integer")
+
+    close = df["close"].to_numpy(dtype=np.float32, copy=False)
+    high = df["high"].to_numpy(dtype=np.float32, copy=False)
+    low = df["low"].to_numpy(dtype=np.float32, copy=False)
+
+    n = len(df)
+    labels = pd.Series(pd.NA, index=df.index, dtype="Int8")
+
+    for i in range(n):
+        horizon_idx = i + periods
+        if horizon_idx >= n:
+            continue
+
+        entry_price = close[i]
+        upper_barrier = entry_price * (1.0 + float(upper_mult))
+        lower_barrier = entry_price * (1.0 - float(lower_mult))
+
+        decision = None
+        for step in range(1, periods + 1):
+            hi = high[i + step]
+            lo = low[i + step]
+
+            if np.isnan(hi) or np.isnan(lo):
+                continue
+
+            if hi >= upper_barrier:
+                decision = 1
+                break
+            if lo <= lower_barrier:
+                decision = -1
+                break
+
+        if decision is None:
+            final_price = close[horizon_idx]
+            if np.isnan(final_price):
+                continue
+            if final_price > entry_price:
+                decision = 1
+            elif final_price < entry_price:
+                decision = -1
+            else:
+                decision = 0
+
+        labels.iat[i] = decision
+
+    return labels
+
+
 def _infer_step_minutes(ts: pd.Series) -> int:
     """Infer sampling period in minutes from a timestamp series."""
     if len(ts) < 2:
@@ -20,6 +87,9 @@ def make_targets(
     horizons_min: list[int] | None = None,
     txn_cost_bps: float = 1.0,
     use_three_class: bool = False,
+    *,
+    triple_barrier_horizons_min: list[int] | None = None,
+    triple_barrier_multipliers: dict[int, float | tuple[float, float]] | None = None,
 ) -> pd.DataFrame:
     """Create classification targets for future price moves.
 
@@ -37,10 +107,29 @@ def make_targets(
     use_three_class:
         If ``True`` the ``beyond_costs`` label returns three classes ``-1``,
         ``0`` and ``1``. Otherwise it is a binary ``0/1`` label.
+    triple_barrier_horizons_min:
+        List of horizons (in minutes) for which triple-barrier labels are
+        generated. Defaults to ``[120, 240, 360]``.
+    triple_barrier_multipliers:
+        Optional mapping from horizon to a single float (symmetric upper and
+        lower barrier) or ``(upper, lower)`` tuple specifying barrier widths in
+        relative terms. When omitted a default of ``1%`` is used.
     """
 
     if horizons_min is None:
         horizons_min = [120]
+
+    if triple_barrier_horizons_min is None:
+        triple_barrier_horizons_min = [120, 240, 360]
+
+    tb_multipliers: dict[int, tuple[float, float]] = {}
+    if triple_barrier_multipliers is not None:
+        for horizon, mult in triple_barrier_multipliers.items():
+            if isinstance(mult, tuple):
+                up, down = mult
+            else:
+                up = down = float(mult)
+            tb_multipliers[horizon] = (float(up), float(down))
 
     df = df.copy(deep=False)
     ts = pd.to_datetime(df["timestamp"])
@@ -60,5 +149,19 @@ def make_targets(
         if not use_three_class:
             bc = np.where(bc == 1, 1, 0)
         df[f"beyond_costs_{horizon}m"] = bc.astype(np.int8)
+
+    default_tb_multiplier = 0.01
+    for horizon in triple_barrier_horizons_min:
+        periods = max(1, int(round(horizon / step_minutes)))
+        up_mult, down_mult = tb_multipliers.get(
+            horizon, (default_tb_multiplier, default_tb_multiplier)
+        )
+        labels = _triple_barrier_labels(
+            df,
+            periods,
+            upper_mult=up_mult,
+            lower_mult=down_mult,
+        )
+        df[f"triple_barrier_{horizon}m"] = labels
 
     return df

--- a/src/crypto_analyzer/pipeline.py
+++ b/src/crypto_analyzer/pipeline.py
@@ -56,7 +56,9 @@ def _build_feature_matrix(df: pd.DataFrame, target_col: str) -> tuple[pd.DataFra
     }
     target_columns = {target_col}
     target_columns.update(
-        c for c in df.columns if c.startswith("cls_sign_") or c.startswith("beyond_costs_")
+        c
+        for c in df.columns
+        if c.startswith(("cls_sign_", "beyond_costs_", "triple_barrier_"))
     )
     feature_cols = [c for c in df.columns if c not in base_cols.union(target_columns)]
     X = df[feature_cols].astype(np.float32)
@@ -103,7 +105,11 @@ def prepare_targets(
         labeled = labeled.iloc[:-forward_steps, :].copy()
 
     labeled = labeled.dropna(subset=[target_col]).reset_index(drop=True)
-    drop_cols = [c for c in labeled.columns if c.startswith("beyond_costs_")]
+    drop_cols = [
+        c
+        for c in labeled.columns
+        if c.startswith(("beyond_costs_", "triple_barrier_"))
+    ]
     if drop_cols:
         labeled = labeled.drop(columns=drop_cols)
     labeled = labeled.rename(columns={target_col: "target_cls"})

--- a/tests/test_labeling_targets.py
+++ b/tests/test_labeling_targets.py
@@ -27,3 +27,74 @@ def test_make_targets_creates_binary_labels_without_leakage():
         labeled["beyond_costs_30m"], expected_bc, check_names=False
     )
     assert labeled["timestamp"].dt.tz is not None
+
+
+def test_make_targets_adds_triple_barrier_labels():
+    ts = pd.date_range("2024-01-01", periods=12, freq="15min", tz="UTC")
+    close = np.array(
+        [
+            100.0,
+            102.0,
+            101.0,
+            101.4,
+            101.3,
+            101.2,
+            101.1,
+            101.15,
+            101.2,
+            101.05,
+            101.0,
+            100.5,
+        ],
+        dtype=np.float32,
+    )
+    high = np.array(
+        [
+            100.2,
+            101.6,
+            101.2,
+            101.5,
+            101.4,
+            101.3,
+            101.2,
+            101.2,
+            101.25,
+            101.1,
+            101.05,
+            100.6,
+        ],
+        dtype=np.float32,
+    )
+    low = np.array(
+        [
+            99.8,
+            101.0,
+            100.5,
+            101.0,
+            101.1,
+            101.0,
+            101.0,
+            101.05,
+            101.1,
+            101.0,
+            100.95,
+            100.4,
+        ],
+        dtype=np.float32,
+    )
+
+    df = pd.DataFrame({"timestamp": ts, "close": close, "high": high, "low": low})
+
+    labeled = make_targets(df, horizons_min=[120])
+
+    expected = pd.Series(
+        [1, -1, 0, -1, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA],
+        dtype="Int8",
+    )
+    pd.testing.assert_series_equal(
+        labeled["triple_barrier_120m"], expected, check_names=False
+    )
+    assert "triple_barrier_240m" in labeled.columns
+    assert labeled["triple_barrier_240m"].isna().all()
+    assert "triple_barrier_360m" in labeled.columns
+    assert labeled["triple_barrier_360m"].isna().all()


### PR DESCRIPTION
## Summary
- add a reusable helper to compute triple-barrier labels based on OHLC candles
- extend make_targets to emit 2h/4h/6h triple-barrier columns with configurable barriers
- ensure pipeline utilities ignore the new label columns and add regression coverage

## Testing
- pytest tests/test_labeling_targets.py

------
https://chatgpt.com/codex/tasks/task_e_68cd635d747483279bef4cdcee20e710