### PR TITLE
Add calibration utilities and integrate reliability reporting

### DIFF
--- a/src/crypto_analyzer/models/calibration.py
+++ b/src/crypto_analyzer/models/calibration.py
@@ -1,4 +1,4 @@
-"""Calibration utilities for probabilistic classification outputs."""
+"""Utilities for fitting simple probability calibrators and visualising calibration."""
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -10,55 +10,73 @@ import numpy as np
 from sklearn.calibration import calibration_curve
 from sklearn.isotonic import IsotonicRegression
 from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import brier_score_loss, log_loss as sklearn_log_loss
+from sklearn.metrics import brier_score_loss, log_loss
 
 
-class ProbabilityCalibrator(Protocol):
-    """Protocol for simple 1D probability calibrators."""
+class Calibrator(Protocol):
+    """Simple protocol representing a fitted probability calibrator."""
 
-    def fit(self, probs: np.ndarray, y_true: np.ndarray) -> "ProbabilityCalibrator":
-        ...
-
-    def predict(self, probs: np.ndarray) -> np.ndarray:
-        ...
+    def predict(self, probs: Iterable[float]) -> np.ndarray:
+        """Transform raw probability estimates to calibrated values."""
 
 
-@dataclass
-class IsotonicCalibrator:
-    """One-dimensional isotonic regression calibrator."""
+@dataclass(slots=True)
+class _IsotonicCalibrator:
+    model: IsotonicRegression
 
-    out_of_bounds: str = "clip"
-
-    def __post_init__(self) -> None:
-        self._model = IsotonicRegression(out_of_bounds=self.out_of_bounds)
-
-    def fit(self, probs: np.ndarray, y_true: np.ndarray) -> "IsotonicCalibrator":
-        self._model.fit(probs, y_true)
-        return self
-
-    def predict(self, probs: np.ndarray) -> np.ndarray:
-        calibrated = self._model.predict(probs)
+    def predict(self, probs: Iterable[float]) -> np.ndarray:
+        arr = np.asarray(list(probs), dtype=float)
+        calibrated = self.model.predict(arr)
         return np.clip(calibrated, 1e-6, 1 - 1e-6)
 
 
-@dataclass
-class PlattCalibrator:
-    """Platt scaling calibrator implemented via logistic regression."""
+@dataclass(slots=True)
+class _PlattCalibrator:
+    model: LogisticRegression
+    use_logit: bool
 
-    max_iter: int = 100
+    @staticmethod
+    def _to_scores(raw: Iterable[float], *, use_logit: bool) -> np.ndarray:
+        scores = np.asarray(list(raw), dtype=float)
+        if use_logit:
+            scores = np.clip(scores, 1e-6, 1 - 1e-6)
+            odds = scores / (1 - scores)
+            scores = np.log(odds)
+        return scores.reshape(-1, 1)
 
-    def __post_init__(self) -> None:
-        self._model = LogisticRegression(max_iter=self.max_iter)
-
-    def fit(self, probs: np.ndarray, y_true: np.ndarray) -> "PlattCalibrator":
-        X = probs.reshape(-1, 1)
-        self._model.fit(X, y_true)
-        return self
-
-    def predict(self, probs: np.ndarray) -> np.ndarray:
-        X = probs.reshape(-1, 1)
-        calibrated = self._model.predict_proba(X)[:, 1]
+    def predict(self, probs: Iterable[float]) -> np.ndarray:
+        X = self._to_scores(probs, use_logit=self.use_logit)
+        calibrated = self.model.predict_proba(X)[:, 1]
         return np.clip(calibrated, 1e-6, 1 - 1e-6)
+
+
+def fit_isotonic(p_raw: Iterable[float], y: Iterable[float]) -> Calibrator:
+    """Fit an isotonic regression calibrator on raw probability estimates."""
+
+    model = IsotonicRegression(out_of_bounds="clip")
+    p_arr = np.asarray(list(p_raw), dtype=float)
+    y_arr = np.asarray(list(y), dtype=float)
+    model.fit(p_arr, y_arr)
+    return _IsotonicCalibrator(model)
+
+
+def fit_platt(logits_or_p: Iterable[float], y: Iterable[float]) -> Calibrator:
+    """Fit Platt scaling via logistic regression."""
+
+    raw_arr = np.asarray(list(logits_or_p), dtype=float)
+    use_logit = False
+    if np.all(np.isfinite(raw_arr)) and np.all((0.0 <= raw_arr) & (raw_arr <= 1.0)):
+        use_logit = True
+        raw_arr = np.clip(raw_arr, 1e-6, 1 - 1e-6)
+        odds = raw_arr / (1 - raw_arr)
+        raw_arr = np.log(odds)
+
+    X = raw_arr.reshape(-1, 1)
+    y_arr = np.asarray(list(y), dtype=int)
+
+    model = LogisticRegression(max_iter=1000)
+    model.fit(X, y_arr)
+    return _PlattCalibrator(model=model, use_logit=use_logit)
 
 
 def reliability_curve(
@@ -67,51 +85,71 @@ def reliability_curve(
     *,
     n_bins: int = 10,
     strategy: str = "uniform",
-) -> tuple[np.ndarray, np.ndarray]:
-    """Return mean predicted value and fraction of positives per bin."""
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, float, float]:
+    """Compute reliability curve statistics for binary classification."""
+
+    y_arr = np.asarray(list(y_true), dtype=float)
+    p_arr = np.asarray(list(probs), dtype=float)
+    p_arr = np.clip(p_arr, 1e-6, 1 - 1e-6)
 
     frac_pos, mean_pred = calibration_curve(
-        y_true, probs, n_bins=n_bins, strategy=strategy
+        y_arr, p_arr, n_bins=n_bins, strategy=strategy
     )
-    return mean_pred, frac_pos
 
+    # Align with manual bin centres for plotting clarity
+    bin_edges = np.linspace(0.0, 1.0, n_bins + 1)
+    bin_centres = (bin_edges[:-1] + bin_edges[1:]) / 2.0
 
-def brier_score(y_true: Iterable[float], probs: Iterable[float]) -> float:
-    """Wrapper around :func:`sklearn.metrics.brier_score_loss`."""
+    # Map calibration_curve outputs back onto our grid
+    obs = np.full_like(bin_centres, np.nan, dtype=float)
+    exp = np.full_like(bin_centres, np.nan, dtype=float)
 
-    return float(brier_score_loss(y_true, probs))
+    if len(mean_pred) == len(frac_pos):
+        # Determine closest bins to the computed mean predictions
+        indices = np.digitize(mean_pred, bin_edges[1:-1], right=True)
+        for idx, (m_pred, f_pos) in enumerate(zip(mean_pred, frac_pos)):
+            bin_idx = indices[idx]
+            obs[bin_idx] = f_pos
+            exp[bin_idx] = m_pred
 
+    brier = float(brier_score_loss(y_arr, p_arr))
+    loss = float(log_loss(y_arr, p_arr))
 
-def log_loss(y_true: Iterable[float], probs: Iterable[float]) -> float:
-    """Numerically-stable log-loss for binary probabilities."""
-
-    probs_arr = np.clip(np.asarray(list(probs)), 1e-6, 1 - 1e-6)
-    return float(sklearn_log_loss(y_true, probs_arr))
+    return bin_centres, obs, exp, brier, loss
 
 
 def plot_reliability(
     y_true: Iterable[float],
-    prob_dict: Dict[str, Iterable[float]],
-    path: Path,
+    prob_series: Dict[str, Iterable[float]] | Iterable[float],
+    path_png: str | Path,
     *,
     n_bins: int = 10,
-    title: str = "Reliability diagram",
+    title: str | None = None,
 ) -> None:
-    """Plot a reliability diagram for the provided probability series."""
+    """Save a reliability diagram for one or more probability series."""
 
-    path = Path(path)
+    if not isinstance(prob_series, dict):
+        prob_series = {"Predicted": prob_series}
+
+    path = Path(path_png)
     path.parent.mkdir(parents=True, exist_ok=True)
 
     plt.figure(figsize=(6, 6))
     plt.plot([0, 1], [0, 1], "--", color="gray", label="Perfect calibration")
 
-    for label, probs in prob_dict.items():
-        mean_pred, frac_pos = reliability_curve(y_true, probs, n_bins=n_bins)
-        plt.plot(mean_pred, frac_pos, marker="o", label=label)
+    for label, probs in prob_series.items():
+        bins, obs, exp, _, _ = reliability_curve(
+            y_true, probs, n_bins=n_bins, strategy="uniform"
+        )
+        mask = ~np.isnan(obs) & ~np.isnan(exp)
+        if not np.any(mask):
+            continue
+        plt.plot(exp[mask], obs[mask], marker="o", label=label)
 
     plt.xlabel("Mean predicted value")
     plt.ylabel("Fraction of positives")
-    plt.title(title)
+    if title:
+        plt.title(title)
     plt.legend()
     plt.xlim(0, 1)
     plt.ylim(0, 1)

--- a/src/crypto_analyzer/models/train.py
+++ b/src/crypto_analyzer/models/train.py
@@ -16,11 +16,10 @@ from sklearn.model_selection import train_test_split
 from crypto_analyzer.eval.cv import purged_walkforward_splits
 from crypto_analyzer.model_manager import atomic_write
 from crypto_analyzer.models.calibration import (
-    IsotonicCalibrator,
-    PlattCalibrator,
-    brier_score,
-    log_loss as calibration_log_loss,
+    fit_isotonic,
+    fit_platt,
     plot_reliability,
+    reliability_curve,
 )
 from crypto_analyzer.models.conformal import generate_touch_conformal_report
 from crypto_analyzer.models.utils import evaluate_model
@@ -478,18 +477,34 @@ def train_xgb(
         )
 
         labels = (preds >= class_threshold).astype(int)
+        raw_bins, raw_obs, raw_exp, raw_brier, raw_logloss = reliability_curve(
+            y_test, preds
+        )
         metrics_raw: dict[str, float] = {
             "accuracy": float(accuracy_score(y_test, labels)),
             "f1": float(f1_score(y_test, labels)),
             "precision": float(precision_score(y_test, labels)),
             "recall": float(recall_score(y_test, labels)),
             "roc_auc": float(roc_auc_score(y_test, preds)),
-            "brier_score": float(brier_score(y_test, preds)),
-            "log_loss": float(calibration_log_loss(y_test, preds)),
+            "brier_score": raw_brier,
+            "log_loss": raw_logloss,
         }
 
         metrics_df = pd.DataFrame([metrics_raw])
         metrics_df.to_csv(output_dir / "metrics_cv.csv", index=False)
+
+        def _series_to_list(values: np.ndarray) -> list[float | None]:
+            return [None if np.isnan(val) else float(val) for val in values]
+
+        reliability_report: dict[str, dict[str, object]] = {
+            "raw": {
+                "bins": raw_bins.tolist(),
+                "observed": _series_to_list(raw_obs),
+                "expected": _series_to_list(raw_exp),
+                "brier_score": raw_brier,
+                "log_loss": raw_logloss,
+            }
+        }
 
         prob_series = {"Raw": preds}
         metrics_report["raw"] = metrics_raw
@@ -503,9 +518,9 @@ def train_xgb(
             cal_probs = booster.predict(xgb.DMatrix(X_cal))
         if calibration_possible and cal_probs is not None:
             calibrator = (
-                IsotonicCalibrator().fit(cal_probs, y_cal.values)
+                fit_isotonic(cal_probs, y_cal.values)
                 if calibration_method == "isotonic"
-                else PlattCalibrator().fit(cal_probs, y_cal.values)
+                else fit_platt(cal_probs, y_cal.values)
             )
             calibrated_probs = calibrator.predict(preds)
             prob_series[f"Calibrated ({calibration_method})"] = calibrated_probs
@@ -513,22 +528,33 @@ def train_xgb(
             calibrated_probs_calibration = calibrator.predict(cal_probs)
 
             labels_cal = (calibrated_probs >= class_threshold).astype(int)
+            cal_bins, cal_obs, cal_exp, cal_brier, cal_logloss = reliability_curve(
+                y_test, calibrated_probs
+            )
             metrics_cal: dict[str, float] = {
                 "accuracy": float(accuracy_score(y_test, labels_cal)),
                 "f1": float(f1_score(y_test, labels_cal)),
                 "precision": float(precision_score(y_test, labels_cal)),
                 "recall": float(recall_score(y_test, labels_cal)),
                 "roc_auc": float(roc_auc_score(y_test, calibrated_probs)),
-                "brier_score": float(brier_score(y_test, calibrated_probs)),
-                "log_loss": float(calibration_log_loss(y_test, calibrated_probs)),
+                "brier_score": cal_brier,
+                "log_loss": cal_logloss,
             }
             metrics_report["calibrated"] = metrics_cal
             metrics_report["calibration_samples"] = int(len(y_cal))
             calibration_applied = True
+            reliability_report["calibrated"] = {
+                "bins": cal_bins.tolist(),
+                "observed": _series_to_list(cal_obs),
+                "expected": _series_to_list(cal_exp),
+                "brier_score": cal_brier,
+                "log_loss": cal_logloss,
+            }
         elif calibration_method != "none" and task == "clf":
             metrics_report["calibration_skipped"] = "insufficient data"
 
         metrics_report["calibration_applied"] = calibration_applied
+        metrics_report["reliability"] = reliability_report
 
         final_run_id = run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
         reports_dir = Path("reports")
@@ -540,6 +566,7 @@ def train_xgb(
             reliability_path,
             title=f"Reliability ({final_run_id})",
         )
+        metrics_report["reliability_plot"] = reliability_path.name
         if conformal_requested:
             conformal_path = reports_dir / f"conformal_{final_run_id}.json"
             if cal_probs is not None and y_cal is not None and len(y_cal) > 0:


### PR DESCRIPTION
## Summary
- add calibration helpers for isotonic and Platt scaling together with reliability diagnostics
- integrate the new calibration utilities into the training pipeline, exporting reliability plots and metrics reports

## Testing
- pytest tests -q

------
https://chatgpt.com/codex/tasks/task_e_68cf031e4e38832787089b7f6b0d267c