### PR TITLE
Enhance backtest CLI with latency controls and reporting

### DIFF
--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+from typing import Optional
+
+import numpy as np
 import pandas as pd
 
 from crypto_analyzer.eval.backtest import run_backtest
@@ -70,24 +73,70 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Reference price column used when computing trade returns.",
     )
     parser.add_argument(
-        "--fee",
+        "--prob-column",
+        default=None,
+        help="Optional probability column for EV-based backtest rules.",
+    )
+    parser.add_argument(
+        "--fee-bps",
         type=float,
-        default=0.0004,
-        help="Proportional transaction cost per trade (in decimal form).",
+        default=4.0,
+        help="Proportional transaction cost per trade in basis points.",
     )
     parser.add_argument(
-        "--metrics-output",
-        type=Path,
-        default=Path("backtest_metrics.json"),
-        help="Destination JSON file for summary metrics.",
+        "--slip-bps",
+        type=float,
+        default=0.0,
+        help="Slippage assumption in basis points added to the fee.",
     )
     parser.add_argument(
-        "--equity-output",
-        type=Path,
-        default=Path("backtest_equity.csv"),
-        help="Destination CSV file storing the equity curve.",
+        "--latency-min",
+        type=float,
+        default=0.0,
+        help="Execution latency in minutes applied by shifting the entry candle forward.",
+    )
+    parser.add_argument(
+        "--p-touch-thr",
+        type=float,
+        default=None,
+        help="Minimum probability of touching the target required to open a trade.",
+    )
+    parser.add_argument(
+        "--p-up-thr",
+        type=float,
+        default=None,
+        help=(
+            "Directional probability threshold. Values above open longs, below (1-thr) open shorts."
+        ),
+    )
+    parser.add_argument(
+        "--run-id",
+        default=None,
+        help="Optional identifier used when storing reports. Defaults to a UTC timestamp.",
     )
     return parser
+
+
+def _infer_latency_steps(timestamps: pd.Series, latency_minutes: float) -> int:
+    if latency_minutes <= 0:
+        return 0
+
+    if timestamps.empty:
+        return 0
+
+    ordered = timestamps.sort_values().reset_index(drop=True)
+    diffs = ordered.diff().dropna()
+    if diffs.empty:
+        return 0
+
+    step_minutes = diffs.dt.total_seconds().median() / 60.0
+    if not np.isfinite(step_minutes) or step_minutes <= 0:
+        return 0
+
+    steps = int(round(latency_minutes / step_minutes))
+    if steps <= 0:
+        steps = 1
+    return steps
 
 
 def main(argv: list[str] | None = None) -> tuple[Path, Path]:
@@ -103,21 +152,60 @@ def main(argv: list[str] | None = None) -> tuple[Path, Path]:
         price_col=args.price_column,
     )
 
-    result = run_backtest(normalised, fee=args.fee)
+    latency_steps = _infer_latency_steps(normalised["timestamp"], args.latency_min)
 
-    args.metrics_output.parent.mkdir(parents=True, exist_ok=True)
-    args.equity_output.parent.mkdir(parents=True, exist_ok=True)
+    prob_col: Optional[str] = args.prob_column or None
+    if prob_col is not None and prob_col == args.prediction_column:
+        prob_col = "p_hat"
+    p_up_col = "p_up" if "p_up" in normalised.columns else None
 
-    equity = result["equity"]
+    result = run_backtest(
+        normalised,
+        fee_bps=args.fee_bps,
+        slippage_bps=args.slip_bps,
+        prob_col=prob_col,
+        latency_steps=latency_steps,
+        p_touch_col="p_hat" if args.p_touch_thr is not None else None,
+        p_touch_threshold=args.p_touch_thr,
+        p_up_col=p_up_col,
+        p_up_threshold=args.p_up_thr,
+    )
+
+    run_id = args.run_id or pd.Timestamp.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    reports_dir = Path("reports")
+    reports_dir.mkdir(parents=True, exist_ok=True)
+
+    equity = result["equity"].assign(run_id=run_id)
     metrics = result["metrics"]
-    equity.to_csv(args.equity_output, index=False)
-    args.metrics_output.write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+
+    equity_output = reports_dir / f"equity_{run_id}.csv"
+    summary_output = reports_dir / f"summary_{run_id}.json"
+
+    equity.to_csv(equity_output, index=False)
+
+    summary = {
+        "run_id": run_id,
+        "parameters": {
+            "fee_bps": args.fee_bps,
+            "slip_bps": args.slip_bps,
+            "latency_minutes": args.latency_min,
+            "p_touch_threshold": args.p_touch_thr,
+            "p_up_threshold": args.p_up_thr,
+            "prob_column": prob_col,
+            "latency_steps": latency_steps,
+        },
+        "metrics": metrics,
+    }
+    summary_output.write_text(json.dumps(summary, indent=2), encoding="utf-8")
 
     print(
         "Backtest complete. Final equity: "
-        f"{float(equity['equity'].iloc[-1]):.4f}, PnL: {metrics['pnl']:.4f}"
+        f"{float(equity['equity'].iloc[-1]):.4f}, PnL: {metrics['pnl']:.4f}, "
+        f"Sharpe: {metrics['sharpe']:.4f}, EV: {metrics['ev']:.6f}, "
+        f"MaxDD: {metrics['max_drawdown']:.4f}"
     )
-    return args.metrics_output, args.equity_output
+
+    return summary_output, equity_output
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI behaviour

--- a/src/crypto_analyzer/eval/backtest.py
+++ b/src/crypto_analyzer/eval/backtest.py
@@ -1,5 +1,4 @@
 """Backtesting utilities with cost-aware decision rules."""
-
 from __future__ import annotations
 
 from typing import TypedDict
@@ -16,12 +15,17 @@ class BacktestResult(TypedDict):
 def run_backtest(
     df: pd.DataFrame,
     *,
-    fee_per_trade: float = 0.0004,
+    fee_per_trade: float | None = None,
+    fee_bps: float | None = None,
     prob_col: str | None = None,
     reward_col: str = "reward_ratio",
     risk_col: str = "risk_ratio",
     slippage_bps: float = 0.0,
     latency_steps: int = 0,
+    p_touch_col: str | None = None,
+    p_up_col: str | None = None,
+    p_touch_threshold: float | None = None,
+    p_up_threshold: float | None = None,
 ) -> BacktestResult:
     """Run a cost-aware backtest using an expected value decision rule."""
 
@@ -30,46 +34,110 @@ def run_backtest(
     if "last_price" not in df.columns or "target" not in df.columns:
         raise KeyError("Dataframe must include 'last_price' and 'target' columns")
 
-    price_return = (df["target"] - df["last_price"]) / df["last_price"]
-    fee_total = float(fee_per_trade + slippage_bps / 10_000.0)
+    ordered = df.sort_values("timestamp").reset_index(drop=True)
+    working = ordered.copy()
+
+    if latency_steps > 0:
+        if latency_steps >= len(working):
+            raise ValueError("Latency exceeds available data length")
+
+        shift_cols = ["timestamp", "last_price", "target"]
+        for extra in (reward_col, risk_col):
+            if extra in working.columns and extra not in shift_cols:
+                shift_cols.append(extra)
+
+        for column in shift_cols:
+            working[column] = working[column].shift(-latency_steps)
+
+        working = working.iloc[:-latency_steps].reset_index(drop=True)
+
+    price_return = (working["target"] - working["last_price"]) / working["last_price"]
+
+    if fee_bps is not None and fee_per_trade is not None:
+        raise ValueError("Specify either fee_per_trade or fee_bps, not both")
+    if fee_bps is not None:
+        fee_component = float(fee_bps / 10_000.0)
+    else:
+        fee_component = float(0.0004 if fee_per_trade is None else fee_per_trade)
+
+    fee_total = float(fee_component + slippage_bps / 10_000.0)
+
+    gating_mask = np.ones(len(working), dtype=bool)
+
+    if p_touch_threshold is not None:
+        touch_column = p_touch_col or prob_col
+        if touch_column is None:
+            raise ValueError("p_touch_threshold specified but no probability column provided")
+        if touch_column not in working.columns:
+            raise KeyError(f"Column '{touch_column}' required for p_touch_threshold")
+        gating_mask &= working[touch_column].astype(np.float64).to_numpy() >= p_touch_threshold
+
+    up_probs = None
+    if p_up_col is not None:
+        if p_up_col not in working.columns:
+            raise KeyError(f"Column '{p_up_col}' required for p_up_threshold")
+        up_probs = working[p_up_col].astype(np.float64).to_numpy()
 
     if prob_col is None:
-        if "p_hat" not in df.columns:
+        if "p_hat" not in working.columns:
             raise KeyError("Dataframe must include 'p_hat' when prob_col is None")
-        direction = np.where(df["p_hat"] > df["last_price"], 1.0, -1.0)
+        if p_up_threshold is not None and up_probs is not None:
+            direction = np.zeros(len(working), dtype=np.float64)
+            direction[up_probs >= p_up_threshold] = 1.0
+            direction[up_probs <= (1.0 - p_up_threshold)] = -1.0
+        else:
+            direction = np.where(
+                working["p_hat"] > working["last_price"], 1.0, -1.0
+            ).astype(np.float64)
+
+        direction = np.where(gating_mask, direction, 0.0)
         trade_ret = direction * price_return.to_numpy() - fee_total * np.abs(direction)
-        ev = np.zeros_like(trade_ret)
+        ev = (
+            ((working["p_hat"] - working["last_price"]) / working["last_price"])
+            .astype(np.float64)
+            .to_numpy()
+            - fee_total * np.abs(direction)
+        )
         trades = np.abs(direction) > 0
     else:
-        probs = df[prob_col].astype(np.float64)
-        if latency_steps > 0:
-            probs = probs.shift(latency_steps)
-        probs = probs.fillna(0.0).clip(0.0, 1.0)
+        probs = working[prob_col].astype(np.float64).clip(0.0, 1.0)
 
         reward_series = (
-            df[reward_col]
-            if reward_col in df.columns
+            working[reward_col]
+            if reward_col in working.columns
             else price_return.clip(lower=0.0)
         ).astype(np.float64).to_numpy()
         risk_series = (
-            df[risk_col]
-            if risk_col in df.columns
+            working[risk_col]
+            if risk_col in working.columns
             else (-price_return).clip(lower=0.0)
         ).astype(np.float64).to_numpy()
 
         prob_arr = probs.to_numpy()
         ev = prob_arr * reward_series - (1.0 - prob_arr) * risk_series - fee_total
         direction = np.where(ev > 0.0, 1.0, 0.0)
+        if p_up_threshold is not None and up_probs is not None:
+            long_mask = up_probs >= p_up_threshold
+            direction = np.where(long_mask, direction, 0.0)
+            gating_mask &= long_mask
+        direction = np.where(gating_mask, direction, 0.0)
         trade_ret = direction * price_return.to_numpy() - fee_total * direction
         trades = direction > 0
 
     equity = (1.0 + trade_ret).cumprod()
     pnl = float(equity[-1] - 1.0)
     sharpe = float(np.mean(trade_ret) / (np.std(trade_ret) + 1e-9) * np.sqrt(len(trade_ret)))
-    hit_rate = float(
-        np.mean(price_return.to_numpy()[trades] > 0) if np.any(trades) else np.nan
+    executed = np.abs(direction) > 0
+    signed_returns = price_return.to_numpy() * np.sign(direction)
+    hit_rate_vs_prediction = float(
+        np.mean(signed_returns[executed] > 0) if np.any(executed) else float("nan")
     )
-    avg_ev = float(np.mean(ev[trades])) if np.any(trades) else float("nan")
+    hit_rate = hit_rate_vs_prediction
+    avg_ev = float(np.mean(ev[executed])) if np.any(executed) else float("nan")
+
+    running_max = np.maximum.accumulate(equity)
+    drawdown = equity / running_max - 1.0
+    max_drawdown = float(drawdown.min()) if len(drawdown) else float(0.0)
 
     metrics = {
         "pnl": pnl,
@@ -77,8 +145,11 @@ def run_backtest(
         "trades": int(np.sum(trades)),
         "hit_rate": hit_rate,
         "avg_ev": avg_ev,
+        "ev": avg_ev,
+        "hit_rate_vs_prediction": hit_rate_vs_prediction,
+        "max_drawdown": max_drawdown,
     }
-    equity_frame = pd.DataFrame({"timestamp": df["timestamp"], "equity": equity})
+    equity_frame = pd.DataFrame({"timestamp": working["timestamp"], "equity": equity})
     return {"equity": equity_frame, "metrics": metrics}
 
 

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -39,3 +39,67 @@ def test_backtest_expected_value_rule_applies_fees_and_slippage():
     metrics = result["metrics"]
     assert metrics["trades"] > 0
     assert metrics["avg_ev"] <= max(df["reward_ratio"])  # bounded by reward
+
+
+def test_backtest_latency_shifts_entries():
+    df = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2024-01-01", periods=6, freq="5min"),
+            "p_hat": [101, 102, 103, 104, 105, 106],
+            "target": [101.5, 102.5, 103.5, 104.5, 105.5, 106.5],
+            "last_price": [101, 102, 103, 104, 105, 106],
+        }
+    )
+
+    result = run_backtest(df, latency_steps=1, fee_per_trade=0.0)
+    equity = result["equity"]
+
+    assert len(equity) == len(df) - 1
+    # the first trade should align with the second timestamp after latency shift
+    assert equity["timestamp"].iloc[0] == df["timestamp"].iloc[1]
+
+
+def test_backtest_prob_thresholds_gate_trades():
+    df = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2024-02-01", periods=4, freq="15min"),
+            "last_price": [100, 101, 102, 103],
+            "target": [101, 102, 103, 104],
+            "p_success": [0.2, 0.3, 0.4, 0.5],
+            "reward_ratio": [0.01, 0.01, 0.01, 0.01],
+            "risk_ratio": [0.005, 0.005, 0.005, 0.005],
+        }
+    )
+
+    result = run_backtest(
+        df,
+        prob_col="p_success",
+        p_touch_col="p_success",
+        p_touch_threshold=0.6,
+        fee_per_trade=0.0,
+    )
+
+    assert result["metrics"]["trades"] == 0
+
+
+def test_backtest_directional_threshold_creates_shorts_and_longs():
+    df = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2024-03-01", periods=4, freq="15min"),
+            "p_hat": [100.5, 99.5, 100.2, 99.8],
+            "last_price": [100, 100, 100, 100],
+            "target": [100.6, 99.4, 100.3, 99.7],
+            "p_up": [0.8, 0.15, 0.7, 0.2],
+        }
+    )
+
+    result = run_backtest(
+        df,
+        p_up_col="p_up",
+        p_up_threshold=0.75,
+        fee_per_trade=0.0,
+    )
+
+    metrics = result["metrics"]
+    assert metrics["trades"] == 3  # long on index 0, short on indices 1 and 3
+    assert metrics["hit_rate"] <= 1.0

--- a/tests/test_backtest_metrics.py
+++ b/tests/test_backtest_metrics.py
@@ -27,6 +27,19 @@ def test_run_backtest_produces_equity_and_metrics():
     assert list(equity.columns) == ["timestamp", "equity"]
     assert equity["equity"].iloc[0] == pytest.approx(1.0, rel=5e-3)
     assert equity["equity"].iloc[-1] >= equity["equity"].iloc[0]
-    assert {"pnl", "sharpe", "trades", "hit_rate", "avg_ev"}.issubset(metrics.keys())
+    expected_keys = {
+        "pnl",
+        "sharpe",
+        "trades",
+        "hit_rate",
+        "avg_ev",
+        "ev",
+        "hit_rate_vs_prediction",
+        "max_drawdown",
+    }
+    assert expected_keys.issubset(metrics.keys())
     assert metrics["pnl"] >= 0.0
     assert np.isfinite(metrics["sharpe"])
+    assert metrics["ev"] == pytest.approx(metrics["avg_ev"])
+    assert metrics["hit_rate"] == pytest.approx(metrics["hit_rate_vs_prediction"])
+    assert metrics["max_drawdown"] <= 0.0


### PR DESCRIPTION
## Summary
- add fee, slippage, latency, and probability threshold options to the backtest CLI
- write standardised equity CSV and JSON summary reports keyed by run identifier
- extend backtest core logic with latency handling, trade gating, and additional metrics while updating the unit tests

## Testing
- `pytest`
- `pytest tests/test_backtest.py tests/test_backtest_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68ce98bd20908327a27523bf27f0fb06