### PR TITLE
Add tests for CV, calibration, and backtest costs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - run: black --check .
       - run: isort --check-only .
       - run: mypy .
-      - run: pytest -q
+      - name: Run pytest
+        run: |
+          set -euo pipefail
+          pytest -q
         env:
           PYTHONPATH: .

--- a/tests/test_backtest_costs.py
+++ b/tests/test_backtest_costs.py
@@ -1,37 +1,79 @@
-from __future__ import annotations
-
+import numpy as np
 import pandas as pd
+import pytest
 
 from crypto_analyzer.eval.backtest import run_backtest
 
 
-def _sample_predictions() -> pd.DataFrame:
-    ts = pd.date_range("2024-01-01", periods=6, freq="5T", tz="UTC")
-    base_price = 100.0
-    prices = base_price + pd.Series([0, 1, 2, 3, 4, 5], dtype=float)
-    targets = prices + pd.Series([0.5, 0.7, -0.3, 0.8, -0.2, 0.4], dtype=float)
-    probs = pd.Series([0.7, 0.6, 0.4, 0.8, 0.45, 0.75], dtype=float)
+FEE_PER_TRADE = 0.001
+SLIPPAGE_BPS = 5
+TOTAL_COST = FEE_PER_TRADE + SLIPPAGE_BPS / 10_000
+
+
+def _manual_backtest(df: pd.DataFrame, latency_steps: int) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    working = df.sort_values("timestamp").reset_index(drop=True)
+
+    if latency_steps > 0:
+        shift_cols = ["timestamp", "last_price", "target", "reward", "risk"]
+        for column in shift_cols:
+            working[column] = working[column].shift(-latency_steps)
+        working = working.iloc[:-latency_steps].reset_index(drop=True)
+
+    price_return = (working["target"] - working["last_price"]) / working["last_price"]
+    prob_arr = working["prob"].to_numpy()
+    reward = working["reward"].to_numpy()
+    risk = working["risk"].to_numpy()
+
+    ev = prob_arr * reward - (1.0 - prob_arr) * risk - TOTAL_COST
+    direction = (ev > 0.0).astype(float)
+    trade_ret = direction * price_return.to_numpy() - TOTAL_COST * direction
+    equity = np.cumprod(1.0 + trade_ret)
+
+    return trade_ret, equity, direction
+
+
+def test_backtest_applies_costs_and_latency():
     df = pd.DataFrame(
         {
-            "timestamp": ts,
-            "last_price": prices,
-            "target": targets,
-            "prob": probs,
-            "reward_ratio": 0.01,
-            "risk_ratio": 0.01,
+            "timestamp": pd.date_range("2024-01-01", periods=4, freq="h", tz="UTC"),
+            "last_price": [100.0, 100.0, 100.0, 100.0],
+            "target": [102.0, 99.0, 101.5, 103.0],
+            "prob": [0.7, 0.55, 0.4, 0.8],
+            "reward": [0.03, 0.025, 0.02, 0.035],
+            "risk": [0.01, 0.02, 0.015, 0.02],
         }
     )
-    return df
 
+    result = run_backtest(
+        df,
+        prob_col="prob",
+        reward_col="reward",
+        risk_col="risk",
+        fee_per_trade=FEE_PER_TRADE,
+        slippage_bps=SLIPPAGE_BPS,
+    )
 
-def test_transaction_costs_reduce_pnl():
-    df = _sample_predictions()
-    base = run_backtest(df, fee_bps=0.0, slippage_bps=0.0, prob_col="prob")
-    costly = run_backtest(df, fee_bps=50.0, slippage_bps=10.0, prob_col="prob")
-    assert costly["metrics"]["pnl"] < base["metrics"]["pnl"]
+    _, manual_equity, manual_direction = _manual_backtest(df, latency_steps=0)
 
+    np.testing.assert_allclose(result["equity"]["equity"].to_numpy(), manual_equity)
+    assert result["metrics"]["trades"] == int(manual_direction.sum())
+    assert result["metrics"]["pnl"] == pytest.approx(float(manual_equity[-1] - 1.0))
 
-def test_latency_shifts_candles():
-    df = _sample_predictions()
-    delayed = run_backtest(df, fee_bps=0.0, slippage_bps=0.0, prob_col="prob", latency_steps=2)
-    assert len(delayed["equity"]) == len(df) - 2
+    latency_result = run_backtest(
+        df,
+        prob_col="prob",
+        reward_col="reward",
+        risk_col="risk",
+        fee_per_trade=FEE_PER_TRADE,
+        slippage_bps=SLIPPAGE_BPS,
+        latency_steps=1,
+    )
+
+    _, manual_equity_lat, manual_direction_lat = _manual_backtest(df, latency_steps=1)
+
+    np.testing.assert_allclose(
+        latency_result["equity"]["equity"].to_numpy(), manual_equity_lat
+    )
+    assert latency_result["metrics"]["trades"] == int(manual_direction_lat.sum())
+    assert latency_result["equity"]["timestamp"].iloc[0] == df["timestamp"].iloc[1]
+    assert latency_result["metrics"]["pnl"] == pytest.approx(float(manual_equity_lat[-1] - 1.0))

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,24 +1,22 @@
-from __future__ import annotations
-
 import numpy as np
+from sklearn.metrics import brier_score_loss
 
-from crypto_analyzer.models.calibration import brier_score, fit_isotonic
+from crypto_analyzer.eval.calibration import calibrate_probabilities
 
 
-def test_isotonic_calibration_improves_brier():
-    rng = np.random.default_rng(42)
-    true_probs = rng.uniform(0.05, 0.95, size=400)
-    labels = rng.binomial(1, true_probs)
+def test_isotonic_calibration_improves_brier_score():
+    rng = np.random.default_rng(1234)
 
-    distorted = true_probs**3
-    cal_probs = distorted[:200]
-    cal_labels = labels[:200]
-    test_probs = distorted[200:]
-    test_labels = labels[200:]
+    true_prob = np.concatenate([np.full(200, 0.1), np.full(200, 0.9)])
+    y_true = rng.binomial(1, true_prob)
+    biased_prob = np.where(true_prob < 0.5, 0.3, 0.7)
 
-    raw_brier = brier_score(test_labels, test_probs)
-    calibrator = fit_isotonic(cal_probs, cal_labels)
-    calibrated = calibrator.predict(test_probs)
-    calibrated_brier = brier_score(test_labels, calibrated)
+    baseline_brier = brier_score_loss(y_true, biased_prob)
 
-    assert calibrated_brier <= raw_brier + 1e-6
+    calibrated = calibrate_probabilities(y_true, biased_prob, method="isotonic")
+
+    calibrated_brier = brier_score_loss(y_true, calibrated.probabilities)
+
+    assert calibrated_brier < baseline_brier
+    assert calibrated.method == "isotonic"
+    assert calibrated.calibrator is not None

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -1,20 +1,74 @@
-from __future__ import annotations
-
 import pandas as pd
 
 from crypto_analyzer.eval.cv import purged_walkforward_splits
+from crypto_analyzer.utils.splitting import PurgedWalkForwardSplit
 
 
-def test_purged_walkforward_respects_embargo():
-    index = pd.date_range("2024-01-01", periods=60, freq="5T", tz="UTC")
-    splits = purged_walkforward_splits(index, n_splits=4, embargo_min=15)
-    assert len(splits) >= 2
+def test_purged_walkforward_splits_respect_order_and_embargo():
+    index = pd.date_range("2024-01-01", periods=120, freq="h", tz="UTC")
+    embargo_min = 180
+
+    splits = purged_walkforward_splits(index, n_splits=5, embargo_min=embargo_min)
+
+    assert splits, "Expected to receive at least one purged walk-forward split"
+
+    embargo_delta = pd.Timedelta(minutes=embargo_min)
+    previous_test_end = index[0]
+    seen_windows: list[tuple[pd.Timestamp, pd.Timestamp]] = []
+
     for train_idx, test_idx in splits:
-        if len(train_idx) == 0 or len(test_idx) == 0:
-            continue
-        assert train_idx.max() < test_idx.min()
+        assert train_idx.size > 0
+        assert test_idx.size > 0
+
         train_times = index[train_idx]
         test_times = index[test_idx]
-        embargo_start = test_times.min() - pd.Timedelta(minutes=15)
-        embargo_end = test_times.max() + pd.Timedelta(minutes=15)
-        assert not ((train_times >= embargo_start) & (train_times <= embargo_end)).any()
+
+        assert (train_times < test_times.min()).all(), "Training indices must precede testing ones"
+
+        window_start = test_times[0] - embargo_delta
+        window_end = test_times[-1] + embargo_delta
+
+        for embargo_start, embargo_end in seen_windows + [(window_start, window_end)]:
+            overlap = (train_times >= embargo_start) & (train_times <= embargo_end)
+            assert not overlap.any(), "Training data must respect embargo windows"
+
+        assert test_times[0] >= previous_test_end, "Test windows must move forward in time"
+
+        previous_test_end = test_times[-1]
+        seen_windows.append((window_start, window_end))
+
+
+def test_purged_walkforward_split_applies_purge_and_embargo():
+    timestamps = pd.date_range("2024-01-01", periods=72, freq="h", tz="UTC")
+    df = pd.DataFrame({"timestamp": timestamps})
+
+    purge_minutes = 120
+    embargo_minutes = 90
+
+    splitter = PurgedWalkForwardSplit(
+        train_span_days=2,
+        test_span_days=1,
+        step_days=1,
+        min_train_days=2,
+        purge_minutes=purge_minutes,
+        embargo_minutes=embargo_minutes,
+    )
+
+    splits = list(splitter.split(df))
+    assert splits, "Expected purged walk-forward splitter to produce folds"
+
+    purge_delta = pd.Timedelta(minutes=purge_minutes)
+    embargo_delta = pd.Timedelta(minutes=embargo_minutes)
+    previous_test_end: pd.Timestamp | None = None
+
+    for train_idx, test_idx in splits:
+        train_times = timestamps[train_idx]
+        test_times = timestamps[test_idx]
+
+        assert (train_times < test_times.min()).all()
+        assert train_times.max() <= test_times.min() - purge_delta
+
+        if previous_test_end is not None:
+            assert train_times.min() >= previous_test_end + embargo_delta
+
+        previous_test_end = test_times.max()


### PR DESCRIPTION
## Summary
- add coverage for purged walk-forward CV ordering and embargo handling
- verify isotonic calibration improves Brier score on biased probabilities
- test backtest cost handling including fees, slippage, and latency
- ensure CI runs pytest with a failing shell on errors

## Checklist
- [x] tests pass
- [ ] typing ok
- [ ] doc updated
- [ ] perf note

## Import-time artifact
Link: <!-- link to the `importtime` artifact -->

## Before vs After
| Metric | Before | After |
|---|---|---|
| Import time (ms) | | |
| RSS (MB) | | |
| Imported modules | | |
| Inference throughput (rows/min) | | |

## Removed symbols / packages
-

------
https://chatgpt.com/codex/tasks/task_e_68cfb912c7b88327851eb0072aa2545d