### PR TITLE
Implement purged walk-forward CV with embargo logging

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -216,8 +216,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--embargo_min",
         type=int,
         choices=(120, 240, 360),
-        default=120,
-        help="Embargo window in minutes used for purged walk-forward cross-validation.",
+        default=360,
+        help=(
+            "Embargo window in minutes used for purged walk-forward cross-validation."
+            " Defaults to 360 minutes."
+        ),
     )
     parser.set_defaults(include_onchain=None, include_orderbook=None, include_derivatives=None)
     return parser

--- a/src/crypto_analyzer/eval/cv.py
+++ b/src/crypto_analyzer/eval/cv.py
@@ -9,23 +9,10 @@ def purged_walkforward_splits(
 ) -> list[tuple[np.ndarray, np.ndarray]]:
     """Build purged walk-forward cross-validation splits.
 
-    Parameters
-    ----------
-    index:
-        Chronologically ordered :class:`pandas.DatetimeIndex` describing the
-        observations that should be split.
-    n_splits:
-        Number of walk-forward folds to generate.
-    embargo_min:
-        Embargo window (in minutes) applied on both sides of each test fold.
-
-    Returns
-    -------
-    list[tuple[np.ndarray, np.ndarray]]
-        Sequence of ``(train_idx, test_idx)`` pairs referencing the positional
-        indices of the provided ``index``.  Each fold respects the
-        chronological order (``train`` precedes ``test``) while purging the
-        embargo window around the test set from the training samples.
+    The splitter respects temporal ordering (training observations always
+    precede their corresponding test fold) and applies a symmetric embargo
+    around every test window.  Observations falling inside the embargo window
+    are removed from all training folds to avoid leakage.
     """
 
     if n_splits < 1:
@@ -47,19 +34,20 @@ def purged_walkforward_splits(
     embargo_minutes = max(0, int(embargo_min))
     embargo_delta = pd.Timedelta(minutes=embargo_minutes)
 
-    boundaries = np.linspace(0, n_samples, n_splits + 2, dtype=int)
+    # Divide the index into n_splits test segments + one initial training block.
+    # ``np.array_split`` keeps the chronological order and balances the segment
+    # sizes while ensuring every test segment receives at least one observation
+    # when possible.
+    segments = np.array_split(np.arange(n_samples, dtype=int), n_splits + 1)
+
     splits: list[tuple[np.ndarray, np.ndarray]] = []
     embargo_windows: list[tuple[pd.Timestamp, pd.Timestamp]] = []
 
-    for i in range(n_splits):
-        train_end = boundaries[i + 1]
-        test_start = train_end
-        test_end = boundaries[i + 2]
-
-        if test_end <= test_start:
+    for fold in range(n_splits):
+        test_idx = segments[fold + 1]
+        if test_idx.size == 0:
             continue
 
-        test_idx = np.arange(test_start, test_end)
         test_start_time = index[test_idx[0]]
         test_end_time = index[test_idx[-1]]
 
@@ -67,13 +55,18 @@ def purged_walkforward_splits(
         window_end = test_end_time + embargo_delta
 
         train_mask = np.zeros(n_samples, dtype=bool)
-        if train_end > 0:
-            train_mask[:test_start] = True
-            for start, end in embargo_windows + [(window_start, window_end)]:
-                mask = (index >= start) & (index <= end)
-                train_mask &= ~mask
+        for segment in segments[: fold + 1]:
+            if segment.size:
+                train_mask[segment] = True
 
-        train_idx = np.nonzero(train_mask)[0]
+        # Enforce the chronological constraint explicitly and purge previous
+        # and current embargo windows from the training candidates.
+        train_mask &= index < test_start_time
+        for start, end in embargo_windows + [(window_start, window_end)]:
+            mask = (index >= start) & (index <= end)
+            train_mask &= ~mask
+
+        train_idx = np.flatnonzero(train_mask)
         if train_idx.size == 0:
             embargo_windows.append((window_start, window_end))
             continue

--- a/src/crypto_analyzer/models/train.py
+++ b/src/crypto_analyzer/models/train.py
@@ -119,8 +119,43 @@ def train_model(
 
         fold_metrics: list[dict[str, float]] = []
         preds_frames: list[pd.DataFrame] = []
+        split_details: list[dict[str, Any]] = []
 
         for fold, (train_idx, test_idx) in enumerate(splits):
+            train_times = timestamps.iloc[train_idx] if len(train_idx) else pd.Series(dtype="datetime64[ns]")
+            test_times = timestamps.iloc[test_idx] if len(test_idx) else pd.Series(dtype="datetime64[ns]")
+
+            detail = {
+                "fold": fold,
+                "train": {
+                    "count": int(len(train_idx)),
+                    "start_idx": int(train_idx[0]) if len(train_idx) else None,
+                    "end_idx": int(train_idx[-1]) if len(train_idx) else None,
+                    "start_time": train_times.iloc[0].isoformat() if len(train_times) else None,
+                    "end_time": train_times.iloc[-1].isoformat() if len(train_times) else None,
+                },
+                "test": {
+                    "count": int(len(test_idx)),
+                    "start_idx": int(test_idx[0]) if len(test_idx) else None,
+                    "end_idx": int(test_idx[-1]) if len(test_idx) else None,
+                    "start_time": test_times.iloc[0].isoformat() if len(test_times) else None,
+                    "end_time": test_times.iloc[-1].isoformat() if len(test_times) else None,
+                },
+                "embargo": {
+                    "start_time": (
+                        (test_times.iloc[0] - pd.Timedelta(minutes=embargo)).isoformat()
+                        if len(test_times)
+                        else None
+                    ),
+                    "end_time": (
+                        (test_times.iloc[-1] + pd.Timedelta(minutes=embargo)).isoformat()
+                        if len(test_times)
+                        else None
+                    ),
+                },
+            }
+            split_details.append(detail)
+
             if len(train_idx) == 0 or len(test_idx) == 0:
                 continue
 
@@ -156,6 +191,7 @@ def train_model(
             "embargo_minutes": embargo,
             "n_splits": n_splits,
             "folds": fold_metrics,
+            "splits": split_details,
         }
         atomic_write(Path(log_path), json.dumps(metrics_data, indent=2).encode("utf-8"))
 

--- a/tests/test_walkforward_split.py
+++ b/tests/test_walkforward_split.py
@@ -1,5 +1,6 @@
 import pandas as pd
 
+from crypto_analyzer.eval.cv import purged_walkforward_splits
 from crypto_analyzer.utils.splitting import PurgedWalkForwardSplit, WalkForwardSplit
 
 
@@ -45,3 +46,30 @@ def test_purged_walkforward_respects_embargo_and_purge():
     if len(splits) > 1:
         for (_, test_idx), (next_train_idx, _) in zip(splits, splits[1:]):
             assert test_idx.max() < next_train_idx.min()
+
+
+def test_purged_walkforward_split_function_respects_embargo():
+    index = pd.date_range("2024-01-01", periods=72, freq="h", tz="UTC")
+    embargo_min = 180
+
+    splits = purged_walkforward_splits(index, n_splits=4, embargo_min=embargo_min)
+    assert splits, "Expected purged walk-forward splitter to return folds"
+
+    embargo_delta = pd.Timedelta(minutes=embargo_min)
+    seen_windows: list[tuple[pd.Timestamp, pd.Timestamp]] = []
+
+    for train_idx, test_idx in splits:
+        assert train_idx.size > 0 and test_idx.size > 0
+        assert train_idx.max() < test_idx.min()
+
+        train_times = index[train_idx]
+        test_times = index[test_idx]
+
+        window_start = test_times[0] - embargo_delta
+        window_end = test_times[-1] + embargo_delta
+
+        assert not ((train_times >= window_start) & (train_times <= window_end)).any()
+        for start, end in seen_windows:
+            assert not ((train_times >= start) & (train_times <= end)).any()
+
+        seen_windows.append((window_start, window_end))


### PR DESCRIPTION
## Summary
- implement a purged walk-forward cross-validation splitter that enforces temporal order and symmetric embargo windows
- expose the `--cv purged-wf` workflow with a 360 minute default embargo in the training CLI
- persist the CV split metadata in the training report and add coverage for the new splitter behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cefcdfc71c8327b0dcd1ed59f1ac97