### PR TITLE
Add config-aware derivative feature loaders

### DIFF
--- a/src/crypto_analyzer/features/derivatives.py
+++ b/src/crypto_analyzer/features/derivatives.py
@@ -1,11 +1,13 @@
 """Utility helpers for constructing derivative market features."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from pathlib import Path
 from typing import Iterable
 
 import numpy as np
 import pandas as pd
+
+from crypto_analyzer.utils.config import CONFIG, DerivativeDataSettings
 
 __all__ = [
     "load_funding",
@@ -14,11 +16,9 @@ __all__ = [
     "make_deriv_features",
 ]
 
-
-@dataclass(frozen=True)
-class _LoaderConfig:
-    column: str
-    resample: str
+_FUNDING_ALIASES: tuple[str, ...] = ("deriv_funding_rate", "funding_8h")
+_BASIS_ALIASES: tuple[str, ...] = ("basis_annualized", "basis", "perp_basis")
+_OI_ALIASES: tuple[str, ...] = ("oi", "openinterest")
 
 
 def _ensure_timestamp_index(df: pd.DataFrame) -> pd.Series:
@@ -36,18 +36,74 @@ def _infer_frequency(index: pd.DatetimeIndex) -> str:
     inferred = pd.infer_freq(index)
     if inferred is not None:
         return inferred
-    diffs = index.to_series().diff().dropna()
+    if len(index) <= 1:
+        return "5T"
+    diffs = index.sort_values().to_series().diff().dropna()
     if diffs.empty:
         return "5T"
     return diffs.mode().iloc[0]
 
 
-def _left_resample(series: pd.Series, freq: str, target_index: pd.DatetimeIndex | None) -> pd.Series:
+def _left_resample(
+    series: pd.Series,
+    freq: str,
+    target_index: pd.DatetimeIndex | None,
+) -> pd.Series:
     series = series.sort_index()
     resampled = series.resample(freq, label="left", closed="left").last().ffill()
     if target_index is not None:
         resampled = resampled.reindex(target_index, method="ffill")
     return resampled
+
+
+def _read_source(
+    source: pd.DataFrame | str | Path | None,
+) -> pd.DataFrame | None:
+    if source is None:
+        return None
+    if isinstance(source, pd.DataFrame):
+        return source.copy()
+    path = Path(source)
+    if not path.is_file():
+        raise FileNotFoundError(f"Derivative data file not found: {path}")
+    if path.suffix.lower() in {".parquet", ".pq"}:
+        frame = pd.read_parquet(path)
+    else:
+        frame = pd.read_csv(path)
+    return frame
+
+
+def _find_column(columns: Iterable[str], primary: str, aliases: Iterable[str]) -> str | None:
+    if primary in columns:
+        return primary
+    for candidate in aliases:
+        if candidate in columns:
+            return candidate
+    return None
+
+
+def _prepare_source(
+    df: pd.DataFrame,
+    column: str,
+    *,
+    source: pd.DataFrame | str | Path | None,
+    aliases: Iterable[str] = (),
+) -> pd.DataFrame | None:
+    if column in df.columns:
+        return df.loc[:, ["timestamp", column]].copy()
+
+    external = _read_source(source)
+    if external is None or external.empty:
+        return None
+
+    actual = _find_column(external.columns, column, aliases)
+    if actual is None:
+        return None
+
+    subset = external.loc[:, ["timestamp", actual]].copy()
+    if actual != column:
+        subset = subset.rename(columns={actual: column})
+    return subset
 
 
 def load_funding(
@@ -101,6 +157,36 @@ def load_open_interest(
     return _left_resample(series, frequency, target_index)
 
 
+def _maybe_load_series(
+    df: pd.DataFrame,
+    column: str,
+    loader,
+    *,
+    source: pd.DataFrame | str | Path | None,
+    aliases: Iterable[str],
+    freq: str,
+    target_index: pd.DatetimeIndex,
+) -> pd.Series:
+    frame = _prepare_source(df, column, source=source, aliases=aliases)
+    if frame is None or frame.empty:
+        return pd.Series(np.nan, index=target_index, dtype=float)
+    try:
+        return loader(frame, column=column, freq=freq, target_index=target_index)
+    except (KeyError, ValueError):  # pragma: no cover - defensive
+        return pd.Series(np.nan, index=target_index, dtype=float)
+
+
+def _resolve_derivative_settings(
+    config: DerivativeDataSettings | None,
+) -> DerivativeDataSettings | None:
+    if config is not None:
+        return config
+    try:
+        return CONFIG.derivatives
+    except AttributeError:  # pragma: no cover - defensive
+        return None
+
+
 def make_deriv_features(
     df: pd.DataFrame,
     *,
@@ -108,6 +194,10 @@ def make_deriv_features(
     basis_col: str = "perp_basis",
     oi_col: str = "open_interest",
     freq: str | None = None,
+    funding_source: pd.DataFrame | str | Path | None = None,
+    basis_source: pd.DataFrame | str | Path | None = None,
+    oi_source: pd.DataFrame | str | Path | None = None,
+    config: DerivativeDataSettings | None = None,
 ) -> pd.DataFrame:
     """Construct derivative features aligned to the provided price dataframe."""
 
@@ -119,40 +209,59 @@ def make_deriv_features(
         raise ValueError("Input timestamps contain NaT values")
 
     base_index = pd.DatetimeIndex(timestamps).sort_values().unique()
-    frequency = freq or _infer_frequency(base_index)
+    cfg = _resolve_derivative_settings(config)
+    cfg_freq = cfg.resample_freq if cfg is not None else None
+    frequency = freq or cfg_freq or _infer_frequency(base_index)
+
+    if cfg is not None:
+        funding_source = funding_source or cfg.funding_source
+        basis_source = basis_source or cfg.basis_source
+        oi_source = oi_source or cfg.open_interest_source
 
     features = pd.DataFrame(index=base_index)
 
-    if funding_col in df.columns:
-        funding_series = load_funding(
-            df[["timestamp", funding_col]], freq=frequency, target_index=base_index
-        )
-        mean = float(funding_series.mean()) if not funding_series.empty else 0.0
-        std = float(funding_series.std(ddof=0)) if not funding_series.empty else np.nan
+    funding_series = _maybe_load_series(
+        df,
+        funding_col,
+        load_funding,
+        source=funding_source,
+        aliases=_FUNDING_ALIASES,
+        freq=frequency,
+        target_index=base_index,
+    )
+    if funding_series.notna().any():
+        mean = float(funding_series.mean())
+        std = float(funding_series.std(ddof=0))
         if std == 0 or np.isnan(std):
             funding_z = pd.Series(np.nan, index=funding_series.index)
         else:
             funding_z = (funding_series - mean) / std
-        features["funding_z"] = funding_z.astype(np.float32)
     else:
-        features["funding_z"] = np.nan
+        funding_z = pd.Series(np.nan, index=funding_series.index)
+    features["funding_z"] = funding_z.astype(np.float32)
 
-    if basis_col in df.columns:
-        basis_series = load_perp_basis(
-            df[["timestamp", basis_col]], freq=frequency, target_index=base_index
-        )
-        features["basis_bp"] = (basis_series * 10_000.0).astype(np.float32)
-    else:
-        features["basis_bp"] = np.nan
+    basis_series = _maybe_load_series(
+        df,
+        basis_col,
+        load_perp_basis,
+        source=basis_source,
+        aliases=_BASIS_ALIASES,
+        freq=frequency,
+        target_index=base_index,
+    )
+    features["basis_bp"] = (basis_series * 10_000.0).astype(np.float32)
 
-    if oi_col in df.columns:
-        oi_series = load_open_interest(
-            df[["timestamp", oi_col]], freq=frequency, target_index=base_index
-        )
-        oi_change = oi_series.pct_change().replace([np.inf, -np.inf], np.nan)
-        features["oi_change_rate"] = oi_change.astype(np.float32)
-    else:
-        features["oi_change_rate"] = np.nan
+    oi_series = _maybe_load_series(
+        df,
+        oi_col,
+        load_open_interest,
+        source=oi_source,
+        aliases=_OI_ALIASES,
+        freq=frequency,
+        target_index=base_index,
+    )
+    oi_change = oi_series.pct_change().replace([np.inf, -np.inf], np.nan)
+    features["oi_change_rate"] = oi_change.astype(np.float32)
 
     features = features.reset_index().rename(columns={"index": "timestamp"})
     return features

--- a/src/crypto_analyzer/features/engineering.py
+++ b/src/crypto_analyzer/features/engineering.py
@@ -552,9 +552,11 @@ def create_features(
         from crypto_analyzer.features.derivatives import make_deriv_features
 
         try:
-            deriv_subset = df[["timestamp", "basis_annualized"]].copy()
-        except KeyError:
             deriv_subset = df[["timestamp"]].copy()
+        except KeyError:
+            deriv_subset = pd.DataFrame({"timestamp": pd.Series(dtype="datetime64[ns, UTC]")})
+        if "basis_annualized" in df.columns:
+            deriv_subset["basis_annualized"] = df["basis_annualized"]
         if "deriv_funding_rate" in df.columns:
             deriv_subset["funding_rate"] = df["deriv_funding_rate"]
         elif "funding_rate" in df.columns:
@@ -562,9 +564,20 @@ def create_features(
         if "open_interest" in df.columns:
             deriv_subset["open_interest"] = df["open_interest"]
 
+        deriv_cfg = CONFIG.derivatives
+
         try:
             freq = f"{step_minutes}T"
-            extra = make_deriv_features(deriv_subset, freq=freq)
+            extra = make_deriv_features(
+                deriv_subset,
+                freq=freq,
+                funding_col="funding_rate",
+                basis_col="basis_annualized",
+                oi_col="open_interest",
+                funding_source=deriv_cfg.funding_source,
+                basis_source=deriv_cfg.basis_source,
+                oi_source=deriv_cfg.open_interest_source,
+            )
         except Exception:  # pragma: no cover - defensive fallback
             extra = pd.DataFrame(columns=["timestamp", "funding_z", "basis_bp", "oi_change_rate"])
 


### PR DESCRIPTION
## Summary
- implement derivative loaders that support resampling and optional external sources while producing standardized metrics
- expose funding z-score, basis in basis points, and open interest change rate via `make_deriv_features`
- wire feature engineering to use the configured derivative data sources when `--use_derivatives` is enabled

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d01a3c7c408327962576f437a848bd