### PR TITLE
Refactor CLI scripts to Typer and validate config with Pydantic

### DIFF
--- a/scripts/ablation.py
+++ b/scripts/ablation.py
@@ -1,14 +1,14 @@
-#!/usr/bin/env python
-"""Feature group ablation study on the final walk-forward validation fold."""
+"""Feature ablation experiments using a Typer CLI."""
+
 from __future__ import annotations
 
-import argparse
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import numpy as np
 import pandas as pd
+import typer
 from sklearn.compose import ColumnTransformer
 from sklearn.impute import SimpleImputer
 from sklearn.linear_model import LogisticRegression
@@ -25,7 +25,11 @@ from crypto_analyzer.features.engineering import (
 )
 from crypto_analyzer.features.engineering import make_targets as make_default_targets
 from crypto_analyzer.models.calibration import brier_score
+from crypto_analyzer.utils.cli import run_cli
 from crypto_analyzer.utils.config import CONFIG, FeatureSettings, override_feature_settings
+from crypto_analyzer.utils.errors import DataValidationError
+
+app = typer.Typer(add_completion=False, no_args_is_help=True)
 
 GROUPS = ["price", "volatility", "multi_tf", "derivatives", "orderbook"]
 PATTERNS = {
@@ -38,32 +42,45 @@ PATTERNS = {
 
 
 def _read_table(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        raise DataValidationError(f"Input file '{path}' does not exist")
     if path.suffix.lower() in {".parquet", ".pq"}:
         return pd.read_parquet(path)
     return pd.read_csv(path)
 
 
-def _prepare_settings(args: argparse.Namespace) -> FeatureSettings:
+def _prepare_settings(
+    *,
+    include_onchain: bool | None,
+    include_orderbook: bool | None,
+    include_derivatives: bool | None,
+) -> FeatureSettings:
     settings = CONFIG.features
     overrides: dict[str, Any] = {}
-    if args.include_onchain is not None:
-        overrides["include_onchain"] = args.include_onchain
-    if args.include_orderbook is not None:
-        overrides["include_orderbook"] = args.include_orderbook
-    if args.include_derivatives is not None:
-        overrides["include_derivatives"] = args.include_derivatives
+    if include_onchain is not None:
+        overrides["include_onchain"] = include_onchain
+    if include_orderbook is not None:
+        overrides["include_orderbook"] = include_orderbook
+    if include_derivatives is not None:
+        overrides["include_derivatives"] = include_derivatives
     if overrides:
         settings = override_feature_settings(settings, **overrides)
     return settings
 
 
-def _load_features(args: argparse.Namespace, settings: FeatureSettings) -> pd.DataFrame:
-    if args.features is not None:
-        df = _read_table(args.features)
+def _load_features(
+    *,
+    features_path: Path | None,
+    symbol: str,
+    db_path: Path,
+    settings: FeatureSettings,
+) -> pd.DataFrame:
+    if features_path is not None:
+        df = _read_table(features_path)
         if "timestamp" in df.columns:
             df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
         return df
-    raw = get_price_data(args.symbol, db_path=args.db_path)
+    raw = get_price_data(symbol, db_path=db_path)
     return create_features(raw, settings=settings)
 
 
@@ -94,59 +111,64 @@ def _build_pipeline(feature_names: list[str]) -> Pipeline:
     return Pipeline([("transform", transformer), ("clf", clf)])
 
 
-def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Run feature group ablations")
-    parser.add_argument("--features", type=Path, help="Optional feature table (CSV/Parquet).")
-    parser.add_argument("--symbol", default=CONFIG.symbol)
-    parser.add_argument("--db-path", default=CONFIG.db_path)
-    parser.add_argument("--label", help="Custom label column name.")
-    parser.add_argument("--horizon", type=int, default=CONFIG.core.forward_steps * 15)
-    parser.add_argument("--run-id", type=str, default=None)
-    parser.add_argument("--include-onchain", dest="include_onchain", action="store_true")
-    parser.add_argument("--exclude-onchain", dest="include_onchain", action="store_false")
-    parser.add_argument("--include-orderbook", dest="include_orderbook", action="store_true")
-    parser.add_argument("--exclude-orderbook", dest="include_orderbook", action="store_false")
-    parser.add_argument("--include-derivatives", dest="include_derivatives", action="store_true")
-    parser.add_argument("--exclude-derivatives", dest="include_derivatives", action="store_false")
-    parser.set_defaults(include_onchain=None, include_orderbook=None, include_derivatives=None)
-    return parser
+def _execute_ablation(
+    *,
+    features: Path | None,
+    symbol: str,
+    db_path: Path,
+    label: Optional[str],
+    horizon: int,
+    run_id: str | None,
+    include_onchain: Optional[bool],
+    include_orderbook: Optional[bool],
+    include_derivatives: Optional[bool],
+    dry_run: bool,
+) -> Path:
+    if horizon <= 0:
+        raise DataValidationError("--horizon must be positive")
 
+    settings = _prepare_settings(
+        include_onchain=include_onchain,
+        include_orderbook=include_orderbook,
+        include_derivatives=include_derivatives,
+    )
+    df = _load_features(
+        features_path=features,
+        symbol=symbol,
+        db_path=db_path,
+        settings=settings,
+    )
 
-def main(argv: list[str] | None = None) -> Path:
-    parser = _build_parser()
-    args = parser.parse_args(argv)
+    label_name = label or f"cls_sign_{horizon}m"
+    if label_name not in df.columns:
+        df = make_default_targets(df, horizon=horizon)
+    if label_name not in df.columns:
+        raise DataValidationError(f"Label column '{label_name}' not found")
 
-    settings = _prepare_settings(args)
-    df = _load_features(args, settings)
-
-    label = args.label or f"cls_sign_{args.horizon}m"
-    if label not in df.columns:
-        df = make_default_targets(df, horizon=args.horizon)
-    if label not in df.columns:
-        raise KeyError(f"Label column '{label}' not found even after generation")
-
-    df = df.dropna(subset=[label]).sort_values("timestamp")
+    df = df.dropna(subset=[label_name]).sort_values("timestamp")
 
     feature_cols = get_feature_columns(settings) or FEATURE_COLUMNS
     missing = [col for col in feature_cols if col not in df.columns]
     if missing:
-        raise KeyError("Missing features: " + ", ".join(sorted(missing)))
+        raise DataValidationError("Missing features: " + ", ".join(sorted(missing)))
 
-    run_id = args.run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
+    run_id_value = run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
+    reports_dir = Path("reports")
+    reports_dir.mkdir(parents=True, exist_ok=True)
 
     timestamps = pd.to_datetime(df["timestamp"], utc=True)
     splits = purged_walkforward_splits(
         timestamps,
         CONFIG.cv.n_splits,
         CONFIG.cv.embargo_min,
-        run_id=run_id,
+        run_id=run_id_value,
     )
     if not splits:
-        raise RuntimeError("No walk-forward splits generated")
+        raise DataValidationError("No walk-forward splits generated")
     train_idx, test_idx = splits[-1]
 
     X = df[feature_cols].astype(np.float32)
-    y = df[label].astype(int)
+    y = df[label_name].astype(int)
     X_train, y_train = X.iloc[train_idx], y.iloc[train_idx]
     X_test, y_test = X.iloc[test_idx], y.iloc[test_idx]
 
@@ -184,14 +206,17 @@ def main(argv: list[str] | None = None) -> Path:
 
     result_df = pd.DataFrame(results).sort_values("brier")
 
-    reports_dir = Path("reports")
-    reports_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = reports_dir / f"ablation_{run_id_value}.csv"
+    png_path = reports_dir / f"ablation_{run_id_value}.png"
 
-    csv_path = reports_dir / f"ablation_{run_id}.csv"
-    png_path = reports_dir / f"ablation_{run_id}.png"
+    if dry_run:
+        typer.echo("Dry run requested; skipping report generation.")
+        typer.echo(f"Results would be stored at {csv_path} and {png_path}")
+        return csv_path
+
     result_df.to_csv(csv_path, index=False)
 
-    import matplotlib.pyplot as plt  # local import to avoid polluting module import state
+    import matplotlib.pyplot as plt  # local import for hygiene tests
 
     plt.figure(figsize=(8, 4))
     width = 0.25
@@ -204,9 +229,65 @@ def main(argv: list[str] | None = None) -> Path:
     plt.legend()
     plt.savefig(png_path)
     plt.close()
-    print(f"Ablation results stored at {csv_path} and {png_path}")
+    typer.echo(f"Ablation results stored at {csv_path} and {png_path}")
     return csv_path
 
 
-if __name__ == "__main__":  # pragma: no cover
-    main()
+@app.command()
+def main(
+    features: Optional[Path] = typer.Option(
+        None,
+        "--features",
+        exists=False,
+        file_okay=True,
+        dir_okay=False,
+        resolve_path=True,
+        help="Optional feature table (CSV/Parquet).",
+    ),
+    symbol: str = typer.Option(CONFIG.symbol, help="Symbol used when loading price data."),
+    db_path: Path = typer.Option(
+        CONFIG.db_path,
+        "--db-path",
+        exists=False,
+        file_okay=True,
+        dir_okay=False,
+        resolve_path=True,
+        help="SQLite database used when generating features.",
+    ),
+    label: Optional[str] = typer.Option(None, help="Custom label column name."),
+    horizon: int = typer.Option(CONFIG.core.forward_steps * 15, help="Horizon in minutes."),
+    run_id: Optional[str] = typer.Option(None, help="Optional run identifier."),
+    include_onchain: Optional[bool] = typer.Option(
+        None,
+        "--include-onchain/--exclude-onchain",
+        help="Override on-chain features toggle.",
+    ),
+    include_orderbook: Optional[bool] = typer.Option(
+        None,
+        "--include-orderbook/--exclude-orderbook",
+        help="Override orderbook features toggle.",
+    ),
+    include_derivatives: Optional[bool] = typer.Option(
+        None,
+        "--include-derivatives/--exclude-derivatives",
+        help="Override derivative features toggle.",
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview actions without writing."),
+) -> None:
+    _execute_ablation(
+        features=features,
+        symbol=symbol,
+        db_path=db_path,
+        label=label,
+        horizon=horizon,
+        run_id=run_id,
+        include_onchain=include_onchain,
+        include_orderbook=include_orderbook,
+        include_derivatives=include_derivatives,
+        dry_run=dry_run,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI behaviour
+    run_cli(app)
+

--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -1,21 +1,27 @@
-#!/usr/bin/env python
-"""CLI helper for running quick equity backtests."""
+"""Backtest runner with Typer CLI integration."""
+
 from __future__ import annotations
 
-import argparse
 import json
 from pathlib import Path
 from typing import Optional
 
 import numpy as np
 import pandas as pd
+import typer
 
 from crypto_analyzer.eval.backtest import run_backtest
 from crypto_analyzer.eval.threshold_sweep import SweepParams, sweep_threshold_grid
+from crypto_analyzer.utils.cli import run_cli
 from crypto_analyzer.utils.config import CONFIG
+from crypto_analyzer.utils.errors import DataValidationError
+
+app = typer.Typer(add_completion=False, no_args_is_help=True)
 
 
 def _read_predictions(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        raise DataValidationError(f"Predictions file '{path}' does not exist")
     if path.suffix.lower() in {".parquet", ".pq"}:
         return pd.read_parquet(path)
     return pd.read_csv(path)
@@ -35,7 +41,7 @@ def _normalise_columns(
         if column not in df.columns
     ]
     if missing:
-        raise KeyError("Missing required columns: " + ", ".join(sorted(missing)))
+        raise DataValidationError("Missing required columns: " + ", ".join(sorted(missing)))
 
     out = df.copy()
     out = out.rename(
@@ -51,93 +57,9 @@ def _normalise_columns(
     return out
 
 
-def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Run a simple long/short backtest")
-    parser.add_argument("predictions", type=Path, help="CSV/Parquet file with model forecasts.")
-    parser.add_argument(
-        "--timestamp-column",
-        default="timestamp",
-        help="Column containing the prediction timestamp.",
-    )
-    parser.add_argument(
-        "--prediction-column",
-        default="p_hat",
-        help="Column with the model's predicted price or probability.",
-    )
-    parser.add_argument(
-        "--target-column",
-        default="target",
-        help="Column with the realised target used for P&L computation.",
-    )
-    parser.add_argument(
-        "--price-column",
-        default="last_price",
-        help="Reference price column used when computing trade returns.",
-    )
-    parser.add_argument(
-        "--prob-column",
-        default=None,
-        help="Optional probability column for EV-based backtest rules.",
-    )
-    parser.add_argument(
-        "--fee_bps",
-        "--fee-bps",
-        dest="fee_bps",
-        type=float,
-        default=4.0,
-        help="Proportional transaction cost per trade in basis points.",
-    )
-    parser.add_argument(
-        "--slip_bps",
-        "--slip-bps",
-        dest="slip_bps",
-        type=float,
-        default=0.0,
-        help="Slippage assumption in basis points added to the fee.",
-    )
-    parser.add_argument(
-        "--latency_min",
-        "--latency-min",
-        dest="latency_min",
-        type=float,
-        default=0.0,
-        help="Execution latency in minutes applied by shifting the entry candle forward.",
-    )
-    parser.add_argument(
-        "--p_touch_thr",
-        "--p-touch-thr",
-        dest="p_touch_thr",
-        type=float,
-        default=None,
-        help="Minimum probability of touching the target required to open a trade.",
-    )
-    parser.add_argument(
-        "--p_up_thr",
-        "--p-up-thr",
-        dest="p_up_thr",
-        type=float,
-        default=None,
-        help=(
-            "Directional probability threshold. Values above open longs, below (1-thr) open shorts."
-        ),
-    )
-    parser.add_argument(
-        "--run-id",
-        default=None,
-        help="Optional identifier used when storing reports. Defaults to a UTC timestamp.",
-    )
-    parser.add_argument(
-        "--optimize-thresholds",
-        action="store_true",
-        help="Run a quick EV sweep across default threshold grids before executing the backtest.",
-    )
-    return parser
-
-
 def _infer_latency_steps(timestamps: pd.Series, latency_minutes: float) -> int:
     if latency_minutes <= 0:
         return 0
-
     if timestamps.empty:
         return 0
 
@@ -149,11 +71,8 @@ def _infer_latency_steps(timestamps: pd.Series, latency_minutes: float) -> int:
     step_minutes = diffs.dt.total_seconds().median() / 60.0
     if not np.isfinite(step_minutes) or step_minutes <= 0:
         return 0
-
     steps = int(round(latency_minutes / step_minutes))
-    if steps <= 0:
-        steps = 1
-    return steps
+    return max(steps, 1)
 
 
 def _find_horizon_column(df: pd.DataFrame) -> str | None:
@@ -163,35 +82,48 @@ def _find_horizon_column(df: pd.DataFrame) -> str | None:
     return None
 
 
-def main(argv: list[str] | None = None) -> tuple[Path, Path]:
-    parser = _build_parser()
-    args = parser.parse_args(argv)
-
-    df = _read_predictions(args.predictions)
+def _run_backtest(
+    *,
+    predictions: Path,
+    timestamp_column: str,
+    prediction_column: str,
+    target_column: str,
+    price_column: str,
+    prob_column: Optional[str],
+    fee_bps: float,
+    slip_bps: float,
+    latency_min: float,
+    p_touch_thr: Optional[float],
+    p_up_thr: Optional[float],
+    run_id: Optional[str],
+    optimize_thresholds: bool,
+    dry_run: bool,
+) -> tuple[Path, Path]:
+    df = _read_predictions(predictions)
     normalised = _normalise_columns(
         df,
-        timestamp_col=args.timestamp_column,
-        prediction_col=args.prediction_column,
-        target_col=args.target_column,
-        price_col=args.price_column,
+        timestamp_col=timestamp_column,
+        prediction_col=prediction_column,
+        target_col=target_column,
+        price_col=price_column,
     )
 
-    latency_steps = _infer_latency_steps(normalised["timestamp"], args.latency_min)
+    latency_steps = _infer_latency_steps(normalised["timestamp"], latency_min)
 
-    prob_col: Optional[str] = args.prob_column or None
-    if prob_col is not None and prob_col == args.prediction_column:
+    prob_col: Optional[str] = prob_column or None
+    if prob_col is not None and prob_col == prediction_column:
         prob_col = "p_hat"
     p_up_col = "p_up" if "p_up" in normalised.columns else None
 
-    if args.optimize_thresholds:
+    if optimize_thresholds:
         horizon_col = _find_horizon_column(normalised)
         touch_grid = np.round(np.arange(0.5, 0.8001, 0.05), 4)
         up_grid = np.round(np.arange(0.5, 0.7001, 0.05), 4)
         params = SweepParams(
             p_touch_values=touch_grid,
             p_up_values=up_grid,
-            fee_bps=args.fee_bps,
-            slippage_bps=args.slip_bps,
+            fee_bps=fee_bps,
+            slippage_bps=slip_bps,
             latency_steps=latency_steps,
             p_touch_col="p_hat",
             p_up_col=p_up_col,
@@ -208,28 +140,26 @@ def main(argv: list[str] | None = None) -> tuple[Path, Path]:
             frames.append(sweep_threshold_grid(normalised, params=params, horizon_label=None))
         preview = pd.concat(frames, ignore_index=True)
         top_preview = preview.sort_values("ev", ascending=False).head(5)
-        print("Threshold sweep preview (top 5 by EV):")
-        print(top_preview[["horizon", "p_touch_thr", "p_up_thr", "ev", "pnl", "sharpe", "trades"]])
+        typer.echo("Threshold sweep preview (top 5 by EV):")
+        typer.echo(top_preview[["horizon", "p_touch_thr", "p_up_thr", "ev", "pnl", "sharpe", "trades"]])
 
     result = run_backtest(
         normalised,
-        fee_bps=args.fee_bps,
-        slippage_bps=args.slip_bps,
+        fee_bps=fee_bps,
+        slippage_bps=slip_bps,
         prob_col=prob_col,
         latency_steps=latency_steps,
-        p_touch_col="p_hat" if args.p_touch_thr is not None else None,
-        p_touch_threshold=args.p_touch_thr,
+        p_touch_col="p_hat" if p_touch_thr is not None else None,
+        p_touch_threshold=p_touch_thr,
         p_up_col=p_up_col,
-        p_up_threshold=args.p_up_thr,
+        p_up_threshold=p_up_thr,
     )
 
-    run_id = args.run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
-    run_dir = Path("outputs") / f"run_id={run_id}"
-    run_dir.mkdir(parents=True, exist_ok=True)
+    run_id_value = run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
+    run_dir = Path("outputs") / f"run_id={run_id_value}"
     reports_dir = Path("reports")
-    reports_dir.mkdir(parents=True, exist_ok=True)
 
-    equity = result["equity"].assign(run_id=run_id)
+    equity = result["equity"].assign(run_id=run_id_value)
     metrics = result["metrics"]
 
     summary_metrics = {
@@ -240,7 +170,6 @@ def main(argv: list[str] | None = None) -> tuple[Path, Path]:
     }
 
     for key, value in summary_metrics.items():
-        display: str
         if value is None:
             display = "nan"
         else:
@@ -253,22 +182,31 @@ def main(argv: list[str] | None = None) -> tuple[Path, Path]:
                     display = "nan"
                 else:
                     display = f"{numeric_value:.6f}"
-        print(f"{key}: {display}")
+        typer.echo(f"{key}: {display}")
 
-    equity_output = reports_dir / f"equity_{run_id}.csv"
-    summary_output = reports_dir / f"summary_{run_id}.json"
+    equity_output = reports_dir / f"equity_{run_id_value}.csv"
+    summary_output = reports_dir / f"summary_{run_id_value}.json"
+
+    if dry_run:
+        typer.echo("Dry run requested; skipping file writes.")
+        typer.echo(f"Equity would be written to {equity_output}")
+        typer.echo(f"Summary would be written to {summary_output}")
+        return summary_output, equity_output
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+    reports_dir.mkdir(parents=True, exist_ok=True)
 
     equity.to_csv(equity_output, index=False)
     equity.to_csv(run_dir / "equity.csv", index=False)
 
     summary = {
-        "run_id": run_id,
+        "run_id": run_id_value,
         "parameters": {
-            "fee_bps": args.fee_bps,
-            "slip_bps": args.slip_bps,
-            "latency_minutes": args.latency_min,
-            "p_touch_threshold": args.p_touch_thr,
-            "p_up_threshold": args.p_up_thr,
+            "fee_bps": fee_bps,
+            "slip_bps": slip_bps,
+            "latency_minutes": latency_min,
+            "p_touch_threshold": p_touch_thr,
+            "p_up_threshold": p_up_thr,
             "prob_column": prob_col,
             "latency_steps": latency_steps,
         },
@@ -278,12 +216,24 @@ def main(argv: list[str] | None = None) -> tuple[Path, Path]:
     (run_dir / "summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
 
     config_dump = {
-        "args": {k: (str(v) if isinstance(v, Path) else v) for k, v in vars(args).items()},
+        "args": {
+            "timestamp_column": timestamp_column,
+            "prediction_column": prediction_column,
+            "target_column": target_column,
+            "price_column": price_column,
+            "prob_column": prob_column,
+            "fee_bps": fee_bps,
+            "slip_bps": slip_bps,
+            "latency_min": latency_min,
+            "p_touch_thr": p_touch_thr,
+            "p_up_thr": p_up_thr,
+            "run_id": run_id_value,
+        },
         "config": CONFIG.config_path.as_posix() if CONFIG.config_path else None,
     }
     (run_dir / "config_dump.json").write_text(json.dumps(config_dump, indent=2), encoding="utf-8")
 
-    print(
+    typer.echo(
         "Backtest complete. Final equity: "
         f"{float(equity['equity'].iloc[-1]):.4f}, PnL: {metrics['pnl']:.4f}, "
         f"Sharpe: {metrics['sharpe']:.4f}, EV: {metrics['ev']:.6f}, "
@@ -293,5 +243,65 @@ def main(argv: list[str] | None = None) -> tuple[Path, Path]:
     return summary_output, equity_output
 
 
+@app.command()
+def main(
+    predictions: Path = typer.Argument(..., exists=True, resolve_path=True),
+    timestamp_column: str = typer.Option(
+        "timestamp", help="Column containing the prediction timestamp."
+    ),
+    prediction_column: str = typer.Option(
+        "p_hat", help="Column with the model's predicted price or probability."
+    ),
+    target_column: str = typer.Option(
+        "target", help="Column with the realised target used for P&L computation."
+    ),
+    price_column: str = typer.Option(
+        "last_price", help="Reference price column used when computing trade returns."
+    ),
+    prob_column: Optional[str] = typer.Option(
+        None, help="Optional probability column for EV-based backtest rules."
+    ),
+    fee_bps: float = typer.Option(4.0, help="Proportional transaction cost in basis points."),
+    slip_bps: float = typer.Option(0.0, help="Slippage assumption in basis points."),
+    latency_min: float = typer.Option(0.0, help="Execution latency in minutes."),
+    p_touch_thr: Optional[float] = typer.Option(
+        None, help="Minimum probability of touching the target required to open a trade."
+    ),
+    p_up_thr: Optional[float] = typer.Option(
+        None,
+        help="Directional probability threshold. Values above open longs, below (1-thr) open shorts.",
+    ),
+    run_id: Optional[str] = typer.Option(None, help="Optional identifier used when storing reports."),
+    optimize_thresholds: bool = typer.Option(
+        False, help="Run an EV sweep before executing the backtest."
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview actions without writing."),
+) -> None:
+    if fee_bps < 0 or slip_bps < 0:
+        raise DataValidationError("--fee-bps and --slip-bps must be non-negative")
+    if p_touch_thr is not None and not (0 <= p_touch_thr <= 1):
+        raise DataValidationError("--p-touch-thr must lie in [0, 1]")
+    if p_up_thr is not None and not (0 <= p_up_thr <= 1):
+        raise DataValidationError("--p-up-thr must lie in [0, 1]")
+
+    _run_backtest(
+        predictions=predictions,
+        timestamp_column=timestamp_column,
+        prediction_column=prediction_column,
+        target_column=target_column,
+        price_column=price_column,
+        prob_column=prob_column,
+        fee_bps=fee_bps,
+        slip_bps=slip_bps,
+        latency_min=latency_min,
+        p_touch_thr=p_touch_thr,
+        p_up_thr=p_up_thr,
+        run_id=run_id,
+        optimize_thresholds=optimize_thresholds,
+        dry_run=dry_run,
+    )
+
+
 if __name__ == "__main__":  # pragma: no cover - CLI behaviour
-    main()
+    run_cli(app)
+

--- a/scripts/make_features.py
+++ b/scripts/make_features.py
@@ -1,17 +1,22 @@
-#!/usr/bin/env python
-"""Command-line entry point for feature engineering."""
+"""Generate engineered features using a Typer based CLI."""
+
 from __future__ import annotations
 
-import argparse
 import json
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal, Optional
 
 import pandas as pd
+import typer
 
 from crypto_analyzer.data.db_connector import get_price_data
 from crypto_analyzer.features.engineering import create_features
 from crypto_analyzer.utils.config import CONFIG, FeatureSettings, override_feature_settings
+from crypto_analyzer.utils.cli import run_cli
+from crypto_analyzer.utils.errors import DataValidationError
+
+
+app = typer.Typer(add_completion=False, no_args_is_help=True)
 
 
 def _load_price_data(
@@ -19,12 +24,14 @@ def _load_price_data(
     *,
     path: Path | None,
     symbol: str,
-    db_path: str,
+    db_path: Path,
 ) -> pd.DataFrame:
     if source == "db":
         return get_price_data(symbol, db_path=db_path)
     if path is None:
-        raise ValueError("Path must be provided when source='file'")
+        raise DataValidationError("--input must be provided when --source=file")
+    if not path.exists():
+        raise DataValidationError(f"Input file '{path}' does not exist")
     if path.suffix.lower() in {".parquet", ".pq"}:
         df = pd.read_parquet(path)
     else:
@@ -61,168 +68,221 @@ def _write_output(df: pd.DataFrame, path: Path, fmt: Literal["parquet", "csv"]) 
         df.to_csv(path, index=False)
 
 
-def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Generate engineered features")
-    parser.add_argument(
-        "--source",
-        choices=("db", "file"),
-        default="db",
-        help="Where to load raw price data from.",
-    )
-    parser.add_argument(
-        "--input",
-        type=Path,
-        help="Optional CSV/Parquet file with raw OHLCV data when source=file.",
-    )
-    parser.add_argument(
-        "--output",
-        type=Path,
-        default=Path("features.parquet"),
-        help="Destination file where engineered features will be stored.",
-    )
-    parser.add_argument(
-        "--format",
-        choices=("parquet", "csv"),
-        default="parquet",
-        help="Output file format.",
-    )
-    parser.add_argument(
-        "--symbol",
-        default=CONFIG.symbol,
-        help="Trading symbol to load when pulling data from the configured database.",
-    )
-    parser.add_argument(
-        "--db-path",
-        default=CONFIG.db_path,
-        help="SQLite database file used when source=db.",
-    )
-    parser.add_argument(
-        "--include-onchain",
-        dest="include_onchain",
-        action="store_true",
-        help="Force-enable on-chain features regardless of config defaults.",
-    )
-    parser.add_argument(
-        "--exclude-onchain",
-        dest="include_onchain",
-        action="store_false",
-        help="Force-disable on-chain features regardless of config defaults.",
-    )
-    parser.add_argument(
-        "--include-orderbook",
-        dest="include_orderbook",
-        action="store_true",
-        help="Force-enable orderbook features regardless of config defaults.",
-    )
-    parser.add_argument(
-        "--exclude-orderbook",
-        dest="include_orderbook",
-        action="store_false",
-        help="Force-disable orderbook features regardless of config defaults.",
-    )
-    parser.add_argument(
-        "--include-derivatives",
-        dest="include_derivatives",
-        action="store_true",
-        help="Force-enable derivative features regardless of config defaults.",
-    )
-    parser.add_argument(
-        "--exclude-derivatives",
-        dest="include_derivatives",
-        action="store_false",
-        help="Force-disable derivative features regardless of config defaults.",
-    )
-    parser.add_argument(
-        "--use_derivatives",
-        action="store_true",
-        help="Convenience flag to enable derivative features from auxiliary loaders.",
-    )
-    parser.add_argument(
-        "--use_orderbook",
-        action="store_true",
-        help="Convenience flag to enable order book feature engineering.",
-    )
-    parser.add_argument(
-        "--forward-fill-limit",
-        type=int,
-        help="Override forward-fill window for NaN handling.",
-    )
-    parser.add_argument(
-        "--fillna-value",
-        type=float,
-        help="Override fallback value used when forward fill runs out.",
-    )
-    parser.add_argument("--run-id", type=str, default=None, help="Optional run identifier.")
-    parser.set_defaults(include_onchain=None, include_orderbook=None, include_derivatives=None)
-    return parser
-
-
-def main(argv: list[str] | None = None) -> Path:
-    parser = _build_parser()
-    args = parser.parse_args(argv)
-
+def _prepare_settings(
+    *,
+    forward_fill_limit: Optional[int],
+    fillna_value: Optional[float],
+    include_onchain: Optional[bool],
+    include_orderbook: Optional[bool],
+    include_derivatives: Optional[bool],
+) -> FeatureSettings:
     settings = CONFIG.features
-    if args.forward_fill_limit is not None or args.fillna_value is not None:
+    if forward_fill_limit is not None or fillna_value is not None:
         settings = FeatureSettings(
             include_onchain=settings.include_onchain,
             include_orderbook=settings.include_orderbook,
             include_derivatives=settings.include_derivatives,
-            forward_fill_limit=args.forward_fill_limit
-            if args.forward_fill_limit is not None
-            else settings.forward_fill_limit,
-            fillna_value=args.fillna_value if args.fillna_value is not None else settings.fillna_value,
+            forward_fill_limit=
+            forward_fill_limit if forward_fill_limit is not None else settings.forward_fill_limit,
+            fillna_value=fillna_value if fillna_value is not None else settings.fillna_value,
         )
-
-    if args.use_derivatives:
-        args.include_derivatives = True
-    if args.use_orderbook:
-        args.include_orderbook = True
-
-    settings = _configure_features(
+    return _configure_features(
         settings=settings,
-        include_onchain=args.include_onchain,
-        include_orderbook=args.include_orderbook,
-        include_derivatives=args.include_derivatives,
+        include_onchain=include_onchain,
+        include_orderbook=include_orderbook,
+        include_derivatives=include_derivatives,
     )
 
-    df = _load_price_data(
-        args.source,
-        path=args.input,
-        symbol=args.symbol,
-        db_path=args.db_path,
-    )
-    feature_df = create_features(df, settings=settings)
 
-    run_id = args.run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
-    run_dir = Path("outputs") / f"run_id={run_id}"
+def _resolve_output(
+    *,
+    output: Path,
+    run_dir: Path,
+) -> tuple[Path, Path]:
     run_dir.mkdir(parents=True, exist_ok=True)
-
-    default_output = parser.get_default("output")
-    if args.output == default_output:
-        target_output = run_dir / args.output.name
+    if not output.is_absolute():
+        target_output = run_dir / output.name
     else:
-        target_output = args.output
+        target_output = output
+    return target_output, run_dir / output.name
 
-    run_output = run_dir / target_output.name
-    _write_output(feature_df, run_output, args.format)
-    if target_output != run_output:
-        _write_output(feature_df, target_output, args.format)
 
+def _persist_metadata(run_dir: Path, args: dict[str, Any]) -> None:
     config_dump = {
         "config": CONFIG.config_path.as_posix() if CONFIG.config_path else None,
-        "args": {k: (str(v) if isinstance(v, Path) else v) for k, v in vars(args).items()},
+        "args": {k: (str(v) if isinstance(v, Path) else v) for k, v in args.items()},
     }
-    config_path = run_dir / "config_dump.json"
-    config_path.write_text(json.dumps(config_dump, indent=2), encoding="utf-8")
+    (run_dir / "config_dump.json").write_text(json.dumps(config_dump, indent=2), encoding="utf-8")
+
+
+def _print_outputs(primary: Path, secondary: Path | None) -> None:
+    typer.echo(f"Features written to {primary}")
+    if secondary and secondary != primary:
+        typer.echo(f"Features copied to {secondary}")
+
+
+def _generate_features(
+    *,
+    source: Literal["db", "file"],
+    input_path: Path | None,
+    output: Path,
+    fmt: Literal["parquet", "csv"],
+    symbol: str,
+    db_path: Path,
+    forward_fill_limit: Optional[int],
+    fillna_value: Optional[float],
+    include_onchain: Optional[bool],
+    include_orderbook: Optional[bool],
+    include_derivatives: Optional[bool],
+    use_derivatives: bool,
+    use_orderbook: bool,
+    run_id: str | None,
+    dry_run: bool,
+) -> Path:
+    if forward_fill_limit is not None and forward_fill_limit < 0:
+        raise DataValidationError("--forward-fill-limit must be non-negative")
+
+    include_derivatives = True if use_derivatives else include_derivatives
+    include_orderbook = True if use_orderbook else include_orderbook
+
+    settings = _prepare_settings(
+        forward_fill_limit=forward_fill_limit,
+        fillna_value=fillna_value,
+        include_onchain=include_onchain,
+        include_orderbook=include_orderbook,
+        include_derivatives=include_derivatives,
+    )
+
+    df = _load_price_data(source, path=input_path, symbol=symbol, db_path=db_path)
+    feature_df = create_features(df, settings=settings)
+
+    run_id_value = run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
+    run_dir = Path("outputs") / f"run_id={run_id_value}"
+    target_output, run_output = _resolve_output(output=output, run_dir=run_dir)
+
+    if dry_run:
+        typer.echo("Dry run requested; skipping file writes.")
+        _print_outputs(run_output, None)
+        return run_output
+
+    _write_output(feature_df, run_output, fmt)
+    if target_output != run_output:
+        _write_output(feature_df, target_output, fmt)
+
+    _persist_metadata(run_dir, {
+        "source": source,
+        "input": input_path,
+        "output": output,
+        "format": fmt,
+        "symbol": symbol,
+        "db_path": db_path,
+        "forward_fill_limit": forward_fill_limit,
+        "fillna_value": fillna_value,
+        "include_onchain": include_onchain,
+        "include_orderbook": include_orderbook,
+        "include_derivatives": include_derivatives,
+        "use_derivatives": use_derivatives,
+        "use_orderbook": use_orderbook,
+        "run_id": run_id_value,
+        "dry_run": dry_run,
+    })
 
     reports_dir = Path("reports")
     reports_dir.mkdir(parents=True, exist_ok=True)
 
-    print(f"Features written to {run_output}")
-    if target_output != run_output:
-        print(f"Features copied to {target_output}")
+    _print_outputs(run_output, target_output if target_output != run_output else None)
     return run_output
 
 
-if __name__ == "__main__":  # pragma: no cover - CLI behaviour
-    main()
+@app.command()
+def main(
+    source: Literal["db", "file"] = typer.Option(
+        "db", help="Where to load raw price data from."
+    ),
+    input_path: Path | None = typer.Option(
+        None,
+        "--input",
+        exists=False,
+        file_okay=True,
+        dir_okay=False,
+        writable=False,
+        readable=True,
+        resolve_path=True,
+        help="Optional CSV/Parquet file when --source=file.",
+    ),
+    output: Path = typer.Option(
+        Path("features.parquet"),
+        "--output",
+        help="Destination path for engineered features.",
+    ),
+    fmt: Literal["parquet", "csv"] = typer.Option(
+        "parquet", "--format", help="Output file format."
+    ),
+    symbol: str = typer.Option(CONFIG.symbol, "--symbol", help="Trading symbol to load."),
+    db_path: Path = typer.Option(
+        CONFIG.db_path,
+        "--db-path",
+        exists=False,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        resolve_path=True,
+        help="SQLite database path when source=db.",
+    ),
+    include_onchain: Optional[bool] = typer.Option(
+        None,
+        "--include-onchain/--exclude-onchain",
+        help="Override on-chain features toggle.",
+    ),
+    include_orderbook: Optional[bool] = typer.Option(
+        None,
+        "--include-orderbook/--exclude-orderbook",
+        help="Override orderbook features toggle.",
+    ),
+    include_derivatives: Optional[bool] = typer.Option(
+        None,
+        "--include-derivatives/--exclude-derivatives",
+        help="Override derivative features toggle.",
+    ),
+    use_derivatives: bool = typer.Option(
+        False, "--use-derivatives", help="Convenience flag to enable derivative features."
+    ),
+    use_orderbook: bool = typer.Option(
+        False, "--use-orderbook", help="Convenience flag to enable orderbook features."
+    ),
+    forward_fill_limit: Optional[int] = typer.Option(
+        None, help="Override forward-fill window for NaN handling."
+    ),
+    fillna_value: Optional[float] = typer.Option(
+        None, help="Override fallback value when forward fill runs out."
+    ),
+    run_id: str | None = typer.Option(None, help="Optional run identifier."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview actions without writing."),
+) -> None:
+    if source == "file" and input_path is None:
+        raise DataValidationError("--input is required when --source=file")
+    if source == "db" and input_path is not None:
+        typer.secho("Ignoring --input because --source=db", fg=typer.colors.YELLOW)
+
+    _generate_features(
+        source=source,
+        input_path=input_path,
+        output=output,
+        fmt=fmt,
+        symbol=symbol,
+        db_path=db_path,
+        forward_fill_limit=forward_fill_limit,
+        fillna_value=fillna_value,
+        include_onchain=include_onchain,
+        include_orderbook=include_orderbook,
+        include_derivatives=include_derivatives,
+        use_derivatives=use_derivatives,
+        use_orderbook=use_orderbook,
+        run_id=run_id,
+        dry_run=dry_run,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    run_cli(app)
+

--- a/scripts/optimize_thresholds.py
+++ b/scripts/optimize_thresholds.py
@@ -1,19 +1,25 @@
-#!/usr/bin/env python
-"""Grid-search utility for optimising backtest probability thresholds."""
+"""Sweep touch/up thresholds using a Typer CLI."""
+
 from __future__ import annotations
 
-import argparse
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Optional
 
 import numpy as np
 import pandas as pd
+import typer
 
 from crypto_analyzer.eval.threshold_sweep import SweepParams, sweep_threshold_grid
+from crypto_analyzer.utils.cli import run_cli
 from crypto_analyzer.utils.config import CONFIG
+from crypto_analyzer.utils.errors import DataValidationError
+
+app = typer.Typer(add_completion=False, no_args_is_help=True)
 
 
 def _read_predictions(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        raise DataValidationError(f"Predictions file '{path}' does not exist")
     if path.suffix.lower() in {".parquet", ".pq"}:
         return pd.read_parquet(path)
     return pd.read_csv(path)
@@ -33,7 +39,7 @@ def _normalise_columns(
         if column not in df.columns
     ]
     if missing:
-        raise KeyError("Missing required columns: " + ", ".join(sorted(missing)))
+        raise DataValidationError("Missing required columns: " + ", ".join(sorted(missing)))
 
     out = df.copy()
     out = out.rename(
@@ -52,7 +58,6 @@ def _normalise_columns(
 def _infer_latency_steps(timestamps: pd.Series, latency_minutes: float) -> int:
     if latency_minutes <= 0:
         return 0
-
     if timestamps.empty:
         return 0
 
@@ -71,10 +76,10 @@ def _infer_latency_steps(timestamps: pd.Series, latency_minutes: float) -> int:
 
 def _build_grid(start: float, stop: float, step: float) -> np.ndarray:
     if step <= 0:
-        raise ValueError("Step must be positive")
+        raise DataValidationError("Step must be positive")
     values = np.arange(start, stop + step * 0.5, step)
     if values.size == 0:
-        raise ValueError("Invalid grid range")
+        raise DataValidationError("Invalid grid range")
     values = np.clip(values, start, stop)
     return np.unique(np.round(values, 4))
 
@@ -88,107 +93,6 @@ def _find_horizon_column(df: pd.DataFrame, preferred: str | None) -> str | None:
         if name and name in df.columns:
             return name
     return None
-
-
-def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Sweep p_touch/p_up thresholds and plot EV heatmaps")
-    parser.add_argument("predictions", type=Path, help="CSV/Parquet file with model forecasts.")
-    parser.add_argument(
-        "--timestamp-column",
-        default="timestamp",
-        help="Column containing the prediction timestamp.",
-    )
-    parser.add_argument(
-        "--prediction-column",
-        default="p_hat",
-        help="Column with the touch probability or price forecast.",
-    )
-    parser.add_argument(
-        "--target-column",
-        default="target",
-        help="Column with the realised label used for P&L computation.",
-    )
-    parser.add_argument(
-        "--price-column",
-        default="last_price",
-        help="Reference price column used when computing trade returns.",
-    )
-    parser.add_argument(
-        "--p-up-column",
-        default="p_up",
-        help="Directional probability column gating long/short decisions.",
-    )
-    parser.add_argument(
-        "--group-column",
-        default="horizon",
-        help="Optional column used to split predictions by horizon before sweeping.",
-    )
-    parser.add_argument(
-        "--fee_bps",
-        "--fee-bps",
-        dest="fee_bps",
-        type=float,
-        default=getattr(CONFIG.backtest, "fee_bps", 4.0),
-        help="Proportional transaction cost per trade in basis points.",
-    )
-    parser.add_argument(
-        "--slip_bps",
-        "--slip-bps",
-        dest="slip_bps",
-        type=float,
-        default=getattr(CONFIG.backtest, "slippage_bps", 0.0),
-        help="Slippage assumption in basis points added to the fee.",
-    )
-    parser.add_argument(
-        "--latency_min",
-        "--latency-min",
-        dest="latency_min",
-        type=float,
-        default=0.0,
-        help="Execution latency in minutes applied by shifting the entry candle forward.",
-    )
-    parser.add_argument(
-        "--p-touch-min",
-        type=float,
-        default=0.5,
-        help="Minimum p_touch threshold evaluated during the sweep.",
-    )
-    parser.add_argument(
-        "--p-touch-max",
-        type=float,
-        default=0.8,
-        help="Maximum p_touch threshold evaluated during the sweep.",
-    )
-    parser.add_argument(
-        "--p-touch-step",
-        type=float,
-        default=0.05,
-        help="Step size between p_touch thresholds.",
-    )
-    parser.add_argument(
-        "--p-up-min",
-        type=float,
-        default=0.5,
-        help="Minimum p_up threshold evaluated during the sweep.",
-    )
-    parser.add_argument(
-        "--p-up-max",
-        type=float,
-        default=0.7,
-        help="Maximum p_up threshold evaluated during the sweep.",
-    )
-    parser.add_argument(
-        "--p-up-step",
-        type=float,
-        default=0.05,
-        help="Step size between p_up thresholds.",
-    )
-    parser.add_argument(
-        "--run-id",
-        default=None,
-        help="Optional identifier used when storing reports. Defaults to a UTC timestamp.",
-    )
-    return parser
 
 
 def _iter_groups(df: pd.DataFrame, column: str | None) -> Iterable[tuple[str | int | float | None, pd.DataFrame]]:
@@ -209,33 +113,50 @@ def _iter_groups(df: pd.DataFrame, column: str | None) -> Iterable[tuple[str | i
         yield value, subset
 
 
-def main(argv: list[str] | None = None) -> tuple[Path, Path]:
-    parser = _build_parser()
-    args = parser.parse_args(argv)
-
-    df = _read_predictions(args.predictions)
+def _run_sweep(
+    *,
+    predictions: Path,
+    timestamp_column: str,
+    prediction_column: str,
+    target_column: str,
+    price_column: str,
+    p_up_column: str,
+    group_column: str,
+    fee_bps: float,
+    slip_bps: float,
+    latency_min: float,
+    p_touch_min: float,
+    p_touch_max: float,
+    p_touch_step: float,
+    p_up_min: float,
+    p_up_max: float,
+    p_up_step: float,
+    run_id: Optional[str],
+    dry_run: bool,
+) -> tuple[Path, Path]:
+    df = _read_predictions(predictions)
     normalised = _normalise_columns(
         df,
-        timestamp_col=args.timestamp_column,
-        prediction_col=args.prediction_column,
-        target_col=args.target_column,
-        price_col=args.price_column,
+        timestamp_col=timestamp_column,
+        prediction_col=prediction_column,
+        target_col=target_column,
+        price_col=price_column,
     )
 
-    latency_steps = _infer_latency_steps(normalised["timestamp"], args.latency_min)
+    latency_steps = _infer_latency_steps(normalised["timestamp"], latency_min)
 
-    group_col = _find_horizon_column(normalised, args.group_column)
-    p_touch_grid = _build_grid(args.p_touch_min, args.p_touch_max, args.p_touch_step)
-    p_up_grid = _build_grid(args.p_up_min, args.p_up_max, args.p_up_step)
+    group_col = _find_horizon_column(normalised, group_column)
+    p_touch_grid = _build_grid(p_touch_min, p_touch_max, p_touch_step)
+    p_up_grid = _build_grid(p_up_min, p_up_max, p_up_step)
 
     params = SweepParams(
         p_touch_values=p_touch_grid,
         p_up_values=p_up_grid,
-        fee_bps=args.fee_bps,
-        slippage_bps=args.slip_bps,
+        fee_bps=fee_bps,
+        slippage_bps=slip_bps,
         latency_steps=latency_steps,
         p_touch_col="p_hat",
-        p_up_col=args.p_up_column,
+        p_up_col=p_up_column,
     )
 
     frames: list[pd.DataFrame] = []
@@ -244,15 +165,22 @@ def main(argv: list[str] | None = None) -> tuple[Path, Path]:
         frames.append(frame)
 
     if not frames:
-        raise RuntimeError("No data available for threshold sweep")
+        raise DataValidationError("No data available for threshold sweep")
 
     result = pd.concat(frames, ignore_index=True)
 
-    run_id = args.run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
+    run_id_value = run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
     reports_dir = Path("reports")
     reports_dir.mkdir(parents=True, exist_ok=True)
 
-    csv_path = reports_dir / f"threshold_sweep_{run_id}.csv"
+    csv_path = reports_dir / f"threshold_sweep_{run_id_value}.csv"
+    png_path = reports_dir / f"threshold_sweep_{run_id_value}.png"
+
+    if dry_run:
+        typer.echo("Dry run requested; skipping report generation.")
+        typer.echo(f"Sweep results would be stored at {csv_path} and {png_path}")
+        return csv_path, png_path
+
     result.to_csv(csv_path, index=False)
 
     pivot_groups = []
@@ -265,7 +193,7 @@ def main(argv: list[str] | None = None) -> tuple[Path, Path]:
         )
         pivot_groups.append((horizon, pivot))
 
-    import matplotlib.pyplot as plt  # deferred import for hygiene tests
+    import matplotlib.pyplot as plt  # deferred import
 
     if not pivot_groups:
         pivot_groups.append((None, pd.DataFrame()))
@@ -290,18 +218,88 @@ def main(argv: list[str] | None = None) -> tuple[Path, Path]:
         fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04, label="EV")
 
     plt.tight_layout()
-    png_path = reports_dir / f"threshold_sweep_{run_id}.png"
     plt.savefig(png_path)
     plt.close(fig)
 
     top = result.sort_values("ev", ascending=False).head(10)
-    print("Top threshold combinations by expected value:")
-    print(top[["horizon", "p_touch_thr", "p_up_thr", "ev", "pnl", "sharpe", "trades"]])
-    print(f"Sweep results saved to {csv_path}")
-    print(f"Heatmap saved to {png_path}")
+    typer.echo("Top threshold combinations by expected value:")
+    typer.echo(top[["horizon", "p_touch_thr", "p_up_thr", "ev", "pnl", "sharpe", "trades"]])
+    typer.echo(f"Sweep results saved to {csv_path}")
+    typer.echo(f"Heatmap saved to {png_path}")
 
     return csv_path, png_path
 
 
+@app.command()
+def main(
+    predictions: Path = typer.Argument(..., exists=True, resolve_path=True),
+    timestamp_column: str = typer.Option(
+        "timestamp", help="Column containing the prediction timestamp."
+    ),
+    prediction_column: str = typer.Option(
+        "p_hat", help="Column with the touch probability or price forecast."
+    ),
+    target_column: str = typer.Option(
+        "target", help="Column with the realised label used for P&L computation."
+    ),
+    price_column: str = typer.Option(
+        "last_price", help="Reference price column for trade returns."
+    ),
+    p_up_column: str = typer.Option(
+        "p_up", help="Directional probability column gating long/short decisions."
+    ),
+    group_column: str = typer.Option(
+        "horizon", help="Column used to split predictions before sweeping."
+    ),
+    fee_bps: float = typer.Option(
+        getattr(CONFIG.backtest, "fee_bps", 4.0),
+        help="Proportional transaction cost per trade in basis points.",
+    ),
+    slip_bps: float = typer.Option(
+        getattr(CONFIG.backtest, "slippage_bps", 0.0),
+        help="Slippage assumption in basis points added to the fee.",
+    ),
+    latency_min: float = typer.Option(
+        0.0, help="Execution latency in minutes applied via timestamp shifts."
+    ),
+    p_touch_min: float = typer.Option(0.5, help="Minimum p_touch threshold evaluated."),
+    p_touch_max: float = typer.Option(0.8, help="Maximum p_touch threshold evaluated."),
+    p_touch_step: float = typer.Option(0.05, help="Step size between p_touch thresholds."),
+    p_up_min: float = typer.Option(0.5, help="Minimum p_up threshold evaluated."),
+    p_up_max: float = typer.Option(0.7, help="Maximum p_up threshold evaluated."),
+    p_up_step: float = typer.Option(0.05, help="Step size between p_up thresholds."),
+    run_id: Optional[str] = typer.Option(None, help="Optional identifier used when storing reports."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview actions without writing."),
+) -> None:
+    if fee_bps < 0 or slip_bps < 0:
+        raise DataValidationError("--fee-bps and --slip-bps must be non-negative")
+    if p_touch_min > p_touch_max:
+        raise DataValidationError("--p-touch-min must be <= --p-touch-max")
+    if p_up_min > p_up_max:
+        raise DataValidationError("--p-up-min must be <= --p-up-max")
+
+    _run_sweep(
+        predictions=predictions,
+        timestamp_column=timestamp_column,
+        prediction_column=prediction_column,
+        target_column=target_column,
+        price_column=price_column,
+        p_up_column=p_up_column,
+        group_column=group_column,
+        fee_bps=fee_bps,
+        slip_bps=slip_bps,
+        latency_min=latency_min,
+        p_touch_min=p_touch_min,
+        p_touch_max=p_touch_max,
+        p_touch_step=p_touch_step,
+        p_up_min=p_up_min,
+        p_up_max=p_up_max,
+        p_up_step=p_up_step,
+        run_id=run_id,
+        dry_run=dry_run,
+    )
+
+
 if __name__ == "__main__":  # pragma: no cover - CLI behaviour
-    main()
+    run_cli(app)
+

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -6,16 +6,17 @@ from __future__ import annotations
 """Training entry-point with optional calibration and conformal outputs."""
 from __future__ import annotations
 
-import argparse
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import joblib
 import numpy as np
 import pandas as pd
 import xgboost as xgb
 from sklearn import metrics
+
+import typer
 
 from crypto_analyzer.data.db_connector import get_price_data
 from crypto_analyzer.features.engineering import (
@@ -34,52 +35,72 @@ from crypto_analyzer.models.calibration import (
     reliability_curve,
 )
 from crypto_analyzer.models.conformal import conformal_interval
+from crypto_analyzer.utils.cli import run_cli
 from crypto_analyzer.utils.config import CONFIG, FeatureSettings, override_feature_settings
+from crypto_analyzer.utils.errors import DataValidationError, ModelError
+
+
+app = typer.Typer(add_completion=False, no_args_is_help=True)
 
 
 def _read_table(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        raise DataValidationError(f"Feature file '{path}' does not exist")
     if path.suffix.lower() in {".parquet", ".pq"}:
         return pd.read_parquet(path)
     return pd.read_csv(path)
 
 
-def _prepare_settings(args: argparse.Namespace) -> FeatureSettings:
+def _prepare_settings(
+    *,
+    include_onchain: Optional[bool],
+    include_orderbook: Optional[bool],
+    include_derivatives: Optional[bool],
+    forward_fill_limit: Optional[int],
+    fillna_value: Optional[float],
+) -> FeatureSettings:
     settings = CONFIG.features
     overrides: dict[str, Any] = {}
-    if args.include_onchain is not None:
-        overrides["include_onchain"] = args.include_onchain
-    if args.include_orderbook is not None:
-        overrides["include_orderbook"] = args.include_orderbook
-    if args.include_derivatives is not None:
-        overrides["include_derivatives"] = args.include_derivatives
+    if include_onchain is not None:
+        overrides["include_onchain"] = include_onchain
+    if include_orderbook is not None:
+        overrides["include_orderbook"] = include_orderbook
+    if include_derivatives is not None:
+        overrides["include_derivatives"] = include_derivatives
     if overrides:
         settings = override_feature_settings(settings, **overrides)
 
-    if args.forward_fill_limit is not None or args.fillna_value is not None:
+    if forward_fill_limit is not None or fillna_value is not None:
         settings = FeatureSettings(
             include_onchain=settings.include_onchain,
             include_orderbook=settings.include_orderbook,
             include_derivatives=settings.include_derivatives,
             forward_fill_limit=(
-                args.forward_fill_limit
-                if args.forward_fill_limit is not None
+                forward_fill_limit
+                if forward_fill_limit is not None
                 else settings.forward_fill_limit
             ),
             fillna_value=(
-                args.fillna_value if args.fillna_value is not None else settings.fillna_value
+                fillna_value if fillna_value is not None else settings.fillna_value
             ),
         )
     return settings
 
 
-def _load_features(args: argparse.Namespace, settings: FeatureSettings) -> pd.DataFrame:
-    if args.features is not None:
-        df = _read_table(args.features)
+def _load_features(
+    *,
+    features: Optional[Path],
+    symbol: str,
+    db_path: Path,
+    settings: FeatureSettings,
+) -> pd.DataFrame:
+    if features is not None:
+        df = _read_table(features)
         if "timestamp" in df.columns:
             df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
         return df
 
-    raw = get_price_data(args.symbol, db_path=args.db_path)
+    raw = get_price_data(symbol, db_path=db_path)
     return create_features(raw, settings=settings)
 
 
@@ -90,7 +111,7 @@ def _ensure_label(df: pd.DataFrame, horizon: int, label: str) -> tuple[pd.DataFr
     labeled = make_default_targets(df, horizon=horizon)
     target_col = f"cls_sign_{horizon}m"
     if target_col not in labeled.columns:
-        raise ValueError(
+        raise DataValidationError(
             "Unable to infer training targets. Provide a --label column or ensure the input data "
             "contains OHLC prices so targets can be generated."
         )
@@ -118,7 +139,7 @@ def _chronological_split(
     X: pd.DataFrame, y: pd.Series, timestamps: pd.Series, test_size: float
 ) -> tuple[pd.DataFrame, pd.DataFrame, pd.Series, pd.Series, pd.Series, pd.Series]:
     if not 0.0 < test_size < 1.0:
-        raise ValueError("test_size must lie in (0, 1)")
+        raise DataValidationError("--test-size must lie in (0, 1)")
     split_idx = max(1, int(round(len(X) * (1 - test_size))))
     X_train = X.iloc[:split_idx]
     X_test = X.iloc[split_idx:]
@@ -330,241 +351,110 @@ def _fit_model(
     return model
 
 
-def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Train the Crypto Analyzer meta-model")
-    parser.add_argument(
-        "--features",
-        type=Path,
-        help="Optional engineered feature table (CSV/Parquet). If omitted data is pulled from the DB.",
-    )
-    parser.add_argument(
-        "--symbol",
-        default=CONFIG.symbol,
-        help="Trading symbol used when sourcing data from the database.",
-    )
-    parser.add_argument(
-        "--db-path",
-        default=CONFIG.db_path,
-        help="SQLite database file to read raw price data from.",
-    )
-    parser.add_argument(
-        "--horizon",
-        type=int,
-        default=120,
-        help="Target horizon in minutes for label generation when not provided in the dataset.",
-    )
-    parser.add_argument(
-        "--label",
-        help="Existing label column to use. Defaults to cls_sign_<horizon>m.",
-    )
-    parser.add_argument(
-        "--model-path",
-        type=Path,
-        default=Path("artifacts/meta_model.joblib"),
-        help="Output path for the trained model.",
-    )
-    parser.add_argument(
-        "--log-path",
-        type=Path,
-        default=Path("artifacts/oob_metrics.json"),
-        help="Where to store evaluation metrics gathered during training.",
-    )
-    parser.add_argument(
-        "--split",
-        choices=("holdout", "walkforward"),
-        default="holdout",
-        help="Evaluation split used during training.",
-    )
-    parser.add_argument(
-        "--test-size",
-        type=float,
-        default=0.2,
-        help="Hold-out fraction used for the validation split.",
-    )
-    parser.add_argument(
-        "--random-state",
-        type=int,
-        default=42,
-        help="Random seed used for model training.",
-    )
-    parser.add_argument(
-        "--no-gpu",
-        action="store_true",
-        help="Disable GPU acceleration even when available.",
-    )
-    parser.add_argument(
-        "--include-onchain",
-        dest="include_onchain",
-        action="store_true",
-        help="Force-enable on-chain features regardless of config defaults.",
-    )
-    parser.add_argument(
-        "--exclude-onchain",
-        dest="include_onchain",
-        action="store_false",
-        help="Force-disable on-chain features regardless of config defaults.",
-    )
-    parser.add_argument(
-        "--include-orderbook",
-        dest="include_orderbook",
-        action="store_true",
-        help="Force-enable orderbook features regardless of config defaults.",
-    )
-    parser.add_argument(
-        "--exclude-orderbook",
-        dest="include_orderbook",
-        action="store_false",
-        help="Force-disable orderbook features regardless of config defaults.",
-    )
-    parser.add_argument(
-        "--include-derivatives",
-        dest="include_derivatives",
-        action="store_true",
-        help="Force-enable derivative features regardless of config defaults.",
-    )
-    parser.add_argument(
-        "--exclude-derivatives",
-        dest="include_derivatives",
-        action="store_false",
-        help="Force-disable derivative features regardless of config defaults.",
-    )
-    parser.add_argument(
-        "--forward-fill-limit",
-        type=int,
-        help="Override forward-fill window for NaN handling.",
-    )
-    parser.add_argument(
-        "--fillna-value",
-        type=float,
-        help="Override fallback value used when forward fill runs out.",
-    )
-    parser.add_argument(
-        "--wfs-train-days",
-        type=int,
-        help="Training window size in days for walk-forward evaluation.",
-    )
-    parser.add_argument(
-        "--wfs-test-days",
-        type=int,
-        help="Test window size in days for walk-forward evaluation.",
-    )
-    parser.add_argument(
-        "--wfs-step-days",
-        type=int,
-        help="Step size in days when rolling the walk-forward window.",
-    )
-    parser.add_argument(
-        "--wfs-min-train-days",
-        type=int,
-        help="Minimal amount of training data required for walk-forward evaluation.",
-    )
-    parser.add_argument(
-        "--cv",
-        choices=("purged-wf",),
-        help="Optional cross-validation strategy to evaluate during training.",
-    )
-    parser.add_argument(
-        "--embargo_min",
-        type=int,
-        default=CONFIG.cv.embargo_min,
-        help=(
-            "Embargo window in minutes used for purged walk-forward cross-validation."
-            " Defaults to 360 minutes."
-        ),
-    )
-    parser.add_argument(
-        "--calibration",
-        choices=("none", "isotonic", "platt"),
-        default=CONFIG.calibration.method,
-        help="Probability calibration method applied on the validation split.",
-    )
-    parser.add_argument(
-        "--conformal_alpha",
-        type=float,
-        default=0.1,
-        help="Enable conformal prediction intervals at the specified miscoverage level.",
-    )
-    parser.add_argument(
-        "--run-id",
-        type=str,
-        default=None,
-        help="Optional run identifier used when storing artefacts.",
-    )
-    parser.add_argument(
-        "--dump-cv",
-        action="store_true",
-        help="Export purged walk-forward CV splits to reports/cv_<run_id>.json.",
-    )
-    parser.add_argument(
-        "--by_vol_bins",
-        type=int,
-        default=5,
-        help="Number of realised volatility quantiles used for metrics by regime.",
-    )
-    parser.set_defaults(include_onchain=None, include_orderbook=None, include_derivatives=None)
-    return parser
+DEFAULT_MODEL_PATH = Path("artifacts/meta_model.joblib")
 
 
-def main(argv: list[str] | None = None) -> Path:
-    parser = _build_parser()
-    args = parser.parse_args(argv)
+def _run_training(
+    *,
+    features: Optional[Path],
+    symbol: str,
+    db_path: Path,
+    horizon: int,
+    label: Optional[str],
+    model_path: Path,
+    split: str,
+    test_size: float,
+    random_state: int,
+    use_gpu: bool,
+    include_onchain: Optional[bool],
+    include_orderbook: Optional[bool],
+    include_derivatives: Optional[bool],
+    forward_fill_limit: Optional[int],
+    fillna_value: Optional[float],
+    cv_strategy: Optional[str],
+    embargo_min: int,
+    calibration: str,
+    conformal_alpha: Optional[float],
+    run_id: Optional[str],
+    dump_cv: bool,
+    by_vol_bins: int,
+    dry_run: bool,
+) -> Path:
+    if horizon <= 0:
+        raise DataValidationError("--horizon must be positive")
+    if split.lower() != "holdout":
+        raise DataValidationError("Only holdout split is supported in the CLI")
+    if cv_strategy not in (None, "purged-wf"):
+        raise DataValidationError("Only 'purged-wf' cross-validation is supported")
+    if conformal_alpha is not None and not (0.0 < float(conformal_alpha) < 1.0):
+        raise DataValidationError("--conformal-alpha must lie in (0, 1)")
+    if by_vol_bins <= 0:
+        raise DataValidationError("--by-vol-bins must be a positive integer")
 
-    if args.split != "holdout":
-        raise NotImplementedError("Only holdout split is supported in the CLI")
+    settings = _prepare_settings(
+        include_onchain=include_onchain,
+        include_orderbook=include_orderbook,
+        include_derivatives=include_derivatives,
+        forward_fill_limit=forward_fill_limit,
+        fillna_value=fillna_value,
+    )
+    df = _load_features(
+        features=features,
+        symbol=symbol,
+        db_path=db_path,
+        settings=settings,
+    )
 
-    settings = _prepare_settings(args)
-    df = _load_features(args, settings)
-
-    label = args.label or f"cls_sign_{args.horizon}m"
-    df, label_col = _ensure_label(df, args.horizon, label)
+    label_name = label or f"cls_sign_{horizon}m"
+    df, label_col = _ensure_label(df, horizon, label_name)
     df = df.dropna(subset=[label_col]).sort_values("timestamp")
 
-    feature_cols = get_feature_columns(settings)
-    if not feature_cols:
-        feature_cols = FEATURE_COLUMNS
-
+    feature_cols = get_feature_columns(settings) or FEATURE_COLUMNS
     missing = [col for col in feature_cols if col not in df.columns]
     if missing:
-        raise KeyError(
-            "Feature columns missing from dataset: " + ", ".join(sorted(missing))
-        )
+        joined = ", ".join(sorted(missing))
+        raise DataValidationError(f"Feature columns missing from dataset: {joined}")
 
     X = df[feature_cols].astype(np.float32)
     y = df[label_col].astype(int)
     timestamps = pd.to_datetime(df["timestamp"], utc=True)
     realized_volatility = _compute_realized_volatility(df)
 
-    run_id = args.run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
-    run_dir = Path("outputs") / f"run_id={run_id}"
-    run_dir.mkdir(parents=True, exist_ok=True)
+    run_id_value = run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
+    run_dir = Path("outputs") / f"run_id={run_id_value}"
     reports_dir = Path("reports")
-    reports_dir.mkdir(parents=True, exist_ok=True)
 
-    if args.conformal_alpha is not None and not (0.0 < float(args.conformal_alpha) < 1.0):
-        raise ValueError("conformal_alpha must lie in (0, 1)")
+    if not dry_run:
+        run_dir.mkdir(parents=True, exist_ok=True)
+        reports_dir.mkdir(parents=True, exist_ok=True)
 
-    if args.cv == "purged-wf":
+    if cv_strategy == "purged-wf" and not dry_run:
         purged_walkforward_splits(
             pd.DatetimeIndex(timestamps),
             n_splits=CONFIG.cv.n_splits,
-            embargo_min=args.embargo_min,
-            run_id=run_id if args.dump_cv else None,
+            embargo_min=embargo_min,
+            run_id=run_id_value if dump_cv else None,
             reports_dir=reports_dir,
         )
 
     X_train_full, X_test, y_train_full, y_test, ts_train_full, ts_test = _chronological_split(
-        X, y, timestamps, args.test_size
+        X, y, timestamps, test_size
     )
     X_train, X_cal, y_train, y_cal, ts_train, ts_cal = _split_calibration(
         X_train_full, y_train_full, ts_train_full
     )
 
-    model_path_default = parser.get_default("model_path")
-    model_output = args.model_path if args.model_path != model_path_default else run_dir / "model.joblib"
-    model_output.parent.mkdir(parents=True, exist_ok=True)
+    model_output = model_path if model_path != DEFAULT_MODEL_PATH else run_dir / "model.joblib"
+    if not dry_run:
+        model_output.parent.mkdir(parents=True, exist_ok=True)
 
-    model = _fit_model(X_train, y_train, use_gpu=not args.no_gpu, random_state=args.random_state)
-    joblib.dump(model, model_output)
+    try:
+        model = _fit_model(X_train, y_train, use_gpu=use_gpu, random_state=random_state)
+    except xgb.core.XGBoostError as exc:  # pragma: no cover - defensive
+        raise ModelError(f"Training failed: {exc}") from exc
+
+    if not dry_run:
+        joblib.dump(model, model_output)
 
     proba_test = model.predict_proba(X_test)[:, 1]
     labels_test = (proba_test >= 0.5).astype(int)
@@ -584,7 +474,9 @@ def main(argv: list[str] | None = None) -> Path:
 
     calibrated_metrics = None
     calibrated_probs = None
-    calibration_method = args.calibration
+    calibration_method = (calibration or "none").lower()
+    if calibration_method not in {"none", "isotonic", "platt"}:
+        raise DataValidationError("Unsupported calibration method")
     if calibration_method != "none" and X_cal is not None and len(X_cal) > 0:
         cal_probs = model.predict_proba(X_cal)[:, 1]
         if calibration_method == "isotonic":
@@ -605,66 +497,199 @@ def main(argv: list[str] | None = None) -> Path:
         }
         reliability_data[f"calibrated_{calibration_method}"] = calibrated_metrics
 
-    reliability_path = reports_dir / f"reliability_{run_id}.png"
-    plot_reliability(y_test, prob_series, reliability_path)
+    if not dry_run:
+        reliability_path = reports_dir / f"reliability_{run_id_value}.png"
+        plot_reliability(y_test, prob_series, reliability_path)
 
-    metrics_by_vol_path = reports_dir / f"metrics_by_vol_{run_id}.csv"
-    reliability_by_vol_path = reports_dir / f"reliability_by_vol_{run_id}.png"
-    if args.by_vol_bins <= 0:
-        raise ValueError("by_vol_bins must be a positive integer")
+        metrics_by_vol_path = reports_dir / f"metrics_by_vol_{run_id_value}.csv"
+        reliability_by_vol_path = reports_dir / f"reliability_by_vol_{run_id_value}.png"
 
-    _export_metrics_by_volatility(
-        y_test,
-        proba_test,
-        realized_volatility.reindex(y_test.index),
-        metrics_by_vol_path,
-        reliability_by_vol_path,
-        calibrated_probs=calibrated_probs,
-        calibration_label=(
-            f"Calibrated ({calibration_method})" if calibrated_probs is not None else None
-        ),
-        n_quantiles=int(args.by_vol_bins),
-    )
-
-    metrics_report = {
-        "run_id": run_id,
-        "raw": metrics_raw,
-        "calibration": calibration_method,
-        "calibrated": calibrated_metrics,
-    }
-
-    metrics_path = reports_dir / f"metrics_{run_id}.json"
-    metrics_payload = json.dumps(metrics_report, indent=2)
-    metrics_path.write_text(metrics_payload, encoding="utf-8")
-    (run_dir / "metrics.json").write_text(metrics_payload, encoding="utf-8")
-
-    reliability_copy = run_dir / "reliability.png"
-    if not reliability_copy.exists():
-        reliability_copy.write_bytes(reliability_path.read_bytes())
-
-    if args.conformal_alpha is not None and X_cal is not None and len(X_cal) > 0:
-        cal_probs = model.predict_proba(X_cal)[:, 1]
-        conformal = conformal_interval(
-            y_cal,
-            cal_probs,
-            (y_test, proba_test),
-            float(args.conformal_alpha),
+        _export_metrics_by_volatility(
+            y_test,
+            proba_test,
+            realized_volatility.reindex(y_test.index),
+            metrics_by_vol_path,
+            reliability_by_vol_path,
+            calibrated_probs=calibrated_probs,
+            calibration_label=(
+                f"Calibrated ({calibration_method})" if calibrated_probs is not None else None
+            ),
+            n_quantiles=int(by_vol_bins),
         )
-        conformal_path = reports_dir / f"conformal_{run_id}.json"
-        conformal_json = json.dumps(conformal, indent=2)
-        conformal_path.write_text(conformal_json, encoding="utf-8")
-        (run_dir / "conformal.json").write_text(conformal_json, encoding="utf-8")
 
-    config_dump = {
-        "config": CONFIG.config_path.as_posix() if CONFIG.config_path else None,
-        "args": {k: (str(v) if isinstance(v, Path) else v) for k, v in vars(args).items()},
-        "features": feature_cols,
-    }
-    (run_dir / "config_dump.json").write_text(json.dumps(config_dump, indent=2), encoding="utf-8")
+        metrics_report = {
+            "run_id": run_id_value,
+            "raw": metrics_raw,
+            "calibration": calibration_method,
+            "calibrated": calibrated_metrics,
+        }
 
-    print(f"Model trained and stored at {model_output}")
+        metrics_path = reports_dir / f"metrics_{run_id_value}.json"
+        metrics_payload = json.dumps(metrics_report, indent=2)
+        metrics_path.write_text(metrics_payload, encoding="utf-8")
+        (run_dir / "metrics.json").write_text(metrics_payload, encoding="utf-8")
+
+        reliability_copy = run_dir / "reliability.png"
+        if not reliability_copy.exists():
+            reliability_copy.write_bytes(reliability_path.read_bytes())
+
+        if conformal_alpha is not None and X_cal is not None and len(X_cal) > 0:
+            cal_probs = model.predict_proba(X_cal)[:, 1]
+            conformal = conformal_interval(
+                y_cal,
+                cal_probs,
+                (y_test, proba_test),
+                float(conformal_alpha),
+            )
+            conformal_path = reports_dir / f"conformal_{run_id_value}.json"
+            conformal_json = json.dumps(conformal, indent=2)
+            conformal_path.write_text(conformal_json, encoding="utf-8")
+            (run_dir / "conformal.json").write_text(conformal_json, encoding="utf-8")
+
+        args_snapshot = {
+            "features": features,
+            "symbol": symbol,
+            "db_path": db_path,
+            "horizon": horizon,
+            "label": label,
+            "model_path": model_path,
+            "split": split,
+            "test_size": test_size,
+            "random_state": random_state,
+            "use_gpu": use_gpu,
+            "include_onchain": include_onchain,
+            "include_orderbook": include_orderbook,
+            "include_derivatives": include_derivatives,
+            "forward_fill_limit": forward_fill_limit,
+            "fillna_value": fillna_value,
+            "cv_strategy": cv_strategy,
+            "embargo_min": embargo_min,
+            "calibration": calibration,
+            "conformal_alpha": conformal_alpha,
+            "run_id": run_id_value,
+            "dump_cv": dump_cv,
+            "by_vol_bins": by_vol_bins,
+        }
+        config_dump = {
+            "config": CONFIG.config_path.as_posix() if CONFIG.config_path else None,
+            "args": {k: (str(v) if isinstance(v, Path) else v) for k, v in args_snapshot.items()},
+            "features": feature_cols,
+        }
+        (run_dir / "config_dump.json").write_text(json.dumps(config_dump, indent=2), encoding="utf-8")
+    else:
+        typer.echo("Dry run requested; metrics and artefacts will not be written.")
+
+    typer.echo(f"Model trained{' (dry run)' if dry_run else ''} and stored at {model_output}")
     return model_output
 
 
+@app.command()
+def main(
+    features: Optional[Path] = typer.Option(
+        None,
+        "--features",
+        exists=False,
+        file_okay=True,
+        dir_okay=False,
+        resolve_path=True,
+        help="Optional engineered feature table (CSV/Parquet).",
+    ),
+    symbol: str = typer.Option(CONFIG.symbol, "--symbol", help="Trading symbol used when sourcing data."),
+    db_path: Path = typer.Option(
+        CONFIG.db_path,
+        "--db-path",
+        exists=False,
+        file_okay=True,
+        dir_okay=False,
+        resolve_path=True,
+        help="SQLite database file to read raw price data from.",
+    ),
+    horizon: int = typer.Option(120, "--horizon", help="Target horizon in minutes for label generation."),
+    label: Optional[str] = typer.Option(None, "--label", help="Existing label column to use."),
+    model_path: Path = typer.Option(
+        DEFAULT_MODEL_PATH,
+        "--model-path",
+        resolve_path=True,
+        help="Output path for the trained model.",
+    ),
+    split: str = typer.Option("holdout", "--split", help="Evaluation split used during training."),
+    test_size: float = typer.Option(0.2, "--test-size", help="Hold-out fraction used for the validation split."),
+    random_state: int = typer.Option(42, "--random-state", help="Random seed used for model training."),
+    use_gpu: bool = typer.Option(True, "--use-gpu/--no-gpu", help="Toggle GPU acceleration."),
+    include_onchain: Optional[bool] = typer.Option(
+        None,
+        "--include-onchain/--exclude-onchain",
+        help="Override on-chain features regardless of config defaults.",
+    ),
+    include_orderbook: Optional[bool] = typer.Option(
+        None,
+        "--include-orderbook/--exclude-orderbook",
+        help="Override orderbook features regardless of config defaults.",
+    ),
+    include_derivatives: Optional[bool] = typer.Option(
+        None,
+        "--include-derivatives/--exclude-derivatives",
+        help="Override derivative features regardless of config defaults.",
+    ),
+    forward_fill_limit: Optional[int] = typer.Option(
+        None, "--forward-fill-limit", help="Override forward-fill window for NaN handling."
+    ),
+    fillna_value: Optional[float] = typer.Option(
+        None, "--fillna-value", help="Override fallback value used when forward fill runs out."
+    ),
+    cv_strategy: Optional[str] = typer.Option(
+        None, "--cv", help="Optional cross-validation strategy to evaluate during training."
+    ),
+    embargo_min: int = typer.Option(
+        CONFIG.cv.embargo_min,
+        "--embargo-min",
+        help="Embargo window in minutes used for purged walk-forward cross-validation.",
+    ),
+    calibration: str = typer.Option(
+        CONFIG.calibration.method,
+        "--calibration",
+        help="Probability calibration method applied on the validation split.",
+    ),
+    conformal_alpha: Optional[float] = typer.Option(
+        0.1, "--conformal-alpha", help="Enable conformal prediction intervals at the specified miscoverage level."
+    ),
+    run_id: Optional[str] = typer.Option(None, "--run-id", help="Optional run identifier."),
+    dump_cv: bool = typer.Option(
+        False, "--dump-cv", help="Export purged walk-forward CV splits to reports/cv_<run_id>.json."
+    ),
+    by_vol_bins: int = typer.Option(
+        5, "--by-vol-bins", help="Number of realised volatility quantiles used for metrics by regime."
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview actions without writing."),
+) -> None:
+    cv_normalised = cv_strategy.lower() if cv_strategy else None
+    calibration_normalised = calibration.lower()
+    _run_training(
+        features=features,
+        symbol=symbol,
+        db_path=db_path,
+        horizon=horizon,
+        label=label,
+        model_path=model_path,
+        split=split,
+        test_size=test_size,
+        random_state=random_state,
+        use_gpu=use_gpu,
+        include_onchain=include_onchain,
+        include_orderbook=include_orderbook,
+        include_derivatives=include_derivatives,
+        forward_fill_limit=forward_fill_limit,
+        fillna_value=fillna_value,
+        cv_strategy=cv_normalised,
+        embargo_min=embargo_min,
+        calibration=calibration_normalised,
+        conformal_alpha=conformal_alpha,
+        run_id=run_id,
+        dump_cv=dump_cv,
+        by_vol_bins=by_vol_bins,
+        dry_run=dry_run,
+    )
+
+
 if __name__ == "__main__":  # pragma: no cover - CLI behaviour
-    main()
+    run_cli(app)

--- a/src/crypto_analyzer/config/schema.py
+++ b/src/crypto_analyzer/config/schema.py
@@ -1,0 +1,195 @@
+"""Pydantic models describing the application configuration schema."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class _BaseModel(BaseModel):
+    """Helper base class providing common configuration."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class CoreSettings(_BaseModel):
+    symbol: str = "BTCUSDT"
+    interval: str = "15m"
+    forward_steps: int = Field(default=8, ge=1)
+    history_days: int = Field(default=5 * 365, ge=1)
+    timezone: str = "UTC"
+
+
+class DatabaseSettings(_BaseModel):
+    price_store: Path = Path("data/crypto_data.sqlite")
+    predictions_table: str = "predictions"
+    onchain_table: str = "onchain_15m"
+    feature_store: Path | None = None
+    read_chunksize: int = Field(default=100_000, ge=1)
+
+
+class RuntimeSettings(_BaseModel):
+    cpu_limit: int = Field(default=-1)
+    repeat_count: int = Field(default=50, ge=1)
+    log_level: str = "INFO"
+    data_dir: Path = Path("data")
+    cache_dir: Path = Path("data/cache")
+    tmp_dir: Path = Path("data/tmp")
+
+
+class FeatureSettings(_BaseModel):
+    include_onchain: bool = True
+    include_orderbook: bool = True
+    include_derivatives: bool = True
+    forward_fill_limit: int = Field(default=12)
+    fillna_value: float = 0.0
+
+
+class ModelSettings(_BaseModel):
+    directory: Path = Path("artifacts/models")
+    weights_glob: str = "artifacts/backtest_acc_*.json"
+    use_gpu: bool = True
+    gpu_tree_method: str = "gpu_hist"
+    max_models: int = Field(default=16, ge=1)
+    random_seed: int = Field(default=1337)
+
+
+class BacktestSettings(_BaseModel):
+    mode: str = "holdout"
+    validation_fraction: float = Field(default=0.2, ge=0.0, le=1.0)
+    walkforward_window_days: int = Field(default=30, ge=1)
+    metrics: tuple[str, ...] = ("accuracy", "precision", "recall")
+
+
+class OnChainSettings(_BaseModel):
+    use_mempool: bool = True
+    use_exchange_flows: bool = True
+    use_usdt_events: bool = True
+    cache_dir: Path = Path("data/cache/onchain")
+    glassnode_api_key: str | None = None
+    whale_api_key: str | None = None
+    exchange_flow_source: Literal["csv", "api"] = "csv"
+    exchange_flow_path: Path | None = None
+    request_timeout: int = Field(default=10, ge=0)
+    request_retries: int = Field(default=5, ge=0)
+
+
+class CVSettings(_BaseModel):
+    type: str = "holdout"
+    embargo_min: int = Field(default=0, ge=0)
+    n_splits: int = Field(default=5, ge=1)
+
+
+class CalibrationSettings(_BaseModel):
+    method: str = "none"
+
+
+class ExecutionSettings(_BaseModel):
+    fees_bps: float = Field(default=0.0)
+    slip_bps: float = Field(default=0.0)
+    latency_min: float = Field(default=0.0)
+
+    @field_validator("fees_bps", mode="after")
+    @classmethod
+    def _ensure_non_negative(cls, value: float) -> float:
+        if value < 0:
+            raise ValueError("fees_bps must be non-negative")
+        return value
+
+
+class DerivativeDataSettings(_BaseModel):
+    funding_source: Path | None = None
+    basis_source: Path | None = None
+    open_interest_source: Path | None = None
+    resample_freq: str = "5T"
+
+
+class OrderbookSettings(_BaseModel):
+    depth_levels: int = Field(default=5, ge=1)
+
+
+class AppConfig(_BaseModel):
+    core: CoreSettings
+    database: DatabaseSettings
+    runtime: RuntimeSettings
+    features: FeatureSettings
+    models: ModelSettings
+    backtest: BacktestSettings
+    onchain: OnChainSettings
+    cv: CVSettings
+    calibration: CalibrationSettings
+    execution: ExecutionSettings
+    horizons: tuple[int, ...]
+    pct_threshold: float
+    derivatives: DerivativeDataSettings
+    orderbook: OrderbookSettings
+    config_path: Path | None = None
+
+    @field_validator("horizons", mode="before")
+    @classmethod
+    def _coerce_horizons(cls, value: object) -> tuple[int, ...]:
+        if value is None:
+            return tuple()
+        if isinstance(value, (list, tuple, set)):
+            return tuple(int(v) for v in value)
+        return (int(value),)
+
+    @model_validator(mode="after")
+    def _validate_ranges(self) -> "AppConfig":
+        if not (0 < self.pct_threshold < 0.1):
+            raise ValueError("pct_threshold must be between 0 and 0.1")
+        if self.horizons:
+            max_horizon = max(self.horizons)
+        else:
+            max_horizon = 0
+        if self.cv.embargo_min < max_horizon:
+            raise ValueError("cv.embargo_min must be greater than or equal to the maximum horizon")
+        return self
+
+    @property
+    def symbol(self) -> str:
+        return self.core.symbol
+
+    @property
+    def interval(self) -> str:
+        return self.core.interval
+
+    @property
+    def forward_steps(self) -> int:
+        return self.core.forward_steps
+
+    @property
+    def db_path(self) -> Path:
+        return self.database.price_store
+
+    @property
+    def table_pred(self) -> str:
+        return self.database.predictions_table
+
+    @property
+    def cpu_limit(self) -> int:
+        return self.runtime.cpu_limit
+
+    @property
+    def repeat_count(self) -> int:
+        return self.runtime.repeat_count
+
+
+__all__ = [
+    "AppConfig",
+    "BacktestSettings",
+    "CalibrationSettings",
+    "CoreSettings",
+    "CVSettings",
+    "DatabaseSettings",
+    "DerivativeDataSettings",
+    "ExecutionSettings",
+    "FeatureSettings",
+    "ModelSettings",
+    "OnChainSettings",
+    "OrderbookSettings",
+    "RuntimeSettings",
+]
+

--- a/src/crypto_analyzer/utils/cli.py
+++ b/src/crypto_analyzer/utils/cli.py
@@ -1,0 +1,27 @@
+"""Utilities shared across Typer-based CLI entrypoints."""
+
+from __future__ import annotations
+
+import typer
+
+from crypto_analyzer.utils.errors import ConfigError, DataValidationError, ModelError
+
+
+def run_cli(app: typer.Typer) -> None:
+    """Execute *app* while mapping domain exceptions to exit codes."""
+
+    try:
+        app()
+    except DataValidationError as exc:
+        typer.secho(str(exc), err=True, fg=typer.colors.RED)
+        raise SystemExit(2) from exc
+    except ConfigError as exc:
+        typer.secho(str(exc), err=True, fg=typer.colors.RED)
+        raise SystemExit(3) from exc
+    except ModelError as exc:
+        typer.secho(str(exc), err=True, fg=typer.colors.RED)
+        raise SystemExit(4) from exc
+
+
+__all__ = ["run_cli"]
+

--- a/src/crypto_analyzer/utils/config.py
+++ b/src/crypto_analyzer/utils/config.py
@@ -1,12 +1,31 @@
+"""Configuration loading helpers."""
+
 from __future__ import annotations
 
 import os
-from dataclasses import asdict, dataclass, is_dataclass, replace
 from pathlib import Path
 from typing import Any
 
 import yaml
 from dotenv import load_dotenv
+from pydantic import ValidationError
+
+from crypto_analyzer.config.schema import (
+    AppConfig,
+    BacktestSettings,
+    CalibrationSettings,
+    CoreSettings,
+    CVSettings,
+    DatabaseSettings,
+    DerivativeDataSettings,
+    ExecutionSettings,
+    FeatureSettings,
+    ModelSettings,
+    OnChainSettings,
+    OrderbookSettings,
+    RuntimeSettings,
+)
+from crypto_analyzer.utils.errors import ConfigError
 
 CONFIG_FILE_ENV = "APP_CONFIG_FILE"
 
@@ -14,164 +33,6 @@ _TRUE_VALUES = {"1", "true", "yes", "on"}
 _FALSE_VALUES = {"0", "false", "no", "off"}
 
 load_dotenv(override=False)
-
-
-@dataclass(frozen=True)
-class CoreSettings:
-    symbol: str
-    interval: str
-    forward_steps: int
-    history_days: int
-    timezone: str
-
-
-@dataclass(frozen=True)
-class DatabaseSettings:
-    price_store: str
-    predictions_table: str
-    onchain_table: str
-    feature_store: str | None
-    read_chunksize: int
-
-
-@dataclass(frozen=True)
-class RuntimeSettings:
-    cpu_limit: int
-    repeat_count: int
-    log_level: str
-    data_dir: str
-    cache_dir: str
-    tmp_dir: str
-
-
-@dataclass(frozen=True)
-class FeatureSettings:
-    include_onchain: bool
-    include_orderbook: bool
-    include_derivatives: bool
-    forward_fill_limit: int
-    fillna_value: float
-
-
-@dataclass(frozen=True)
-class ModelSettings:
-    directory: str
-    weights_glob: str
-    use_gpu: bool
-    gpu_tree_method: str
-    max_models: int
-    random_seed: int
-
-
-@dataclass(frozen=True)
-class BacktestSettings:
-    mode: str
-    validation_fraction: float
-    walkforward_window_days: int
-    metrics: tuple[str, ...]
-
-
-@dataclass(frozen=True)
-class OnChainSettings:
-    use_mempool: bool
-    use_exchange_flows: bool
-    use_usdt_events: bool
-    cache_dir: str
-    glassnode_api_key: str | None
-    whale_api_key: str | None
-    exchange_flow_source: str
-    exchange_flow_path: str | None
-    request_timeout: int
-    request_retries: int
-
-
-@dataclass(frozen=True)
-class CVSettings:
-    """Cross-validation defaults loaded from the configuration file."""
-
-    type: str
-    embargo_min: int
-    n_splits: int
-
-
-@dataclass(frozen=True)
-class CalibrationSettings:
-    """Probability calibration defaults for training scripts."""
-
-    method: str
-
-
-@dataclass(frozen=True)
-class ExecutionSettings:
-    """Assumptions about trading frictions used across backtests."""
-
-    fees_bps: float
-    slip_bps: float
-    latency_min: float
-
-
-@dataclass(frozen=True)
-class DerivativeDataSettings:
-    """Metadata pointing to external derivative data sources."""
-
-    funding_source: str | None
-    basis_source: str | None
-    open_interest_source: str | None
-    resample_freq: str
-
-
-@dataclass(frozen=True)
-class OrderbookSettings:
-    """Configuration for optional order book feature generation."""
-
-    depth_levels: int
-
-
-@dataclass(frozen=True)
-class AppConfig:
-    core: CoreSettings
-    database: DatabaseSettings
-    runtime: RuntimeSettings
-    features: FeatureSettings
-    models: ModelSettings
-    backtest: BacktestSettings
-    onchain: OnChainSettings
-    cv: CVSettings
-    calibration: CalibrationSettings
-    execution: ExecutionSettings
-    horizons: tuple[int, ...]
-    pct_threshold: float
-    derivatives: DerivativeDataSettings
-    orderbook: OrderbookSettings
-    config_path: Path | None = None
-
-    @property
-    def symbol(self) -> str:
-        return self.core.symbol
-
-    @property
-    def interval(self) -> str:
-        return self.core.interval
-
-    @property
-    def forward_steps(self) -> int:
-        return self.core.forward_steps
-
-    @property
-    def db_path(self) -> str:
-        return self.database.price_store
-
-    @property
-    def table_pred(self) -> str:
-        return self.database.predictions_table
-
-    @property
-    def cpu_limit(self) -> int:
-        return self.runtime.cpu_limit
-
-    @property
-    def repeat_count(self) -> int:
-        return self.runtime.repeat_count
 
 
 def _read_config_file() -> tuple[dict[str, Any], Path | None]:
@@ -196,7 +57,8 @@ def _read_config_file() -> tuple[dict[str, Any], Path | None]:
 def _as_str(value: Any, default: str) -> str:
     if value is None:
         return default
-    return str(value)
+    text = str(value).strip()
+    return default if not text else text
 
 
 def _as_int(value: Any, default: int) -> int:
@@ -204,17 +66,10 @@ def _as_int(value: Any, default: int) -> int:
         return default
     if isinstance(value, int):
         return value
-    if isinstance(value, float):
+    if isinstance(value, float) and value.is_integer():
         return int(value)
-    if isinstance(value, str):
-        value = value.strip()
-        if not value:
-            return default
-        lowered = value.lower()
-        if lowered in {"auto", "max", "all"}:
-            return default
     try:
-        return int(value)
+        return int(str(value).strip())
     except (TypeError, ValueError):
         return default
 
@@ -224,12 +79,10 @@ def _as_float(value: Any, default: float) -> float:
         return default
     if isinstance(value, (int, float)):
         return float(value)
-    if isinstance(value, str):
-        try:
-            return float(value)
-        except ValueError:
-            return default
-    return default
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return default
 
 
 def _as_bool(value: Any, default: bool) -> bool:
@@ -249,12 +102,12 @@ def _as_bool(value: Any, default: bool) -> bool:
         return default
 
 
-def _as_list(value: Any, default: list[str]) -> list[str]:
+def _as_list(value: Any, default: list[Any]) -> list[Any]:
     if value is None:
         return list(default)
     if isinstance(value, (list, tuple, set)):
-        return [str(item) for item in value]
-    return [str(value)]
+        return list(value)
+    return [value]
 
 
 def _resolve_cpu_limit(value: Any) -> int:
@@ -269,20 +122,21 @@ def _resolve_cpu_limit(value: Any) -> int:
         limit = int(value)
     except (TypeError, ValueError):
         return default
-    return limit if limit != 0 else default
+    return default if limit == 0 else limit
 
 
 def _build_core_settings(data: dict[str, Any]) -> CoreSettings:
-    symbol = os.getenv("SYMBOL") or _as_str(data.get("symbol"), "BTCUSDT")
-    interval = os.getenv("INTERVAL") or _as_str(data.get("interval"), "15m")
+    defaults = CoreSettings()
+    symbol = os.getenv("SYMBOL") or _as_str(data.get("symbol"), defaults.symbol)
+    interval = os.getenv("INTERVAL") or _as_str(data.get("interval"), defaults.interval)
     forward_env = os.getenv("FORWARD_STEPS")
     forward_steps = (
-        int(forward_env)
+        _as_int(forward_env, defaults.forward_steps)
         if forward_env is not None
-        else _as_int(data.get("forward_steps"), 8)
+        else _as_int(data.get("forward_steps"), defaults.forward_steps)
     )
-    history_days = _as_int(data.get("history_days"), 5 * 365)
-    timezone = _as_str(data.get("timezone"), "UTC")
+    history_days = _as_int(data.get("history_days"), defaults.history_days)
+    timezone = _as_str(data.get("timezone"), defaults.timezone)
     return CoreSettings(
         symbol=symbol,
         interval=interval,
@@ -293,38 +147,42 @@ def _build_core_settings(data: dict[str, Any]) -> CoreSettings:
 
 
 def _build_database_settings(data: dict[str, Any]) -> DatabaseSettings:
-    db_path = os.getenv("DB_PATH") or _as_str(
-        data.get("price_store"), "data/crypto_data.sqlite"
-    )
+    defaults = DatabaseSettings()
+    db_path = os.getenv("DB_PATH") or _as_str(data.get("price_store"), str(defaults.price_store))
     table_pred = os.getenv("TABLE_PRED") or _as_str(
-        data.get("predictions_table"), "predictions"
+        data.get("predictions_table"), defaults.predictions_table
     )
-    onchain_table = _as_str(data.get("onchain_table"), "onchain_15m")
-    feature_store = data.get("feature_store")
-    feature_store_str = str(feature_store) if feature_store not in (None, "") else None
-    read_chunksize = _as_int(data.get("read_chunksize"), 100_000)
+    onchain_table = _as_str(data.get("onchain_table"), defaults.onchain_table)
+    feature_store_value = data.get("feature_store")
+    feature_store = (
+        str(feature_store_value)
+        if feature_store_value not in (None, "")
+        else defaults.feature_store
+    )
+    read_chunksize = _as_int(data.get("read_chunksize"), defaults.read_chunksize)
     return DatabaseSettings(
-        price_store=db_path,
+        price_store=Path(db_path),
         predictions_table=table_pred,
         onchain_table=onchain_table,
-        feature_store=feature_store_str,
+        feature_store=Path(feature_store) if feature_store else None,
         read_chunksize=read_chunksize,
     )
 
 
 def _build_runtime_settings(data: dict[str, Any]) -> RuntimeSettings:
+    defaults = RuntimeSettings()
     cpu_env = os.getenv("CPU_LIMIT")
     cpu_limit = _resolve_cpu_limit(cpu_env if cpu_env is not None else data.get("cpu_limit"))
     repeat_env = os.getenv("REPEAT_COUNT")
     repeat_count = (
-        int(repeat_env)
+        _as_int(repeat_env, defaults.repeat_count)
         if repeat_env is not None
-        else _as_int(data.get("repeat_count"), 50)
+        else _as_int(data.get("repeat_count"), defaults.repeat_count)
     )
-    log_level = _as_str(data.get("log_level"), "INFO")
-    data_dir = _as_str(data.get("data_dir"), "data")
-    cache_dir = _as_str(data.get("cache_dir"), "data/cache")
-    tmp_dir = _as_str(data.get("tmp_dir"), "data/tmp")
+    log_level = _as_str(data.get("log_level"), defaults.log_level)
+    data_dir = Path(_as_str(data.get("data_dir"), str(defaults.data_dir)))
+    cache_dir = Path(_as_str(data.get("cache_dir"), str(defaults.cache_dir)))
+    tmp_dir = Path(_as_str(data.get("tmp_dir"), str(defaults.tmp_dir)))
     return RuntimeSettings(
         cpu_limit=cpu_limit,
         repeat_count=repeat_count,
@@ -336,11 +194,12 @@ def _build_runtime_settings(data: dict[str, Any]) -> RuntimeSettings:
 
 
 def _build_feature_settings(data: dict[str, Any]) -> FeatureSettings:
-    include_onchain = _as_bool(data.get("include_onchain"), True)
-    include_orderbook = _as_bool(data.get("include_orderbook"), True)
-    include_derivatives = _as_bool(data.get("include_derivatives"), True)
-    forward_fill_limit = _as_int(data.get("forward_fill_limit"), 12)
-    fillna_value = _as_float(data.get("fillna_value"), 0.0)
+    defaults = FeatureSettings()
+    include_onchain = _as_bool(data.get("include_onchain"), defaults.include_onchain)
+    include_orderbook = _as_bool(data.get("include_orderbook"), defaults.include_orderbook)
+    include_derivatives = _as_bool(data.get("include_derivatives"), defaults.include_derivatives)
+    forward_fill_limit = _as_int(data.get("forward_fill_limit"), defaults.forward_fill_limit)
+    fillna_value = _as_float(data.get("fillna_value"), defaults.fillna_value)
     return FeatureSettings(
         include_onchain=include_onchain,
         include_orderbook=include_orderbook,
@@ -351,12 +210,13 @@ def _build_feature_settings(data: dict[str, Any]) -> FeatureSettings:
 
 
 def _build_model_settings(data: dict[str, Any]) -> ModelSettings:
-    directory = _as_str(data.get("directory"), "artifacts/models")
-    weights_glob = _as_str(data.get("weights_glob"), "artifacts/backtest_acc_*.json")
-    use_gpu = _as_bool(data.get("use_gpu"), True)
-    gpu_tree_method = _as_str(data.get("gpu_tree_method"), "gpu_hist")
-    max_models = _as_int(data.get("max_models"), 16)
-    random_seed = _as_int(data.get("random_seed"), 1337)
+    defaults = ModelSettings()
+    directory = Path(_as_str(data.get("directory"), str(defaults.directory)))
+    weights_glob = _as_str(data.get("weights_glob"), defaults.weights_glob)
+    use_gpu = _as_bool(data.get("use_gpu"), defaults.use_gpu)
+    gpu_tree_method = _as_str(data.get("gpu_tree_method"), defaults.gpu_tree_method)
+    max_models = _as_int(data.get("max_models"), defaults.max_models)
+    random_seed = _as_int(data.get("random_seed"), defaults.random_seed)
     return ModelSettings(
         directory=directory,
         weights_glob=weights_glob,
@@ -368,10 +228,13 @@ def _build_model_settings(data: dict[str, Any]) -> ModelSettings:
 
 
 def _build_backtest_settings(data: dict[str, Any]) -> BacktestSettings:
-    mode = _as_str(data.get("mode"), "holdout")
-    validation_fraction = _as_float(data.get("validation_fraction"), 0.2)
-    walkforward_window_days = _as_int(data.get("walkforward_window_days"), 30)
-    metrics = tuple(_as_list(data.get("metrics"), ["accuracy", "precision", "recall"]))
+    defaults = BacktestSettings()
+    mode = _as_str(data.get("mode"), defaults.mode)
+    validation_fraction = _as_float(data.get("validation_fraction"), defaults.validation_fraction)
+    walkforward_window_days = _as_int(
+        data.get("walkforward_window_days"), defaults.walkforward_window_days
+    )
+    metrics = tuple(str(item) for item in _as_list(data.get("metrics"), list(defaults.metrics)))
     return BacktestSettings(
         mode=mode,
         validation_fraction=validation_fraction,
@@ -383,33 +246,35 @@ def _build_backtest_settings(data: dict[str, Any]) -> BacktestSettings:
 def _build_onchain_settings(
     data: dict[str, Any], runtime: RuntimeSettings
 ) -> OnChainSettings:
-    use_mempool = _as_bool(data.get("use_mempool"), True)
-    use_exchange_flows = _as_bool(data.get("use_exchange_flows"), True)
-    use_usdt_events = _as_bool(data.get("use_usdt_events"), True)
-    cache_default = Path(runtime.cache_dir) / "onchain"
-    cache_dir = _as_str(data.get("cache_dir"), str(cache_default))
-    glassnode_api_key = data.get("glassnode_api_key")
-    if glassnode_api_key is not None:
-        glassnode_api_key = str(glassnode_api_key) or None
-    whale_api_key = data.get("whale_api_key")
-    if whale_api_key is not None:
-        whale_api_key = str(whale_api_key) or None
-    exchange_flow_source = _as_str(data.get("exchange_flow_source"), "csv")
-    exchange_flow_path_value = data.get("exchange_flow_path")
-    exchange_flow_path = (
-        str(exchange_flow_path_value)
-        if exchange_flow_path_value not in (None, "")
-        else None
+    defaults = OnChainSettings()
+    use_mempool = _as_bool(data.get("use_mempool"), defaults.use_mempool)
+    use_exchange_flows = _as_bool(
+        data.get("use_exchange_flows"), defaults.use_exchange_flows
     )
-    request_timeout = _as_int(data.get("request_timeout"), 10)
-    request_retries = _as_int(data.get("request_retries"), 5)
+    use_usdt_events = _as_bool(data.get("use_usdt_events"), defaults.use_usdt_events)
+    cache_default = runtime.cache_dir / "onchain"
+    cache_dir = Path(_as_str(data.get("cache_dir"), str(cache_default)))
+    glassnode_api_key = data.get("glassnode_api_key")
+    glassnode = str(glassnode_api_key).strip() or None if glassnode_api_key is not None else None
+    whale_api_key = data.get("whale_api_key")
+    whale = str(whale_api_key).strip() or None if whale_api_key is not None else None
+    exchange_flow_source = _as_str(
+        data.get("exchange_flow_source"), defaults.exchange_flow_source
+    )
+    exchange_flow_path_value = data.get("exchange_flow_path")
+    if exchange_flow_path_value in (None, ""):
+        exchange_flow_path = None
+    else:
+        exchange_flow_path = Path(str(exchange_flow_path_value))
+    request_timeout = _as_int(data.get("request_timeout"), defaults.request_timeout)
+    request_retries = _as_int(data.get("request_retries"), defaults.request_retries)
     return OnChainSettings(
         use_mempool=use_mempool,
         use_exchange_flows=use_exchange_flows,
         use_usdt_events=use_usdt_events,
         cache_dir=cache_dir,
-        glassnode_api_key=glassnode_api_key,
-        whale_api_key=whale_api_key,
+        glassnode_api_key=glassnode,
+        whale_api_key=whale,
         exchange_flow_source=exchange_flow_source,
         exchange_flow_path=exchange_flow_path,
         request_timeout=request_timeout,
@@ -418,82 +283,98 @@ def _build_onchain_settings(
 
 
 def _build_cv_settings(data: dict[str, Any]) -> CVSettings:
-    cv_type = _as_str(data.get("type"), "holdout")
-    embargo = _as_int(data.get("embargo_min"), 0)
-    n_splits = _as_int(data.get("n_splits"), 5)
+    defaults = CVSettings()
+    cv_type = _as_str(data.get("type"), defaults.type)
+    embargo = _as_int(data.get("embargo_min"), defaults.embargo_min)
+    n_splits = _as_int(data.get("n_splits"), defaults.n_splits)
     return CVSettings(type=cv_type, embargo_min=embargo, n_splits=n_splits)
 
 
 def _build_calibration_settings(data: dict[str, Any]) -> CalibrationSettings:
-    method = _as_str(data.get("method"), "none").lower()
+    defaults = CalibrationSettings()
+    method = _as_str(data.get("method"), defaults.method).lower()
     return CalibrationSettings(method=method)
 
 
 def _build_execution_settings(data: dict[str, Any]) -> ExecutionSettings:
-    fees_bps = _as_float(data.get("fees_bps"), 0.0)
-    slip_bps = _as_float(data.get("slip_bps"), 0.0)
-    latency = _as_float(data.get("latency_min"), 0.0)
+    defaults = ExecutionSettings()
+    fees_bps = _as_float(data.get("fees_bps"), defaults.fees_bps)
+    slip_bps = _as_float(data.get("slip_bps"), defaults.slip_bps)
+    latency = _as_float(data.get("latency_min"), defaults.latency_min)
     return ExecutionSettings(fees_bps=fees_bps, slip_bps=slip_bps, latency_min=latency)
 
 
 def _build_derivative_settings(data: dict[str, Any]) -> DerivativeDataSettings:
+    defaults = DerivativeDataSettings()
     funding_source = data.get("funding_source")
     basis_source = data.get("basis_source")
     oi_source = data.get("open_interest_source")
-    freq = _as_str(data.get("resample_freq"), "5T")
+    freq = _as_str(data.get("resample_freq"), defaults.resample_freq)
     return DerivativeDataSettings(
-        funding_source=str(funding_source) if funding_source not in (None, "") else None,
-        basis_source=str(basis_source) if basis_source not in (None, "") else None,
-        open_interest_source=str(oi_source) if oi_source not in (None, "") else None,
+        funding_source=Path(funding_source) if funding_source not in (None, "") else None,
+        basis_source=Path(basis_source) if basis_source not in (None, "") else None,
+        open_interest_source=Path(oi_source) if oi_source not in (None, "") else None,
         resample_freq=freq,
     )
 
 
 def _build_orderbook_settings(data: dict[str, Any]) -> OrderbookSettings:
-    depth_levels = _as_int(data.get("depth_levels"), 5)
+    defaults = OrderbookSettings()
+    depth_levels = _as_int(data.get("depth_levels"), defaults.depth_levels)
     if depth_levels <= 0:
-        depth_levels = 1
+        depth_levels = defaults.depth_levels
     return OrderbookSettings(depth_levels=depth_levels)
 
 
 def _build_config() -> AppConfig:
     raw_config, path = _read_config_file()
-    core = _build_core_settings(raw_config.get("core", {}))
-    database = _build_database_settings(raw_config.get("database", {}))
-    runtime = _build_runtime_settings(raw_config.get("runtime", {}))
-    features = _build_feature_settings(raw_config.get("features", {}))
-    models = _build_model_settings(raw_config.get("models", {}))
-    backtest = _build_backtest_settings(raw_config.get("backtest", {}))
-    onchain = _build_onchain_settings(raw_config.get("onchain", {}), runtime)
-    cv = _build_cv_settings(raw_config.get("cv", {}))
-    calibration = _build_calibration_settings(raw_config.get("calibration", {}))
-    execution = _build_execution_settings(raw_config.get("execution", {}))
-    derivatives = _build_derivative_settings(raw_config.get("derivatives", {}))
-    orderbook = _build_orderbook_settings(raw_config.get("orderbook", {}))
-    horizons = tuple(int(float(x)) for x in _as_list(raw_config.get("horizons"), [core.forward_steps * 15]))
-    pct_threshold = _as_float(raw_config.get("pct_threshold"), 0.0)
-    return AppConfig(
-        core=core,
-        database=database,
-        runtime=runtime,
-        features=features,
-        models=models,
-        backtest=backtest,
-        onchain=onchain,
-        cv=cv,
-        calibration=calibration,
-        execution=execution,
-        horizons=horizons,
-        pct_threshold=pct_threshold,
-        derivatives=derivatives,
-        orderbook=orderbook,
-        config_path=path,
-    )
+    try:
+        core = _build_core_settings(raw_config.get("core", {}))
+        database = _build_database_settings(raw_config.get("database", {}))
+        runtime = _build_runtime_settings(raw_config.get("runtime", {}))
+        features = _build_feature_settings(raw_config.get("features", {}))
+        models = _build_model_settings(raw_config.get("models", {}))
+        backtest = _build_backtest_settings(raw_config.get("backtest", {}))
+        onchain = _build_onchain_settings(raw_config.get("onchain", {}), runtime)
+        cv = _build_cv_settings(raw_config.get("cv", {}))
+        calibration = _build_calibration_settings(raw_config.get("calibration", {}))
+        execution = _build_execution_settings(raw_config.get("execution", {}))
+        derivatives = _build_derivative_settings(raw_config.get("derivatives", {}))
+        orderbook = _build_orderbook_settings(raw_config.get("orderbook", {}))
+        horizons = tuple(int(float(x)) for x in _as_list(raw_config.get("horizons"), []))
+        if not horizons:
+            default_horizon = core.forward_steps * 15
+            horizons = (default_horizon,)
+        pct_threshold = _as_float(raw_config.get("pct_threshold"), 0.01)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise ConfigError(f"Unable to parse configuration: {exc}") from exc
+
+    try:
+        config = AppConfig(
+            core=core,
+            database=database,
+            runtime=runtime,
+            features=features,
+            models=models,
+            backtest=backtest,
+            onchain=onchain,
+            cv=cv,
+            calibration=calibration,
+            execution=execution,
+            horizons=horizons,
+            pct_threshold=pct_threshold,
+            derivatives=derivatives,
+            orderbook=orderbook,
+            config_path=path,
+        )
+    except ValidationError as exc:  # pragma: no cover - defensive
+        raise ConfigError(f"Invalid configuration: {exc}") from exc
+    return config
 
 
 CONFIG = _build_config()
 
- 
+
 def override_feature_settings(
     settings: FeatureSettings,
     *,
@@ -518,7 +399,13 @@ def override_feature_settings(
         updates["fillna_value"] = float(fillna_value)
     if not updates:
         return settings
-    return replace(settings, **updates)
+    return settings.model_copy(update=updates)
+
+
+def config_to_dict(config: AppConfig) -> dict[str, Any]:
+    """Return a JSON/YAML serialisable representation of *config*."""
+
+    return config.model_dump(mode="json")
 
 
 __all__ = [
@@ -535,22 +422,3 @@ __all__ = [
     "config_to_dict",
 ]
 
-
-def _serialise(value: Any) -> Any:
-    if is_dataclass(value):
-        return {k: _serialise(v) for k, v in asdict(value).items()}
-    if isinstance(value, Path):
-        return str(value)
-    if isinstance(value, tuple):
-        return [_serialise(v) for v in value]
-    if isinstance(value, list):
-        return [_serialise(v) for v in value]
-    if isinstance(value, dict):
-        return {k: _serialise(v) for k, v in value.items()}
-    return value
-
-
-def config_to_dict(config: AppConfig) -> dict[str, Any]:
-    """Return a JSON/YAML serialisable representation of *config*."""
-
-    return _serialise(config)

--- a/src/crypto_analyzer/utils/errors.py
+++ b/src/crypto_analyzer/utils/errors.py
@@ -1,0 +1,23 @@
+"""Custom exception hierarchy used across CLI utilities."""
+
+from __future__ import annotations
+
+
+class CryptoAnalyzerError(Exception):
+    """Base class for domain specific exceptions."""
+
+
+class DataValidationError(CryptoAnalyzerError):
+    """Raised when user supplied data or CLI arguments are invalid."""
+
+
+class ConfigError(CryptoAnalyzerError):
+    """Raised when configuration loading or validation fails."""
+
+
+class ModelError(CryptoAnalyzerError):
+    """Raised for model and training related failures."""
+
+
+__all__ = ["ConfigError", "CryptoAnalyzerError", "DataValidationError", "ModelError"]
+


### PR DESCRIPTION
## Summary
- add a Pydantic-based configuration schema and validate config/app.yaml at load time with range checks
- centralize CLI error handling with custom exceptions and convert the data scripts to Typer apps with dry-run support and validation
- update training CLI to use the new Typer pattern while preserving calibration and reporting features

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d032c05a408327a7ef426fb6143acf