### PR TITLE
Add conformal reporting with coverage metrics

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -481,7 +481,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--conformal_alpha",
         type=float,
-        default=None,
+        default=0.1,
         help="Enable conformal prediction intervals at the specified miscoverage level.",
     )
     parser.add_argument(
@@ -629,7 +629,12 @@ def main(argv: list[str] | None = None) -> Path:
 
     if args.conformal_alpha is not None and X_cal is not None and len(X_cal) > 0:
         cal_probs = model.predict_proba(X_cal)[:, 1]
-        conformal = conformal_interval(y_cal, cal_probs, proba_test, float(args.conformal_alpha))
+        conformal = conformal_interval(
+            y_cal,
+            cal_probs,
+            (y_test, proba_test),
+            float(args.conformal_alpha),
+        )
         conformal_path = reports_dir / f"conformal_{run_id}.json"
         conformal_json = json.dumps(conformal, indent=2)
         conformal_path.write_text(conformal_json, encoding="utf-8")

--- a/src/crypto_analyzer/models/conformal.py
+++ b/src/crypto_analyzer/models/conformal.py
@@ -199,26 +199,82 @@ def generate_touch_conformal_report(
     }
 
 
+def _extract_test_arrays(
+    test_data: (
+        Iterable[int]
+        | np.ndarray
+        | pd.Series
+        | tuple[Iterable[int] | np.ndarray | pd.Series, Iterable[float] | np.ndarray | pd.Series]
+        | dict[str, Iterable[int] | np.ndarray | pd.Series]
+    )
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return label/probability arrays from user provided test data."""
+
+    if isinstance(test_data, dict):
+        if {"labels", "probs"} <= set(test_data):
+            labels = test_data["labels"]
+            probs = test_data["probs"]
+        elif {"y", "p"} <= set(test_data):
+            labels = test_data["y"]
+            probs = test_data["p"]
+        else:
+            raise KeyError(
+                "Dictionary input must contain 'labels'/'probs' or 'y'/'p' keys for test data"
+            )
+        return _to_numpy(labels), np.clip(_to_numpy(probs), 1e-6, 1 - 1e-6)
+
+    if isinstance(test_data, tuple) or isinstance(test_data, list):
+        if len(test_data) != 2:
+            raise ValueError("Tuple/list input must provide (labels, probabilities)")
+        labels, probs = test_data
+        return _to_numpy(labels), np.clip(_to_numpy(probs), 1e-6, 1 - 1e-6)
+
+    raise TypeError(
+        "Test data must be provided as a tuple/list of (labels, probs) or a dictionary "
+        "with 'labels'/'probs' keys"
+    )
+
+
 def conformal_interval(
     y_val: Iterable[int] | np.ndarray | pd.Series,
     p_val: Iterable[float] | np.ndarray | pd.Series,
-    p_test: Iterable[float] | np.ndarray | pd.Series,
+    y_test: (
+        Iterable[int]
+        | np.ndarray
+        | pd.Series
+        | tuple[Iterable[int] | np.ndarray | pd.Series, Iterable[float] | np.ndarray | pd.Series]
+        | dict[str, Iterable[int] | np.ndarray | pd.Series]
+    ),
     alpha: float,
 ) -> dict[str, object]:
     """Return symmetric conformal intervals around test probabilities."""
 
     y_cal_arr = _to_numpy(y_val)
     p_cal_arr = np.clip(_to_numpy(p_val), 1e-6, 1 - 1e-6)
-    p_test_arr = np.clip(_to_numpy(p_test), 1e-6, 1 - 1e-6)
+    y_test_arr, p_test_arr = _extract_test_arrays(y_test)
     _validate_inputs(y_cal_arr, p_cal_arr, p_test_arr, alpha=alpha)
+
+    if y_test_arr.shape != p_test_arr.shape:
+        raise ValueError("`y_test` labels and probabilities must have matching shapes")
 
     residuals = np.abs(y_cal_arr - p_cal_arr)
     radius = _finite_sample_quantile(residuals, alpha)
     lower = np.clip(p_test_arr - radius, 0.0, 1.0)
     upper = np.clip(p_test_arr + radius, 0.0, 1.0)
+
+    mask = (y_test_arr >= lower) & (y_test_arr <= upper)
+    calib_cover = float(np.mean(residuals <= radius))
+    test_cover = float(np.mean(mask))
+    widths = upper - lower
+    effective_width = float(np.mean(np.where(mask, widths, 0.0)))
+
     return {
         "alpha": float(alpha),
         "radius": float(radius),
         "lower": lower.tolist(),
         "upper": upper.tolist(),
+        "calibration_coverage": calib_cover,
+        "test_coverage": test_cover,
+        "mean_width": float(np.mean(widths)),
+        "effective_width": effective_width,
     }

--- a/tests/test_models_conformal.py
+++ b/tests/test_models_conformal.py
@@ -3,6 +3,7 @@ import pytest
 
 from crypto_analyzer.models.conformal import (
     aps_conformal_interval,
+    conformal_interval,
     generate_touch_conformal_report,
     split_conformal_interval,
 )
@@ -61,3 +62,16 @@ def test_invalid_alpha_raises(alpha):
     y_cal, p_cal, _, p_test = _sample_data()
     with pytest.raises(ValueError):
         split_conformal_interval(y_cal, p_cal, p_test, alpha=alpha)
+
+
+def test_conformal_interval_returns_coverage_and_widths():
+    y_cal, p_cal, y_test, p_test = _sample_data()
+    summary = conformal_interval(y_cal, p_cal, (y_test, p_test), alpha=0.2)
+
+    assert summary["alpha"] == pytest.approx(0.2)
+    assert summary["radius"] > 0
+    assert len(summary["lower"]) == len(p_test)
+    assert len(summary["upper"]) == len(p_test)
+    assert 0 <= summary["test_coverage"] <= 1
+    assert 0 <= summary["calibration_coverage"] <= 1
+    assert summary["effective_width"] <= summary["mean_width"]


### PR DESCRIPTION
## Summary
- extend touch conformal helper to accept label/probability pairs and report coverage plus width diagnostics
- default conformal alpha to 0.1 in the training CLI and persist richer conformal reports
- add regression test ensuring the conformal interval helper outputs coverage and width metrics

## Testing
- pytest tests/test_models_conformal.py

------
https://chatgpt.com/codex/tasks/task_e_68d01ef5ac8083279df4228ec4727f93