### PR TITLE
Export purged walk-forward splits metadata

### DIFF
--- a/scripts/ablation.py
+++ b/scripts/ablation.py
@@ -133,8 +133,15 @@ def main(argv: list[str] | None = None) -> Path:
     if missing:
         raise KeyError("Missing features: " + ", ".join(sorted(missing)))
 
+    run_id = args.run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
+
     timestamps = pd.to_datetime(df["timestamp"], utc=True)
-    splits = purged_walkforward_splits(timestamps, CONFIG.cv.n_splits, CONFIG.cv.embargo_min)
+    splits = purged_walkforward_splits(
+        timestamps,
+        CONFIG.cv.n_splits,
+        CONFIG.cv.embargo_min,
+        run_id=run_id,
+    )
     if not splits:
         raise RuntimeError("No walk-forward splits generated")
     train_idx, test_idx = splits[-1]
@@ -167,7 +174,6 @@ def main(argv: list[str] | None = None) -> Path:
 
     result_df = pd.DataFrame(results).sort_values("brier")
 
-    run_id = args.run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
     run_dir = Path("outputs") / f"run_id={run_id}"
     run_dir.mkdir(parents=True, exist_ok=True)
     reports_dir = Path("reports")

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -364,28 +364,13 @@ def main(argv: list[str] | None = None) -> Path:
         raise ValueError("conformal_alpha must lie in (0, 1)")
 
     if args.cv == "purged-wf":
-        splits = purged_walkforward_splits(
-            pd.DatetimeIndex(timestamps), n_splits=CONFIG.cv.n_splits, embargo_min=args.embargo_min
+        purged_walkforward_splits(
+            pd.DatetimeIndex(timestamps),
+            n_splits=CONFIG.cv.n_splits,
+            embargo_min=args.embargo_min,
+            run_id=run_id,
+            reports_dir=reports_dir,
         )
-        cv_payload = []
-        for fold, (train_idx, test_idx) in enumerate(splits):
-            cv_payload.append(
-                {
-                    "fold": fold,
-                    "train_indices": train_idx.tolist(),
-                    "test_indices": test_idx.tolist(),
-                    "train_range": [
-                        timestamps.iloc[train_idx[0]].isoformat() if len(train_idx) else None,
-                        timestamps.iloc[train_idx[-1]].isoformat() if len(train_idx) else None,
-                    ],
-                    "test_range": [
-                        timestamps.iloc[test_idx[0]].isoformat() if len(test_idx) else None,
-                        timestamps.iloc[test_idx[-1]].isoformat() if len(test_idx) else None,
-                    ],
-                }
-            )
-        cv_path = reports_dir / f"cv_{run_id}.json"
-        cv_path.write_text(json.dumps(cv_payload, indent=2), encoding="utf-8")
 
     X_train_full, X_test, y_train_full, y_test, ts_train_full, ts_test = _chronological_split(
         X, y, timestamps, args.test_size

--- a/src/crypto_analyzer/eval/cv.py
+++ b/src/crypto_analyzer/eval/cv.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 
 
 def purged_walkforward_splits(
-    index: pd.DatetimeIndex, n_splits: int, embargo_min: int
+    index: pd.DatetimeIndex,
+    n_splits: int,
+    embargo_min: int,
+    *,
+    run_id: str | None = None,
+    reports_dir: str | Path = "reports",
 ) -> list[tuple[np.ndarray, np.ndarray]]:
     """Build purged walk-forward cross-validation splits.
 
@@ -41,6 +49,7 @@ def purged_walkforward_splits(
     segments = np.array_split(np.arange(n_samples, dtype=int), n_splits + 1)
 
     splits: list[tuple[np.ndarray, np.ndarray]] = []
+    export_records: list[dict[str, object]] = []
     embargo_windows: list[tuple[pd.Timestamp, pd.Timestamp]] = []
 
     for fold in range(n_splits):
@@ -72,6 +81,27 @@ def purged_walkforward_splits(
             continue
 
         splits.append((train_idx, test_idx))
+
+        record_fold = len(splits) - 1
+        export_records.append(
+            {
+                "fold": record_fold,
+                "train_start": index[train_idx[0]].isoformat(),
+                "train_end": index[train_idx[-1]].isoformat(),
+                "test_start": index[test_idx[0]].isoformat(),
+                "test_end": index[test_idx[-1]].isoformat(),
+                "embargo_min": embargo_minutes,
+            }
+        )
         embargo_windows.append((window_start, window_end))
+
+    if run_id is not None:
+        reports_path = Path(reports_dir)
+        reports_path.mkdir(parents=True, exist_ok=True)
+        export_path = reports_path / f"cv_{run_id}.json"
+        export_path.write_text(
+            json.dumps(export_records, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
 
     return splits

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -1,3 +1,6 @@
+import json
+from pathlib import Path
+
 import pandas as pd
 
 from crypto_analyzer.eval.cv import purged_walkforward_splits
@@ -72,3 +75,29 @@ def test_purged_walkforward_split_applies_purge_and_embargo():
             assert train_times.min() >= previous_test_end + embargo_delta
 
         previous_test_end = test_times.max()
+
+
+def test_purged_walkforward_exports_metadata(tmp_path: Path):
+    index = pd.date_range("2024-01-01", periods=24, freq="h", tz="UTC")
+    run_id = "unit"
+    embargo = 30
+
+    splits = purged_walkforward_splits(
+        index,
+        n_splits=3,
+        embargo_min=embargo,
+        run_id=run_id,
+        reports_dir=tmp_path,
+    )
+
+    cv_path = tmp_path / f"cv_{run_id}.json"
+    assert cv_path.exists(), "Expected purged walk-forward splits to be exported"
+
+    payload = json.loads(cv_path.read_text(encoding="utf-8"))
+    assert len(payload) == len(splits)
+
+    first_fold = payload[0]
+    assert first_fold["fold"] == 0
+    assert first_fold["embargo_min"] == embargo
+    assert first_fold["train_start"] <= first_fold["train_end"]
+    assert first_fold["test_start"] <= first_fold["test_end"]


### PR DESCRIPTION
## Summary
- add optional metadata export to `purged_walkforward_splits` and persist the folds into `reports/cv_{run_id}.json`
- update CLI utilities to rely on the splitter for purged walk-forward logging
- extend the cross-validation tests to cover metadata generation

## Testing
- pytest tests/test_cv.py

------
https://chatgpt.com/codex/tasks/task_e_68cfbd88386c832787bf3df91a12917c