### PR TITLE
Add conformal probability intervals and CLI support

### DIFF
--- a/src/crypto_analyzer/models/conformal.py
+++ b/src/crypto_analyzer/models/conformal.py
@@ -1,0 +1,198 @@
+"""Conformal prediction helpers for binary touch classification."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+__all__ = [
+    "ProbabilityInterval",
+    "ConformalSummary",
+    "split_conformal_interval",
+    "aps_conformal_interval",
+    "generate_touch_conformal_report",
+]
+
+
+@dataclass(slots=True)
+class ProbabilityInterval:
+    """Lower/upper bounds describing uncertainty around ``p̂``."""
+
+    method: str
+    alpha: float
+    lower: np.ndarray
+    upper: np.ndarray
+    radius: float
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "method": self.method,
+            "alpha": float(self.alpha),
+            "radius": float(self.radius),
+            "lower": self.lower.tolist(),
+            "upper": self.upper.tolist(),
+            "mean_width": float(np.mean(self.upper - self.lower)),
+        }
+
+
+@dataclass(slots=True)
+class ConformalSummary:
+    """Wrap a :class:`ProbabilityInterval` with calibration diagnostics."""
+
+    interval: ProbabilityInterval
+    calibration_coverage: float
+
+    def to_dict(self) -> dict[str, object]:
+        data = self.interval.to_dict()
+        data["calibration_coverage"] = float(self.calibration_coverage)
+        return data
+
+
+def _to_numpy(arr: Iterable[float] | np.ndarray | pd.Series) -> np.ndarray:
+    if isinstance(arr, np.ndarray):
+        return arr.astype(np.float64, copy=False)
+    if isinstance(arr, pd.Series):
+        return arr.to_numpy(dtype=np.float64, copy=False)
+    return np.asarray(list(arr), dtype=np.float64)
+
+
+def _validate_inputs(
+    y_cal: np.ndarray,
+    p_cal: np.ndarray,
+    p_test: np.ndarray,
+    *,
+    alpha: float,
+) -> None:
+    if y_cal.shape != p_cal.shape:
+        raise ValueError("`y_cal` and `p_cal` must have matching shapes")
+    if y_cal.ndim != 1:
+        raise ValueError("`y_cal` must be one-dimensional")
+    if p_test.ndim != 1:
+        raise ValueError("`p_test` must be one-dimensional")
+    if len(y_cal) == 0:
+        raise ValueError("Calibration set must not be empty")
+    if not (0.0 < alpha < 1.0):
+        raise ValueError("alpha must lie in (0, 1)")
+
+
+def _finite_sample_quantile(scores: np.ndarray, alpha: float) -> float:
+    n = scores.size
+    adjusted = 1 - alpha * (1 + 1 / n)
+    adjusted = float(np.clip(adjusted, 0.0, 1.0))
+    return float(np.quantile(scores, adjusted, method="higher"))
+
+
+def split_conformal_interval(
+    y_cal: Iterable[int] | np.ndarray | pd.Series,
+    p_cal: Iterable[float] | np.ndarray | pd.Series,
+    p_test: Iterable[float] | np.ndarray | pd.Series,
+    *,
+    alpha: float = 0.1,
+) -> ConformalSummary:
+    """Return symmetric split conformal intervals for binary probabilities."""
+
+    y_cal_arr = _to_numpy(y_cal)
+    p_cal_arr = np.clip(_to_numpy(p_cal), 1e-6, 1 - 1e-6)
+    p_test_arr = np.clip(_to_numpy(p_test), 1e-6, 1 - 1e-6)
+    _validate_inputs(y_cal_arr, p_cal_arr, p_test_arr, alpha=alpha)
+
+    residuals = np.abs(y_cal_arr - p_cal_arr)
+    radius = _finite_sample_quantile(residuals, alpha)
+    lower = np.clip(p_test_arr - radius, 0.0, 1.0)
+    upper = np.clip(p_test_arr + radius, 0.0, 1.0)
+
+    calib_cover = float(np.mean(residuals <= radius))
+
+    interval = ProbabilityInterval(
+        method="split",
+        alpha=alpha,
+        lower=lower,
+        upper=upper,
+        radius=radius,
+    )
+    return ConformalSummary(interval=interval, calibration_coverage=calib_cover)
+
+
+def aps_conformal_interval(
+    y_cal: Iterable[int] | np.ndarray | pd.Series,
+    p_cal: Iterable[float] | np.ndarray | pd.Series,
+    p_test: Iterable[float] | np.ndarray | pd.Series,
+    *,
+    alpha: float = 0.1,
+) -> ConformalSummary:
+    """Return APS-style conformal intervals for binary probabilities."""
+
+    y_cal_arr = _to_numpy(y_cal)
+    p_cal_arr = np.clip(_to_numpy(p_cal), 1e-6, 1 - 1e-6)
+    p_test_arr = np.clip(_to_numpy(p_test), 1e-6, 1 - 1e-6)
+    _validate_inputs(y_cal_arr, p_cal_arr, p_test_arr, alpha=alpha)
+
+    wrong_mass = np.where(y_cal_arr >= 0.5, 1.0 - p_cal_arr, p_cal_arr)
+    radius = _finite_sample_quantile(wrong_mass, alpha)
+    lower = np.clip(p_test_arr - radius, 0.0, 1.0)
+    upper = np.clip(p_test_arr + radius, 0.0, 1.0)
+
+    calib_cover = float(np.mean(wrong_mass <= radius))
+
+    interval = ProbabilityInterval(
+        method="aps",
+        alpha=alpha,
+        lower=lower,
+        upper=upper,
+        radius=radius,
+    )
+    return ConformalSummary(interval=interval, calibration_coverage=calib_cover)
+
+
+def _label_coverage_split(y: np.ndarray, p: np.ndarray, radius: float) -> float:
+    return float(np.mean(np.abs(y - p) <= radius))
+
+
+def _label_coverage_aps(y: np.ndarray, p: np.ndarray, radius: float) -> float:
+    wrong_mass = np.where(y >= 0.5, 1.0 - p, p)
+    return float(np.mean(wrong_mass <= radius))
+
+
+def generate_touch_conformal_report(
+    *,
+    y_cal: Iterable[int] | np.ndarray | pd.Series,
+    p_cal: Iterable[float] | np.ndarray | pd.Series,
+    y_test: Iterable[int] | np.ndarray | pd.Series,
+    p_test: Iterable[float] | np.ndarray | pd.Series,
+    alpha: float = 0.1,
+) -> dict[str, object]:
+    """Compute conformal confidence intervals and diagnostics."""
+
+    y_cal_arr = _to_numpy(y_cal)
+    p_cal_arr = _to_numpy(p_cal)
+    y_test_arr = _to_numpy(y_test)
+    p_test_arr = _to_numpy(p_test)
+
+    if y_test_arr.shape != p_test_arr.shape:
+        raise ValueError("`y_test` and `p_test` must have matching shapes")
+
+    split_summary = split_conformal_interval(y_cal_arr, p_cal_arr, p_test_arr, alpha=alpha)
+    aps_summary = aps_conformal_interval(y_cal_arr, p_cal_arr, p_test_arr, alpha=alpha)
+
+    split_dict = split_summary.to_dict()
+    split_dict["label_coverage"] = _label_coverage_split(
+        y_test_arr, p_test_arr, split_summary.interval.radius
+    )
+
+    aps_dict = aps_summary.to_dict()
+    aps_dict["label_coverage"] = _label_coverage_aps(
+        y_test_arr, p_test_arr, aps_summary.interval.radius
+    )
+
+    return {
+        "alpha": float(alpha),
+        "n_calibration": int(len(y_cal_arr)),
+        "n_test": int(len(y_test_arr)),
+        "methods": {
+            "split": split_dict,
+            "aps": aps_dict,
+        },
+    }

--- a/src/crypto_analyzer/models/train.py
+++ b/src/crypto_analyzer/models/train.py
@@ -22,6 +22,7 @@ from crypto_analyzer.models.calibration import (
     log_loss as calibration_log_loss,
     plot_reliability,
 )
+from crypto_analyzer.models.conformal import generate_touch_conformal_report
 from crypto_analyzer.models.utils import evaluate_model
 from crypto_analyzer.utils.config import CONFIG
 from crypto_analyzer.utils.splitting import WalkForwardSplit
@@ -343,6 +344,7 @@ def train_xgb(
     half_life_days: float = 30.0,
     calibration: str = "none",
     run_id: str | None = None,
+    conformal: dict[str, float] | None = None,
 ) -> xgb.Booster:
     """Train XGBoost model with exponential time decay weighting."""
 
@@ -374,13 +376,24 @@ def train_xgb(
     calibration_method = (calibration or "none").lower()
     calibration_possible = task == "clf" and calibration_method in {"isotonic", "platt"}
 
+    conformal_cfg = conformal or None
+    if conformal_cfg is not None and task != "clf":
+        raise ValueError("Conformal intervals are only supported for classification tasks")
+    conformal_alpha = 0.1
+    if conformal_cfg is not None:
+        conformal_alpha = float(conformal_cfg.get("alpha", 0.1))
+        if not (0.0 < conformal_alpha < 1.0):
+            raise ValueError("conformal alpha must lie in (0, 1)")
+    conformal_requested = conformal_cfg is not None
+
     X_train = X_train_full
     y_train = y_train_full
     ts_train = ts_train_full
     X_cal = None
     y_cal = None
 
-    if calibration_possible and len(X_train_full) > 1:
+    need_calibration_split = (calibration_possible or conformal_requested) and len(X_train_full) > 1
+    if need_calibration_split:
         cal_size = max(int(len(X_train_full) * 0.2), 1)
         cal_size = min(cal_size, len(X_train_full) - 1)
         if cal_size > 0:
@@ -447,9 +460,12 @@ def train_xgb(
         metrics_report["class_threshold"] = class_threshold
 
         calibrated_probs = None
+        calibrated_probs_calibration = None
         calibration_applied = False
-        if calibration_possible and X_cal is not None and len(X_cal) > 0:
+        cal_probs = None
+        if (calibration_possible or conformal_requested) and X_cal is not None and len(X_cal) > 0:
             cal_probs = booster.predict(xgb.DMatrix(X_cal))
+        if calibration_possible and cal_probs is not None:
             calibrator = (
                 IsotonicCalibrator().fit(cal_probs, y_cal.values)
                 if calibration_method == "isotonic"
@@ -457,6 +473,8 @@ def train_xgb(
             )
             calibrated_probs = calibrator.predict(preds)
             prob_series[f"Calibrated ({calibration_method})"] = calibrated_probs
+
+            calibrated_probs_calibration = calibrator.predict(cal_probs)
 
             labels_cal = (calibrated_probs >= class_threshold).astype(int)
             metrics_cal: dict[str, float] = {
@@ -486,6 +504,43 @@ def train_xgb(
             reliability_path,
             title=f"Reliability ({final_run_id})",
         )
+        if conformal_requested:
+            conformal_path = reports_dir / f"conformal_{final_run_id}.json"
+            if cal_probs is not None and y_cal is not None and len(y_cal) > 0:
+                raw_report = generate_touch_conformal_report(
+                    y_cal=y_cal.values if isinstance(y_cal, pd.Series) else y_cal,
+                    p_cal=cal_probs,
+                    y_test=y_test.values if isinstance(y_test, pd.Series) else y_test,
+                    p_test=preds,
+                    alpha=conformal_alpha,
+                )
+                conformal_payload: dict[str, object] = {"raw": raw_report}
+                if calibrated_probs is not None and calibrated_probs_calibration is not None:
+                    calibrated_report = generate_touch_conformal_report(
+                        y_cal=y_cal.values if isinstance(y_cal, pd.Series) else y_cal,
+                        p_cal=calibrated_probs_calibration,
+                        y_test=y_test.values if isinstance(y_test, pd.Series) else y_test,
+                        p_test=calibrated_probs,
+                        alpha=conformal_alpha,
+                    )
+                    conformal_payload["calibrated"] = calibrated_report
+                with conformal_path.open("w", encoding="utf-8") as f:
+                    json.dump(conformal_payload, f, indent=2)
+                metrics_report.setdefault("conformal", {})
+                metrics_report["conformal"].update(
+                    {
+                        "alpha": conformal_alpha,
+                        "report": conformal_path.name,
+                    }
+                )
+            else:
+                with conformal_path.open("w", encoding="utf-8") as f:
+                    json.dump(
+                        {"error": "insufficient calibration data", "alpha": conformal_alpha},
+                        f,
+                        indent=2,
+                    )
+
         metrics_path = reports_dir / f"metrics_{final_run_id}.json"
         with metrics_path.open("w", encoding="utf-8") as f:
             json.dump(metrics_report, f, indent=2)
@@ -636,7 +691,39 @@ def parse_args(argv: Iterable[str] | None = None):
         help="Probability calibration method for classification",
     )
     parser.add_argument("--run_id", type=str, default=None)
-    return parser.parse_args(argv)
+    parser.add_argument(
+        "--conformal",
+        nargs="*",
+        help="Enable conformal prediction report; optionally pass alpha=0.1",
+    )
+
+    args = parser.parse_args(argv)
+
+    conformal_args = args.conformal
+    if conformal_args is None:
+        args.conformal = None
+        return args
+
+    conformal_cfg: dict[str, float] = {"alpha": 0.1}
+    if len(conformal_args) == 0:
+        args.conformal = conformal_cfg
+        return args
+
+    for item in conformal_args:
+        if "=" not in item:
+            parser.error(f"Invalid --conformal specification: {item}")
+        key, value = item.split("=", 1)
+        key = key.strip().lower()
+        value = value.strip()
+        if key != "alpha":
+            parser.error(f"Unsupported --conformal option: {key}")
+        try:
+            conformal_cfg["alpha"] = float(value)
+        except ValueError:
+            parser.error(f"Invalid alpha value for --conformal: {value}")
+
+    args.conformal = conformal_cfg
+    return args
 
 
 def main_cli(args) -> Path:
@@ -679,6 +766,7 @@ def main_cli(args) -> Path:
         half_life_days=args.half_life,
         calibration=args.calibration,
         run_id=run_id,
+        conformal=args.conformal,
     )
     return out_dir
 

--- a/tests/test_models_conformal.py
+++ b/tests/test_models_conformal.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+
+from crypto_analyzer.models.conformal import (
+    aps_conformal_interval,
+    generate_touch_conformal_report,
+    split_conformal_interval,
+)
+
+
+def _sample_data():
+    y_cal = np.array([0, 1, 0, 1, 0, 1], dtype=float)
+    p_cal = np.array([0.1, 0.9, 0.2, 0.8, 0.15, 0.85], dtype=float)
+    y_test = np.array([0, 1, 1], dtype=float)
+    p_test = np.array([0.2, 0.75, 0.9], dtype=float)
+    return y_cal, p_cal, y_test, p_test
+
+
+def test_split_conformal_interval_basic_properties():
+    y_cal, p_cal, _, p_test = _sample_data()
+    summary = split_conformal_interval(y_cal, p_cal, p_test, alpha=0.1)
+    assert summary.interval.lower.shape == p_test.shape
+    assert summary.interval.upper.shape == p_test.shape
+    assert summary.interval.radius > 0
+    assert summary.calibration_coverage >= 0.8
+
+
+def test_aps_conformal_interval_basic_properties():
+    y_cal, p_cal, _, p_test = _sample_data()
+    summary = aps_conformal_interval(y_cal, p_cal, p_test, alpha=0.1)
+    assert summary.interval.lower.shape == p_test.shape
+    assert summary.interval.upper.shape == p_test.shape
+    assert 0 < summary.interval.radius < 1
+    assert summary.calibration_coverage >= 0.8
+
+
+def test_generate_touch_conformal_report_contains_expected_keys():
+    y_cal, p_cal, y_test, p_test = _sample_data()
+    report = generate_touch_conformal_report(
+        y_cal=y_cal,
+        p_cal=p_cal,
+        y_test=y_test,
+        p_test=p_test,
+        alpha=0.1,
+    )
+    assert report["alpha"] == pytest.approx(0.1)
+    assert report["n_calibration"] == len(y_cal)
+    assert report["n_test"] == len(y_test)
+
+    split_report = report["methods"]["split"]
+    aps_report = report["methods"]["aps"]
+
+    assert len(split_report["lower"]) == len(p_test)
+    assert len(aps_report["upper"]) == len(p_test)
+    assert split_report["label_coverage"] >= 0.66
+    assert aps_report["label_coverage"] >= 0.66
+
+
+@pytest.mark.parametrize("alpha", [0.0, 1.5])
+def test_invalid_alpha_raises(alpha):
+    y_cal, p_cal, _, p_test = _sample_data()
+    with pytest.raises(ValueError):
+        split_conformal_interval(y_cal, p_cal, p_test, alpha=alpha)

--- a/tests/test_train_args.py
+++ b/tests/test_train_args.py
@@ -40,3 +40,29 @@ def test_parses_args(module_name):
         ]
     )
     assert args2.train_window == "10 days"
+
+
+def test_train_cli_conformal_parse():
+    pytest.importorskip("xgboost")
+    from crypto_analyzer.models import train as train_module
+
+    args = train_module.parse_args(
+        [
+            "--task",
+            "clf",
+            "--horizon",
+            "120",
+            "--conformal",
+            "alpha=0.05",
+        ]
+    )
+    assert args.conformal == {"alpha": 0.05}
+
+    args_default = train_module.parse_args([
+        "--task",
+        "clf",
+        "--horizon",
+        "120",
+        "--conformal",
+    ])
+    assert args_default.conformal == {"alpha": 0.1}


### PR DESCRIPTION
## Summary
- implement conformal prediction helpers for binary touch classification that expose split and APS interval diagnostics
- integrate the optional `--conformal` flag into the XGBoost training CLI to persist conformal reports alongside existing metrics
- add unit tests covering the conformal utilities and CLI argument parsing

## Testing
- pytest tests/test_models_conformal.py tests/test_train_args.py

------
https://chatgpt.com/codex/tasks/task_e_68cef3e10dfc832785f28479f58d76f8