### PR TITLE
Document derivative features and add threshold sweep tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,50 @@ A modular Python project for **cryptocurrency price analysis and prediction** fo
 - Lightweight signal aggregation keeps the default pipeline purely classification-based.
 - Fully modular and easy to expand.
 
+## Rozšířené rysy
+
+Advanced data sources can be merged into the default feature table without
+introducing look-ahead bias. All auxiliary loaders align their inputs using
+**left-label resampling**: external snapshots are resampled to the candle
+frequency with the *label* aligned to the left edge of the interval and then
+forward-filled so that the feature timestamp never exceeds the candle open.
+
+### Derivátová data
+
+Enable the derivative enrichments while generating features:
+
+```bash
+python scripts/make_features.py --use_derivatives
+```
+
+The loader expects either the columns to be present in the raw OHLCV source or
+external tables configured via `config/app.yaml`. The following columns are
+produced after left-label alignment:
+
+| Sloupec | Popis |
+| --- | --- |
+| `funding_z` | Z-skóre posledního funding rate s ohledem na historický průměr a směrodatnou odchylku. |
+| `basis_bp` | Perpetual basis přepočtený na basis points (bp) a zarovnaný na mřížku svíček. |
+| `oi_change_rate` | Relativní změna (pct change) open interestu mezi jednotlivými snapshoty. |
+
+### Order book signály
+
+Depth snapshots a event stream lze zapojit přes praktický přepínač:
+
+```bash
+python scripts/make_features.py --use_orderbook
+```
+
+Při zpracování se používá stejná left-label resampling logika – order book depth
+je agregován k času otevření svíčky a nikdy nevidí budoucí tick. Výstup obsahuje
+tyto metriky:
+
+| Sloupec | Popis |
+| --- | --- |
+| `depth_imbalance` | Poměr kumulativních bid/ask velikostí `(bid - ask) / (bid + ask)` v rámci sledovaných hladin. |
+| `spread` | Quoted spread v basis points spočítaný z nejlepšího bidu a asku. |
+| `ofi` | Order flow imbalance agregovaný ze streamu obchodů / objednávek podle timestampu. |
+
 ---
 
 ## Project Structure
@@ -117,6 +161,13 @@ Cost-aware backtest with latency and probability gates:
 
 ```bash
 python scripts/backtest.py data/predictions.csv --fee_bps 1 --slip_bps 1 --latency_min 1 --p_touch_thr 0.6 --p_up_thr 0.55
+```
+
+To explore how execution costs interact with the probability gates you can run
+an EV sweep and heatmap export:
+
+```bash
+python scripts/optimize_thresholds.py data/predictions.csv --fee_bps 1 --slip_bps 1 --latency_min 1
 ```
 
 The CLI entry points can be combined with your own data source by pointing

--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 
 from crypto_analyzer.eval.backtest import run_backtest
+from crypto_analyzer.eval.threshold_sweep import SweepParams, sweep_threshold_grid
 from crypto_analyzer.utils.config import CONFIG
 
 
@@ -125,6 +126,11 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Optional identifier used when storing reports. Defaults to a UTC timestamp.",
     )
+    parser.add_argument(
+        "--optimize-thresholds",
+        action="store_true",
+        help="Run a quick EV sweep across default threshold grids before executing the backtest.",
+    )
     return parser
 
 
@@ -150,6 +156,13 @@ def _infer_latency_steps(timestamps: pd.Series, latency_minutes: float) -> int:
     return steps
 
 
+def _find_horizon_column(df: pd.DataFrame) -> str | None:
+    for column in ("horizon", "horizon_min", "horizon_minutes"):
+        if column in df.columns:
+            return column
+    return None
+
+
 def main(argv: list[str] | None = None) -> tuple[Path, Path]:
     parser = _build_parser()
     args = parser.parse_args(argv)
@@ -169,6 +182,34 @@ def main(argv: list[str] | None = None) -> tuple[Path, Path]:
     if prob_col is not None and prob_col == args.prediction_column:
         prob_col = "p_hat"
     p_up_col = "p_up" if "p_up" in normalised.columns else None
+
+    if args.optimize_thresholds:
+        horizon_col = _find_horizon_column(normalised)
+        touch_grid = np.round(np.arange(0.5, 0.8001, 0.05), 4)
+        up_grid = np.round(np.arange(0.5, 0.7001, 0.05), 4)
+        params = SweepParams(
+            p_touch_values=touch_grid,
+            p_up_values=up_grid,
+            fee_bps=args.fee_bps,
+            slippage_bps=args.slip_bps,
+            latency_steps=latency_steps,
+            p_touch_col="p_hat",
+            p_up_col=p_up_col,
+        )
+        frames: list[pd.DataFrame] = []
+        if horizon_col is not None:
+            values = normalised[horizon_col].dropna().unique()
+            for value in sorted(values):
+                subset = normalised[normalised[horizon_col] == value]
+                if subset.empty:
+                    continue
+                frames.append(sweep_threshold_grid(subset, params=params, horizon_label=value))
+        if not frames:
+            frames.append(sweep_threshold_grid(normalised, params=params, horizon_label=None))
+        preview = pd.concat(frames, ignore_index=True)
+        top_preview = preview.sort_values("ev", ascending=False).head(5)
+        print("Threshold sweep preview (top 5 by EV):")
+        print(top_preview[["horizon", "p_touch_thr", "p_up_thr", "ev", "pnl", "sharpe", "trades"]])
 
     result = run_backtest(
         normalised,

--- a/scripts/optimize_thresholds.py
+++ b/scripts/optimize_thresholds.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python
+"""Grid-search utility for optimising backtest probability thresholds."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+from crypto_analyzer.eval.threshold_sweep import SweepParams, sweep_threshold_grid
+from crypto_analyzer.utils.config import CONFIG
+
+
+def _read_predictions(path: Path) -> pd.DataFrame:
+    if path.suffix.lower() in {".parquet", ".pq"}:
+        return pd.read_parquet(path)
+    return pd.read_csv(path)
+
+
+def _normalise_columns(
+    df: pd.DataFrame,
+    *,
+    timestamp_col: str,
+    prediction_col: str,
+    target_col: str,
+    price_col: str,
+) -> pd.DataFrame:
+    missing = [
+        column
+        for column in (timestamp_col, prediction_col, target_col, price_col)
+        if column not in df.columns
+    ]
+    if missing:
+        raise KeyError("Missing required columns: " + ", ".join(sorted(missing)))
+
+    out = df.copy()
+    out = out.rename(
+        columns={
+            timestamp_col: "timestamp",
+            prediction_col: "p_hat",
+            target_col: "target",
+            price_col: "last_price",
+        }
+    )
+    out["timestamp"] = pd.to_datetime(out["timestamp"], utc=True, errors="coerce")
+    out = out.dropna(subset=["timestamp", "p_hat", "target", "last_price"])
+    return out
+
+
+def _infer_latency_steps(timestamps: pd.Series, latency_minutes: float) -> int:
+    if latency_minutes <= 0:
+        return 0
+
+    if timestamps.empty:
+        return 0
+
+    ordered = timestamps.sort_values().reset_index(drop=True)
+    diffs = ordered.diff().dropna()
+    if diffs.empty:
+        return 0
+
+    step_minutes = diffs.dt.total_seconds().median() / 60.0
+    if not np.isfinite(step_minutes) or step_minutes <= 0:
+        return 0
+
+    steps = int(round(latency_minutes / step_minutes))
+    return max(steps, 1)
+
+
+def _build_grid(start: float, stop: float, step: float) -> np.ndarray:
+    if step <= 0:
+        raise ValueError("Step must be positive")
+    values = np.arange(start, stop + step * 0.5, step)
+    if values.size == 0:
+        raise ValueError("Invalid grid range")
+    values = np.clip(values, start, stop)
+    return np.unique(np.round(values, 4))
+
+
+def _find_horizon_column(df: pd.DataFrame, preferred: str | None) -> str | None:
+    candidates: list[str] = []
+    if preferred:
+        candidates.append(preferred)
+    candidates.extend(["horizon", "horizon_min", "horizon_minutes"])
+    for name in candidates:
+        if name and name in df.columns:
+            return name
+    return None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Sweep p_touch/p_up thresholds and plot EV heatmaps")
+    parser.add_argument("predictions", type=Path, help="CSV/Parquet file with model forecasts.")
+    parser.add_argument(
+        "--timestamp-column",
+        default="timestamp",
+        help="Column containing the prediction timestamp.",
+    )
+    parser.add_argument(
+        "--prediction-column",
+        default="p_hat",
+        help="Column with the touch probability or price forecast.",
+    )
+    parser.add_argument(
+        "--target-column",
+        default="target",
+        help="Column with the realised label used for P&L computation.",
+    )
+    parser.add_argument(
+        "--price-column",
+        default="last_price",
+        help="Reference price column used when computing trade returns.",
+    )
+    parser.add_argument(
+        "--p-up-column",
+        default="p_up",
+        help="Directional probability column gating long/short decisions.",
+    )
+    parser.add_argument(
+        "--group-column",
+        default="horizon",
+        help="Optional column used to split predictions by horizon before sweeping.",
+    )
+    parser.add_argument(
+        "--fee_bps",
+        "--fee-bps",
+        dest="fee_bps",
+        type=float,
+        default=getattr(CONFIG.backtest, "fee_bps", 4.0),
+        help="Proportional transaction cost per trade in basis points.",
+    )
+    parser.add_argument(
+        "--slip_bps",
+        "--slip-bps",
+        dest="slip_bps",
+        type=float,
+        default=getattr(CONFIG.backtest, "slippage_bps", 0.0),
+        help="Slippage assumption in basis points added to the fee.",
+    )
+    parser.add_argument(
+        "--latency_min",
+        "--latency-min",
+        dest="latency_min",
+        type=float,
+        default=0.0,
+        help="Execution latency in minutes applied by shifting the entry candle forward.",
+    )
+    parser.add_argument(
+        "--p-touch-min",
+        type=float,
+        default=0.5,
+        help="Minimum p_touch threshold evaluated during the sweep.",
+    )
+    parser.add_argument(
+        "--p-touch-max",
+        type=float,
+        default=0.8,
+        help="Maximum p_touch threshold evaluated during the sweep.",
+    )
+    parser.add_argument(
+        "--p-touch-step",
+        type=float,
+        default=0.05,
+        help="Step size between p_touch thresholds.",
+    )
+    parser.add_argument(
+        "--p-up-min",
+        type=float,
+        default=0.5,
+        help="Minimum p_up threshold evaluated during the sweep.",
+    )
+    parser.add_argument(
+        "--p-up-max",
+        type=float,
+        default=0.7,
+        help="Maximum p_up threshold evaluated during the sweep.",
+    )
+    parser.add_argument(
+        "--p-up-step",
+        type=float,
+        default=0.05,
+        help="Step size between p_up thresholds.",
+    )
+    parser.add_argument(
+        "--run-id",
+        default=None,
+        help="Optional identifier used when storing reports. Defaults to a UTC timestamp.",
+    )
+    return parser
+
+
+def _iter_groups(df: pd.DataFrame, column: str | None) -> Iterable[tuple[str | int | float | None, pd.DataFrame]]:
+    if column is None or column not in df.columns:
+        yield None, df
+        return
+
+    values = df[column].dropna().unique()
+    if values.size == 0:
+        yield None, df
+        return
+
+    for value in sorted(values):
+        mask = df[column] == value
+        subset = df.loc[mask]
+        if subset.empty:
+            continue
+        yield value, subset
+
+
+def main(argv: list[str] | None = None) -> tuple[Path, Path]:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    df = _read_predictions(args.predictions)
+    normalised = _normalise_columns(
+        df,
+        timestamp_col=args.timestamp_column,
+        prediction_col=args.prediction_column,
+        target_col=args.target_column,
+        price_col=args.price_column,
+    )
+
+    latency_steps = _infer_latency_steps(normalised["timestamp"], args.latency_min)
+
+    group_col = _find_horizon_column(normalised, args.group_column)
+    p_touch_grid = _build_grid(args.p_touch_min, args.p_touch_max, args.p_touch_step)
+    p_up_grid = _build_grid(args.p_up_min, args.p_up_max, args.p_up_step)
+
+    params = SweepParams(
+        p_touch_values=p_touch_grid,
+        p_up_values=p_up_grid,
+        fee_bps=args.fee_bps,
+        slippage_bps=args.slip_bps,
+        latency_steps=latency_steps,
+        p_touch_col="p_hat",
+        p_up_col=args.p_up_column,
+    )
+
+    frames: list[pd.DataFrame] = []
+    for horizon, subset in _iter_groups(normalised, group_col):
+        frame = sweep_threshold_grid(subset, params=params, horizon_label=horizon)
+        frames.append(frame)
+
+    if not frames:
+        raise RuntimeError("No data available for threshold sweep")
+
+    result = pd.concat(frames, ignore_index=True)
+
+    run_id = args.run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
+    reports_dir = Path("reports")
+    reports_dir.mkdir(parents=True, exist_ok=True)
+
+    csv_path = reports_dir / f"threshold_sweep_{run_id}.csv"
+    result.to_csv(csv_path, index=False)
+
+    pivot_groups = []
+    for horizon, subset in _iter_groups(result, "horizon"):
+        pivot = subset.pivot_table(
+            index="p_touch_thr",
+            columns="p_up_thr",
+            values="ev",
+            aggfunc="mean",
+        )
+        pivot_groups.append((horizon, pivot))
+
+    import matplotlib.pyplot as plt  # deferred import for hygiene tests
+
+    if not pivot_groups:
+        pivot_groups.append((None, pd.DataFrame()))
+
+    n_groups = max(1, len(pivot_groups))
+    fig, axes = plt.subplots(1, n_groups, figsize=(4 * n_groups, 4), squeeze=False)
+
+    for ax, (horizon, pivot) in zip(axes.flat, pivot_groups):
+        if pivot.empty:
+            ax.set_visible(False)
+            continue
+        data = np.ma.masked_invalid(pivot.to_numpy())
+        im = ax.imshow(data, origin="lower", cmap="viridis")
+        ax.set_xticks(range(len(pivot.columns)))
+        ax.set_xticklabels([f"{val:.2f}" for val in pivot.columns], rotation=45)
+        ax.set_yticks(range(len(pivot.index)))
+        ax.set_yticklabels([f"{val:.2f}" for val in pivot.index])
+        title = f"Horizon {horizon}" if horizon is not None else "All horizons"
+        ax.set_title(title)
+        ax.set_xlabel("p_up_thr")
+        ax.set_ylabel("p_touch_thr")
+        fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04, label="EV")
+
+    plt.tight_layout()
+    png_path = reports_dir / f"threshold_sweep_{run_id}.png"
+    plt.savefig(png_path)
+    plt.close(fig)
+
+    top = result.sort_values("ev", ascending=False).head(10)
+    print("Top threshold combinations by expected value:")
+    print(top[["horizon", "p_touch_thr", "p_up_thr", "ev", "pnl", "sharpe", "trades"]])
+    print(f"Sweep results saved to {csv_path}")
+    print(f"Heatmap saved to {png_path}")
+
+    return csv_path, png_path
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI behaviour
+    main()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -490,6 +490,17 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Optional run identifier used when storing artefacts.",
     )
+    parser.add_argument(
+        "--dump-cv",
+        action="store_true",
+        help="Export purged walk-forward CV splits to reports/cv_<run_id>.json.",
+    )
+    parser.add_argument(
+        "--by_vol_bins",
+        type=int,
+        default=5,
+        help="Number of realised volatility quantiles used for metrics by regime.",
+    )
     parser.set_defaults(include_onchain=None, include_orderbook=None, include_derivatives=None)
     return parser
 
@@ -537,7 +548,7 @@ def main(argv: list[str] | None = None) -> Path:
             pd.DatetimeIndex(timestamps),
             n_splits=CONFIG.cv.n_splits,
             embargo_min=args.embargo_min,
-            run_id=run_id,
+            run_id=run_id if args.dump_cv else None,
             reports_dir=reports_dir,
         )
 
@@ -599,6 +610,9 @@ def main(argv: list[str] | None = None) -> Path:
 
     metrics_by_vol_path = reports_dir / f"metrics_by_vol_{run_id}.csv"
     reliability_by_vol_path = reports_dir / f"reliability_by_vol_{run_id}.png"
+    if args.by_vol_bins <= 0:
+        raise ValueError("by_vol_bins must be a positive integer")
+
     _export_metrics_by_volatility(
         y_test,
         proba_test,
@@ -609,6 +623,7 @@ def main(argv: list[str] | None = None) -> Path:
         calibration_label=(
             f"Calibrated ({calibration_method})" if calibrated_probs is not None else None
         ),
+        n_quantiles=int(args.by_vol_bins),
     )
 
     metrics_report = {

--- a/src/crypto_analyzer/eval/__init__.py
+++ b/src/crypto_analyzer/eval/__init__.py
@@ -1,5 +1,6 @@
 """Evaluation helpers."""
 
 from .cv import purged_walkforward_splits
+from .threshold_sweep import SweepParams, sweep_threshold_grid
 
-__all__ = ["purged_walkforward_splits"]
+__all__ = ["purged_walkforward_splits", "SweepParams", "sweep_threshold_grid"]

--- a/src/crypto_analyzer/eval/threshold_sweep.py
+++ b/src/crypto_analyzer/eval/threshold_sweep.py
@@ -1,0 +1,99 @@
+"""Utilities for sweeping backtest probability thresholds."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+import numpy as np
+import pandas as pd
+
+from .backtest import run_backtest
+
+
+@dataclass(frozen=True)
+class SweepParams:
+    """Configuration for a threshold sweep."""
+
+    p_touch_values: Sequence[float]
+    p_up_values: Sequence[float]
+    fee_bps: float
+    slippage_bps: float
+    latency_steps: int
+    p_touch_col: str = "p_hat"
+    p_up_col: str | None = None
+
+
+def _ensure_iterable(values: Sequence[float] | Iterable[float]) -> list[float]:
+    arr = list(values)
+    if not arr:
+        raise ValueError("Threshold grid must contain at least one value")
+    return [float(v) for v in arr]
+
+
+def sweep_threshold_grid(
+    df: pd.DataFrame,
+    *,
+    params: SweepParams,
+    horizon_label: str | int | float | None = None,
+) -> pd.DataFrame:
+    """Run a grid search over EV thresholds for a single horizon.
+
+    Parameters
+    ----------
+    df:
+        Normalised prediction dataframe containing ``timestamp``, ``last_price``
+        and ``target`` columns alongside probability estimates.
+    params:
+        Sweep configuration specifying the grids and execution costs.
+    horizon_label:
+        Optional label identifying the horizon these predictions belong to.
+    """
+
+    required = {"timestamp", "last_price", "target"}
+    missing = required.difference(df.columns)
+    if missing:
+        raise KeyError(f"Input dataframe is missing columns: {sorted(missing)!r}")
+
+    p_touch_values = _ensure_iterable(params.p_touch_values)
+    p_up_values = _ensure_iterable(params.p_up_values)
+
+    if params.p_up_col is None or params.p_up_col not in df.columns:
+        p_up_values = [np.nan]
+        p_up_col = None
+    else:
+        p_up_col = params.p_up_col
+
+    records: list[dict[str, float | int | str | None]] = []
+
+    working = df.sort_values("timestamp").reset_index(drop=True)
+
+    for p_touch in p_touch_values:
+        for p_up in p_up_values:
+            result = run_backtest(
+                working,
+                fee_bps=params.fee_bps,
+                slippage_bps=params.slippage_bps,
+                latency_steps=max(0, int(params.latency_steps)),
+                p_touch_col=params.p_touch_col,
+                p_touch_threshold=float(p_touch),
+                p_up_col=p_up_col,
+                p_up_threshold=float(p_up) if np.isfinite(p_up) else None,
+            )
+            metrics = result["metrics"]
+            records.append(
+                {
+                    "horizon": horizon_label,
+                    "p_touch_thr": float(p_touch),
+                    "p_up_thr": float(p_up) if np.isfinite(p_up) else np.nan,
+                    "ev": float(metrics.get("ev", np.nan)),
+                    "pnl": float(metrics.get("pnl", np.nan)),
+                    "sharpe": float(metrics.get("sharpe", np.nan)),
+                    "hit_rate": float(metrics.get("hit_rate", np.nan)),
+                    "trades": float(metrics.get("trades", np.nan)),
+                }
+            )
+
+    return pd.DataFrame.from_records(records)
+
+
+__all__ = ["SweepParams", "sweep_threshold_grid"]


### PR DESCRIPTION
## Summary
- document derivative and order book enrichments in the README and describe left-label resampling outputs
- add an optimize_thresholds CLI with EV heatmap export and expose the sweep helper via eval.threshold_sweep
- extend backtest and training CLIs with threshold sweep preview, CV export flag, and volatility regime metrics bins

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d020f58f5c8327aa2e7387c82df28c