### PR TITLE
Add left-label merge safeguards and leakage tests

### DIFF
--- a/src/crypto_analyzer/utils/merge.py
+++ b/src/crypto_analyzer/utils/merge.py
@@ -1,0 +1,99 @@
+"""Utility helpers for safely merging time-aligned datasets."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import pandas as pd
+
+__all__ = ["merge_left_labeled", "validate_left_label_alignment"]
+
+
+def validate_left_label_alignment(
+    df: pd.DataFrame,
+    *,
+    target_ts_col: str = "timestamp_target_open",
+    feature_ts_col: str = "timestamp_feature",
+) -> None:
+    """Assert that *feature_ts_col* never looks into the future relative to the target."""
+
+    if target_ts_col not in df.columns:
+        raise KeyError(f"Column '{target_ts_col}' missing from dataframe")
+    if feature_ts_col not in df.columns:
+        raise KeyError(f"Column '{feature_ts_col}' missing from dataframe")
+
+    target_ts = pd.to_datetime(df[target_ts_col], utc=True, errors="coerce")
+    if target_ts.isna().any():
+        raise ValueError(f"Column '{target_ts_col}' contains non-parsable timestamps")
+
+    feature_ts = pd.to_datetime(df[feature_ts_col], utc=True, errors="coerce")
+
+    valid = feature_ts.notna()
+    if not valid.any():
+        return
+
+    violations = valid & (feature_ts > target_ts)
+    if violations.any():
+        offending = df.loc[violations, [target_ts_col, feature_ts_col]].head()
+        raise AssertionError(
+            "Left-label merge invariant violated: feature timestamps must not "
+            "exceed target open times. Offending rows:\n"
+            + offending.to_string(index=False)
+        )
+
+
+def merge_left_labeled(
+    targets: pd.DataFrame,
+    features: pd.DataFrame,
+    *,
+    target_ts_col: str = "timestamp_target_open",
+    feature_ts_col: str = "timestamp_feature",
+    feature_columns: Sequence[str] | None = None,
+    suffixes: tuple[str, str] = ("", "_feature"),
+) -> pd.DataFrame:
+    """Merge ``targets`` with ``features`` using left-label resampling semantics."""
+
+    if target_ts_col not in targets.columns:
+        raise KeyError(f"Column '{target_ts_col}' missing from targets dataframe")
+    if feature_ts_col not in features.columns:
+        raise KeyError(f"Column '{feature_ts_col}' missing from features dataframe")
+
+    left = targets.copy()
+    left["__orig_order"] = range(len(left))
+    left[target_ts_col] = pd.to_datetime(left[target_ts_col], utc=True, errors="coerce")
+    if left[target_ts_col].isna().any():
+        raise ValueError(f"Column '{target_ts_col}' contains non-parsable timestamps")
+    left = left.sort_values(target_ts_col).reset_index(drop=True)
+
+    right = features.copy()
+    right[feature_ts_col] = pd.to_datetime(right[feature_ts_col], utc=True, errors="coerce")
+    right = right.dropna(subset=[feature_ts_col]).sort_values(feature_ts_col).reset_index(drop=True)
+
+    if feature_columns is None:
+        merge_cols: list[str] = [c for c in right.columns if c != feature_ts_col]
+    else:
+        missing = [c for c in feature_columns if c not in right.columns]
+        if missing:
+            raise KeyError(f"Columns {missing!r} missing from features dataframe")
+        merge_cols = feature_columns
+
+    right_merge = right[[feature_ts_col, *merge_cols]].copy()
+
+    merged = pd.merge_asof(
+        left,
+        right_merge,
+        left_on=target_ts_col,
+        right_on=feature_ts_col,
+        direction="backward",
+        allow_exact_matches=True,
+        suffixes=suffixes,
+    )
+
+    merged = merged.sort_values("__orig_order").drop(columns="__orig_order").reset_index(drop=True)
+
+    validate_left_label_alignment(
+        merged, target_ts_col=target_ts_col, feature_ts_col=feature_ts_col
+    )
+
+    return merged
+

--- a/tests/test_no_leakage.py
+++ b/tests/test_no_leakage.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from crypto_analyzer.utils.merge import merge_left_labeled, validate_left_label_alignment
+
+
+def test_merge_left_labeled_respects_left_label_alignment() -> None:
+    target_ts = pd.date_range("2024-01-01", periods=4, freq="5min", tz="UTC")
+    targets = pd.DataFrame(
+        {
+            "timestamp_target_open": target_ts,
+            "target": [0.1, -0.2, 0.05, 0.4],
+        }
+    )
+
+    feature_ts = [
+        target_ts[0] - pd.Timedelta(minutes=5),
+        target_ts[1],
+        target_ts[3],
+    ]
+    features = pd.DataFrame(
+        {
+            "timestamp_feature": feature_ts,
+            "alpha": [1.0, 2.0, 3.0],
+        }
+    )
+
+    merged = merge_left_labeled(targets, features)
+
+    expected_alignment = [
+        feature_ts[0],
+        feature_ts[1],
+        feature_ts[1],
+        feature_ts[2],
+    ]
+    assert list(merged["timestamp_feature"].to_list()) == expected_alignment
+
+    valid = merged["timestamp_feature"].notna()
+    aligned_features = merged.loc[valid, "timestamp_feature"]
+    aligned_targets = merged.loc[valid, "timestamp_target_open"]
+    assert (aligned_features <= aligned_targets).all()
+
+
+def test_validate_left_label_alignment_detects_future_features() -> None:
+    df = pd.DataFrame(
+        {
+            "timestamp_target_open": pd.to_datetime(
+                ["2024-01-01T00:00:00Z", "2024-01-01T00:05:00Z"], utc=True
+            ),
+            "timestamp_feature": pd.to_datetime(
+                ["2024-01-01T00:00:00Z", "2024-01-01T00:06:00Z"], utc=True
+            ),
+        }
+    )
+
+    with pytest.raises(AssertionError):
+        validate_left_label_alignment(df)
+


### PR DESCRIPTION
## Summary
- add a merge helper that performs left-label resampling and asserts feature timestamps never exceed the target open time
- provide validation utilities so callers can detect leakage in aligned datasets
- cover the new behaviour with synthetic no-leakage and failure-mode tests

## Testing
- pytest tests/test_no_leakage.py -q
- ruff check src/crypto_analyzer/utils/merge.py tests/test_no_leakage.py

------
https://chatgpt.com/codex/tasks/task_e_68cfc1f8a6108327bdbb120373848925