### PR TITLE
Add safe orderbook feature helpers

### DIFF
--- a/src/crypto_analyzer/features/orderbook.py
+++ b/src/crypto_analyzer/features/orderbook.py
@@ -1,4 +1,4 @@
-"""Lightweight utilities for deriving order book statistics."""
+"""Feature helpers for computing basic order book statistics."""
 from __future__ import annotations
 
 import numpy as np
@@ -7,71 +7,148 @@ import pandas as pd
 __all__ = ["depth_imbalance", "spread", "order_flow_imbalance"]
 
 
-def depth_imbalance(orderbook: pd.DataFrame) -> pd.Series:
-    """Compute depth imbalance from aggregated bid/ask sizes."""
+_BUY_SIDES: frozenset[str] = frozenset({"buy", "bid", "b"})
+_SELL_SIDES: frozenset[str] = frozenset({"sell", "ask", "s"})
 
-    if orderbook is None or len(orderbook) == 0:
+
+def _nan_series_like(frame: pd.DataFrame | None) -> pd.Series:
+    """Return a ``Series`` aligned to ``frame`` filled with ``NaN`` values."""
+
+    if frame is None:
+        return pd.Series([np.nan], dtype=float)
+
+    if frame.empty:
+        return pd.Series(dtype=float)
+
+    index: pd.Index = frame.index
+    if "timestamp" in frame.columns:
+        ts = pd.to_datetime(frame["timestamp"], utc=True, errors="coerce")
+        if ts.notna().any():
+            index = pd.Index(ts)
+
+    return pd.Series(np.nan, index=index, dtype=float)
+
+
+def _sum_with_nan(values: pd.DataFrame | pd.Series) -> pd.Series:
+    """Column-wise sum that preserves ``NaN`` when all entries are missing."""
+
+    if isinstance(values, pd.DataFrame):
+        return values.sum(axis=1, min_count=1)
+    return values.sum(min_count=1)
+
+
+def depth_imbalance(orderbook: pd.DataFrame | None) -> pd.Series:
+    """Compute bid/ask depth imbalance.
+
+    The metric is defined as ``(bid_depth - ask_depth) / (bid_depth + ask_depth)``.
+    Missing inputs degrade gracefully by returning ``NaN`` for the affected rows.
+    """
+
+    if orderbook is None or orderbook.empty:
         return pd.Series(dtype=float)
 
     bid_cols = [col for col in orderbook.columns if col.lower().startswith("bid_size")]
     ask_cols = [col for col in orderbook.columns if col.lower().startswith("ask_size")]
     if not bid_cols or not ask_cols:
-        return pd.Series(np.nan, index=orderbook.index)
+        return _nan_series_like(orderbook)
 
-    bid_sizes = orderbook[bid_cols].sum(axis=1)
-    ask_sizes = orderbook[ask_cols].sum(axis=1)
+    bid_sizes = _sum_with_nan(orderbook[bid_cols])
+    ask_sizes = _sum_with_nan(orderbook[ask_cols])
+
     denom = (bid_sizes + ask_sizes).replace(0, np.nan)
     imbalance = (bid_sizes - ask_sizes) / denom
     return imbalance.astype(float)
 
 
-def spread(orderbook: pd.DataFrame) -> pd.Series:
-    """Return bid/ask spread in basis points when available."""
+def spread(orderbook: pd.DataFrame | None) -> pd.Series:
+    """Return the quoted spread in basis points."""
 
-    if orderbook is None or len(orderbook) == 0:
+    if orderbook is None or orderbook.empty:
         return pd.Series(dtype=float)
 
     bid_cols = [col for col in orderbook.columns if col.lower().startswith("bid_price")]
     ask_cols = [col for col in orderbook.columns if col.lower().startswith("ask_price")]
     if not bid_cols or not ask_cols:
-        return pd.Series(np.nan, index=orderbook.index)
+        return _nan_series_like(orderbook)
 
-    best_bid = orderbook[bid_cols].max(axis=1)
-    best_ask = orderbook[ask_cols].min(axis=1)
+    best_bid = orderbook[bid_cols].max(axis=1, skipna=True)
+    best_ask = orderbook[ask_cols].min(axis=1, skipna=True)
+
     mid = (best_bid + best_ask) / 2.0
     spread_bps = ((best_ask - best_bid) / mid).replace([np.inf, -np.inf], np.nan) * 10_000.0
+    spread_bps = spread_bps.where(~(best_bid.isna() | best_ask.isna()))
     return spread_bps.astype(float)
 
 
-def order_flow_imbalance(events: pd.DataFrame) -> pd.Series:
-    """Compute order flow imbalance from trade events."""
+def _prepare_event_index(events: pd.DataFrame) -> pd.Index:
+    index: pd.Index = events.index
+    if "timestamp" in events.columns:
+        ts = pd.to_datetime(events["timestamp"], utc=True, errors="coerce")
+        if ts.notna().any():
+            index = pd.Index(ts)
+    return index
 
-    if events is None or len(events) == 0:
+
+def _aggregate_sizes(
+    frame: pd.DataFrame, mask: pd.Series, key: pd.Series | pd.Index
+) -> pd.Series:
+    if not mask.any():
+        return pd.Series(dtype=float)
+
+    keyed = key[mask]
+    if isinstance(keyed, pd.Index):
+        keyed = pd.Series(keyed, index=frame.index[mask])
+
+    sizes = frame.loc[mask, "size"]
+    if isinstance(keyed, pd.Series):
+        keyed = keyed.dropna()
+        sizes = sizes.loc[keyed.index]
+
+    if keyed.empty:
+        return pd.Series(dtype=float)
+
+    grouped = sizes.groupby(keyed)
+    return grouped.apply(lambda s: s.sum(min_count=1)).astype(float)
+
+
+def order_flow_imbalance(events: pd.DataFrame | None) -> pd.Series:
+    """Compute order flow imbalance grouped by timestamp.
+
+    ``events`` is expected to contain ``timestamp``, ``side`` and ``size`` columns. When
+    one of these inputs is missing the function returns ``NaN`` values instead of
+    raising.
+    """
+
+    if events is None or events.empty:
         return pd.Series(dtype=float)
 
     required = {"side", "size"}
     if not required.issubset(events.columns):
-        return pd.Series(np.nan, index=(events["timestamp"] if "timestamp" in events.columns else [0]))
+        return _nan_series_like(events)
 
     frame = events.copy()
-    frame["size"] = frame["size"].astype(float)
+    frame["size"] = pd.to_numeric(frame["size"], errors="coerce")
+
+    index = _prepare_event_index(frame)
+    key = pd.Series(index, index=frame.index)
+    valid_key = key.dropna()
+    if valid_key.empty:
+        return _nan_series_like(frame)
+
     side = frame["side"].astype(str).str.lower()
-    buys = frame.loc[side.isin({"buy", "bid", "b"}), "size"]
-    sells = frame.loc[side.isin({"sell", "ask", "s"}), "size"]
-    buy_sum = buys.groupby(frame.get("timestamp", pd.Series(index=frame.index))).sum()
-    sell_sum = sells.groupby(frame.get("timestamp", pd.Series(index=frame.index))).sum()
+    buy_mask = side.isin(_BUY_SIDES)
+    sell_mask = side.isin(_SELL_SIDES)
 
-    if "timestamp" in frame.columns:
-        index = pd.to_datetime(frame["timestamp"], utc=True, errors="coerce")
-        if index.isna().all():
-            index = frame.index
-        else:
-            index = index.sort_values().unique()
-    else:
-        index = frame.index.unique()
+    buy_sum = _aggregate_sizes(frame, buy_mask, key)
+    sell_sum = _aggregate_sizes(frame, sell_mask, key)
 
-    aligned_buys = buy_sum.reindex(index, fill_value=0.0)
-    aligned_sells = sell_sum.reindex(index, fill_value=0.0)
+    timeline = pd.Index(pd.unique(valid_key))
+    aligned_buys = buy_sum.reindex(timeline, fill_value=0.0)
+    aligned_sells = sell_sum.reindex(timeline, fill_value=0.0)
+
     denom = (aligned_buys + aligned_sells).replace(0, np.nan)
     imbalance = (aligned_buys - aligned_sells) / denom
-    return imbalance.astype(float)
+    imbalance = imbalance.astype(float)
+    imbalance.name = None
+    return imbalance
+

--- a/tests/test_orderbook_safe.py
+++ b/tests/test_orderbook_safe.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from crypto_analyzer.features.orderbook import (
+    depth_imbalance,
+    order_flow_imbalance,
+    spread,
+)
+
+
+def test_depth_imbalance_basic():
+    orderbook = pd.DataFrame(
+        {
+            "bid_size1": [5.0, np.nan],
+            "bid_size2": [5.0, 5.0],
+            "ask_size1": [3.0, 2.0],
+            "ask_size2": [1.0, np.nan],
+        },
+        index=pd.Index([0, 1], name="row"),
+    )
+
+    result = depth_imbalance(orderbook)
+
+    expected = pd.Series(
+        [(10.0 - 4.0) / 14.0, (5.0 - 2.0) / 7.0],
+        index=orderbook.index,
+        dtype=float,
+    )
+
+    pd.testing.assert_series_equal(result, expected)
+
+
+def test_spread_basic():
+    orderbook = pd.DataFrame(
+        {
+            "bid_price1": [99.0, 98.5],
+            "bid_price2": [98.5, 98.0],
+            "ask_price1": [101.0, 100.0],
+            "ask_price2": [102.0, 101.0],
+        }
+    )
+
+    result = spread(orderbook)
+    expected = pd.Series([200.0, ((100.0 - 98.5) / 99.25) * 10_000], dtype=float)
+
+    pd.testing.assert_series_equal(result, expected)
+
+
+def test_order_flow_imbalance_groups_by_timestamp():
+    events = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(
+                [
+                    "2024-01-01T00:00:00Z",
+                    "2024-01-01T00:00:00Z",
+                    "2024-01-01T00:01:00Z",
+                    "2024-01-01T00:01:00Z",
+                ],
+                utc=True,
+            ),
+            "side": ["buy", "sell", "buy", "sell"],
+            "size": [5, 3, 2, 2],
+        }
+    )
+
+    result = order_flow_imbalance(events)
+
+    expected = pd.Series(
+        [
+            (5 - 3) / (5 + 3),
+            (2 - 2) / (2 + 2),
+        ],
+        index=pd.Index(
+            pd.to_datetime([
+                "2024-01-01T00:00:00Z",
+                "2024-01-01T00:01:00Z",
+            ], utc=True)
+        ),
+        dtype=float,
+    )
+
+    pd.testing.assert_series_equal(result, expected)
+
+
+def test_missing_data_returns_nan():
+    orderbook = pd.DataFrame({"timestamp": [pd.Timestamp("2024-01-01", tz="UTC")]})
+    events = pd.DataFrame({"timestamp": [pd.Timestamp("2024-01-01", tz="UTC")]})
+
+    depth = depth_imbalance(orderbook)
+    book_spread = spread(orderbook)
+    ofi = order_flow_imbalance(events)
+
+    assert np.isnan(depth.iloc[0])
+    assert np.isnan(book_spread.iloc[0])
+    assert np.isnan(ofi.iloc[0])
+


### PR DESCRIPTION
## Summary
- add robust order book feature calculations that gracefully handle missing data
- cover depth imbalance, spread, and order flow imbalance with focused unit tests

## Testing
- pytest tests/test_orderbook_safe.py tests/test_orderbook_degrade.py

------
https://chatgpt.com/codex/tasks/task_e_68d01c65fc4483279d6f4d3cf258ba3c