### PR TITLE
Add centralized logging, IO helpers, and standardize metrics outputs

### DIFF
--- a/scripts/ablation.py
+++ b/scripts/ablation.py
@@ -28,8 +28,11 @@ from crypto_analyzer.models.calibration import brier_score
 from crypto_analyzer.utils.cli import run_cli
 from crypto_analyzer.utils.config import CONFIG, FeatureSettings, override_feature_settings
 from crypto_analyzer.utils.errors import DataValidationError
+from crypto_analyzer.utils.io import build_path, initialize_run, save_csv, save_json, save_png
+from crypto_analyzer.utils.logging import get_logger
 
 app = typer.Typer(add_completion=False, no_args_is_help=True)
+logger = get_logger(__name__)
 
 GROUPS = ["price", "volatility", "multi_tf", "derivatives", "orderbook"]
 PATTERNS = {
@@ -152,9 +155,11 @@ def _execute_ablation(
     if missing:
         raise DataValidationError("Missing features: " + ", ".join(sorted(missing)))
 
-    run_id_value = run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
-    reports_dir = Path("reports")
-    reports_dir.mkdir(parents=True, exist_ok=True)
+    run_id_value, run_dir, reports_dir = initialize_run(run_id, deterministic_torch=False)
+    logger.info(
+        "Prepared ablation run",
+        extra={"event": "initialised", "run_id": run_id_value, "rows": int(len(df))},
+    )
 
     timestamps = pd.to_datetime(df["timestamp"], utc=True)
     splits = purged_walkforward_splits(
@@ -162,6 +167,7 @@ def _execute_ablation(
         CONFIG.cv.n_splits,
         CONFIG.cv.embargo_min,
         run_id=run_id_value,
+        reports_dir=reports_dir,
     )
     if not splits:
         raise DataValidationError("No walk-forward splits generated")
@@ -206,31 +212,73 @@ def _execute_ablation(
 
     result_df = pd.DataFrame(results).sort_values("brier")
 
-    csv_path = reports_dir / f"ablation_{run_id_value}.csv"
-    png_path = reports_dir / f"ablation_{run_id_value}.png"
+    csv_path = build_path(
+        f"ablation_{run_id_value}.csv", run_id=run_id_value, location="reports"
+    )
+    png_path = build_path(
+        f"ablation_{run_id_value}.png", run_id=run_id_value, location="reports"
+    )
 
     if dry_run:
         typer.echo("Dry run requested; skipping report generation.")
         typer.echo(f"Results would be stored at {csv_path} and {png_path}")
         return csv_path
 
-    result_df.to_csv(csv_path, index=False)
+    csv_report_path = save_csv(
+        result_df,
+        f"ablation_{run_id_value}.csv",
+        run_id=run_id_value,
+        location="reports",
+        index=False,
+    )
+    save_csv(result_df, "ablation.csv", run_id=run_id_value, index=False)
 
     import matplotlib.pyplot as plt  # local import for hygiene tests
 
-    plt.figure(figsize=(8, 4))
+    fig, ax = plt.subplots(figsize=(8, 4))
     width = 0.25
     x = np.arange(len(result_df))
-    plt.bar(x - width, result_df["brier"], width=width, label="Brier")
-    plt.bar(x, result_df["log_loss"], width=width, label="LogLoss")
-    plt.bar(x + width, result_df["auc"], width=width, label="AUC")
-    plt.xticks(x, result_df["group"], rotation=45)
-    plt.tight_layout()
-    plt.legend()
-    plt.savefig(png_path)
-    plt.close()
-    typer.echo(f"Ablation results stored at {csv_path} and {png_path}")
-    return csv_path
+    ax.bar(x - width, result_df["brier"], width=width, label="Brier")
+    ax.bar(x, result_df["log_loss"], width=width, label="LogLoss")
+    ax.bar(x + width, result_df["auc"], width=width, label="AUC")
+    ax.set_xticks(x)
+    ax.set_xticklabels(result_df["group"], rotation=45)
+    ax.legend()
+    fig.tight_layout()
+    png_report_path = save_png(
+        fig,
+        f"ablation_{run_id_value}.png",
+        run_id=run_id_value,
+        location="reports",
+    )
+    save_png(fig, "ablation.png", run_id=run_id_value)
+    plt.close(fig)
+
+    metadata = {
+        "run_id": run_id_value,
+        "horizon": horizon,
+        "include_onchain": include_onchain,
+        "include_orderbook": include_orderbook,
+        "include_derivatives": include_derivatives,
+        "label": label,
+        "features_path": str(features) if features else None,
+        "symbol": symbol,
+        "db_path": str(db_path),
+    }
+    save_json(metadata, "config_dump.json", run_id=run_id_value)
+
+    logger.info(
+        "Generated ablation reports",
+        extra={
+            "event": "artefacts",
+            "run_id": run_id_value,
+            "csv": str(csv_report_path),
+            "png": str(png_report_path),
+        },
+    )
+
+    typer.echo(f"Ablation results stored at {csv_report_path} and {png_report_path}")
+    return csv_report_path
 
 
 @app.command()

--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Optional
 
@@ -15,8 +14,11 @@ from crypto_analyzer.eval.threshold_sweep import SweepParams, sweep_threshold_gr
 from crypto_analyzer.utils.cli import run_cli
 from crypto_analyzer.utils.config import CONFIG
 from crypto_analyzer.utils.errors import DataValidationError
+from crypto_analyzer.utils.io import build_path, initialize_run, save_csv, save_json
+from crypto_analyzer.utils.logging import get_logger
 
 app = typer.Typer(add_completion=False, no_args_is_help=True)
+logger = get_logger(__name__)
 
 
 def _read_predictions(path: Path) -> pd.DataFrame:
@@ -155,9 +157,11 @@ def _run_backtest(
         p_up_threshold=p_up_thr,
     )
 
-    run_id_value = run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
-    run_dir = Path("outputs") / f"run_id={run_id_value}"
-    reports_dir = Path("reports")
+    run_id_value, run_dir, reports_dir = initialize_run(run_id, deterministic_torch=False)
+    logger.info(
+        "Prepared backtest run",
+        extra={"event": "initialised", "run_id": run_id_value, "rows": int(len(normalised))},
+    )
 
     equity = result["equity"].assign(run_id=run_id_value)
     metrics = result["metrics"]
@@ -184,8 +188,12 @@ def _run_backtest(
                     display = f"{numeric_value:.6f}"
         typer.echo(f"{key}: {display}")
 
-    equity_output = reports_dir / f"equity_{run_id_value}.csv"
-    summary_output = reports_dir / f"summary_{run_id_value}.json"
+    equity_output = build_path(
+        f"equity_{run_id_value}.csv", run_id=run_id_value, location="reports"
+    )
+    summary_output = build_path(
+        f"summary_{run_id_value}.json", run_id=run_id_value, location="reports"
+    )
 
     if dry_run:
         typer.echo("Dry run requested; skipping file writes.")
@@ -193,11 +201,14 @@ def _run_backtest(
         typer.echo(f"Summary would be written to {summary_output}")
         return summary_output, equity_output
 
-    run_dir.mkdir(parents=True, exist_ok=True)
-    reports_dir.mkdir(parents=True, exist_ok=True)
-
-    equity.to_csv(equity_output, index=False)
-    equity.to_csv(run_dir / "equity.csv", index=False)
+    equity_report_path = save_csv(
+        equity,
+        f"equity_{run_id_value}.csv",
+        run_id=run_id_value,
+        location="reports",
+        index=False,
+    )
+    save_csv(equity, "equity.csv", run_id=run_id_value, index=False)
 
     summary = {
         "run_id": run_id_value,
@@ -212,8 +223,16 @@ def _run_backtest(
         },
         "metrics": summary_metrics,
     }
-    summary_output.write_text(json.dumps(summary, indent=2), encoding="utf-8")
-    (run_dir / "summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    summary_report_path = save_json(
+        summary,
+        f"summary_{run_id_value}.json",
+        run_id=run_id_value,
+        location="reports",
+    )
+    save_json(summary, "summary.json", run_id=run_id_value)
+
+    equity_output = equity_report_path
+    summary_output = summary_report_path
 
     config_dump = {
         "args": {
@@ -221,7 +240,7 @@ def _run_backtest(
             "prediction_column": prediction_column,
             "target_column": target_column,
             "price_column": price_column,
-            "prob_column": prob_column,
+            "prob_column": prob_col,
             "fee_bps": fee_bps,
             "slip_bps": slip_bps,
             "latency_min": latency_min,
@@ -231,7 +250,17 @@ def _run_backtest(
         },
         "config": CONFIG.config_path.as_posix() if CONFIG.config_path else None,
     }
-    (run_dir / "config_dump.json").write_text(json.dumps(config_dump, indent=2), encoding="utf-8")
+    save_json(config_dump, "config_dump.json", run_id=run_id_value)
+
+    logger.info(
+        "Saved backtest artefacts",
+        extra={
+            "event": "artefacts",
+            "run_id": run_id_value,
+            "equity_report": str(equity_report_path),
+            "summary_report": str(summary_report_path),
+        },
+    )
 
     typer.echo(
         "Backtest complete. Final equity: "

--- a/scripts/make_features.py
+++ b/scripts/make_features.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any, Literal, Optional
 
@@ -14,9 +13,12 @@ from crypto_analyzer.features.engineering import create_features
 from crypto_analyzer.utils.config import CONFIG, FeatureSettings, override_feature_settings
 from crypto_analyzer.utils.cli import run_cli
 from crypto_analyzer.utils.errors import DataValidationError
+from crypto_analyzer.utils.io import initialize_run, save_json
+from crypto_analyzer.utils.logging import get_logger
 
 
 app = typer.Typer(add_completion=False, no_args_is_help=True)
+logger = get_logger(__name__)
 
 
 def _load_price_data(
@@ -107,12 +109,12 @@ def _resolve_output(
     return target_output, run_dir / output.name
 
 
-def _persist_metadata(run_dir: Path, args: dict[str, Any]) -> None:
+def _persist_metadata(run_id: str, args: dict[str, Any]) -> None:
     config_dump = {
         "config": CONFIG.config_path.as_posix() if CONFIG.config_path else None,
         "args": {k: (str(v) if isinstance(v, Path) else v) for k, v in args.items()},
     }
-    (run_dir / "config_dump.json").write_text(json.dumps(config_dump, indent=2), encoding="utf-8")
+    save_json(config_dump, "config_dump.json", run_id=run_id)
 
 
 def _print_outputs(primary: Path, secondary: Path | None) -> None:
@@ -156,8 +158,11 @@ def _generate_features(
     df = _load_price_data(source, path=input_path, symbol=symbol, db_path=db_path)
     feature_df = create_features(df, settings=settings)
 
-    run_id_value = run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
-    run_dir = Path("outputs") / f"run_id={run_id_value}"
+    run_id_value, run_dir, _ = initialize_run(run_id, deterministic_torch=False)
+    logger.info(
+        "Prepared feature generation run",
+        extra={"event": "initialised", "run_id": run_id_value, "rows": int(len(feature_df))},
+    )
     target_output, run_output = _resolve_output(output=output, run_dir=run_dir)
 
     if dry_run:
@@ -169,7 +174,7 @@ def _generate_features(
     if target_output != run_output:
         _write_output(feature_df, target_output, fmt)
 
-    _persist_metadata(run_dir, {
+    _persist_metadata(run_id_value, {
         "source": source,
         "input": input_path,
         "output": output,
@@ -187,8 +192,10 @@ def _generate_features(
         "dry_run": dry_run,
     })
 
-    reports_dir = Path("reports")
-    reports_dir.mkdir(parents=True, exist_ok=True)
+    logger.info(
+        "Persisted engineered features",
+        extra={"event": "artefacts", "run_id": run_id_value, "path": str(run_output)},
+    )
 
     _print_outputs(run_output, target_output if target_output != run_output else None)
     return run_output

--- a/scripts/optimize_thresholds.py
+++ b/scripts/optimize_thresholds.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Iterable, Optional
 
+from pathlib import Path
+from typing import Iterable, Optional
+
 import numpy as np
 import pandas as pd
 import typer
@@ -13,8 +16,11 @@ from crypto_analyzer.eval.threshold_sweep import SweepParams, sweep_threshold_gr
 from crypto_analyzer.utils.cli import run_cli
 from crypto_analyzer.utils.config import CONFIG
 from crypto_analyzer.utils.errors import DataValidationError
+from crypto_analyzer.utils.io import build_path, initialize_run, save_csv, save_json, save_png
+from crypto_analyzer.utils.logging import get_logger
 
 app = typer.Typer(add_completion=False, no_args_is_help=True)
+logger = get_logger(__name__)
 
 
 def _read_predictions(path: Path) -> pd.DataFrame:
@@ -169,19 +175,32 @@ def _run_sweep(
 
     result = pd.concat(frames, ignore_index=True)
 
-    run_id_value = run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
-    reports_dir = Path("reports")
-    reports_dir.mkdir(parents=True, exist_ok=True)
+    run_id_value, run_dir, reports_dir = initialize_run(run_id, deterministic_torch=False)
+    logger.info(
+        "Prepared threshold sweep run",
+        extra={"event": "initialised", "run_id": run_id_value, "rows": int(len(result))},
+    )
 
-    csv_path = reports_dir / f"threshold_sweep_{run_id_value}.csv"
-    png_path = reports_dir / f"threshold_sweep_{run_id_value}.png"
+    csv_path = build_path(
+        f"threshold_sweep_{run_id_value}.csv", run_id=run_id_value, location="reports"
+    )
+    png_path = build_path(
+        f"threshold_sweep_{run_id_value}.png", run_id=run_id_value, location="reports"
+    )
 
     if dry_run:
         typer.echo("Dry run requested; skipping report generation.")
         typer.echo(f"Sweep results would be stored at {csv_path} and {png_path}")
         return csv_path, png_path
 
-    result.to_csv(csv_path, index=False)
+    csv_report_path = save_csv(
+        result,
+        f"threshold_sweep_{run_id_value}.csv",
+        run_id=run_id_value,
+        location="reports",
+        index=False,
+    )
+    save_csv(result, "threshold_sweep.csv", run_id=run_id_value, index=False)
 
     pivot_groups = []
     for horizon, subset in _iter_groups(result, "horizon"):
@@ -218,16 +237,53 @@ def _run_sweep(
         fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04, label="EV")
 
     plt.tight_layout()
-    plt.savefig(png_path)
+    png_report_path = save_png(
+        fig,
+        f"threshold_sweep_{run_id_value}.png",
+        run_id=run_id_value,
+        location="reports",
+    )
+    save_png(fig, "threshold_sweep.png", run_id=run_id_value)
     plt.close(fig)
+
+    metadata = {
+        "run_id": run_id_value,
+        "fee_bps": fee_bps,
+        "slip_bps": slip_bps,
+        "latency_min": latency_min,
+        "group_column": group_column,
+        "p_touch_grid": {
+            "min": p_touch_min,
+            "max": p_touch_max,
+            "step": p_touch_step,
+        },
+        "p_up_grid": {
+            "min": p_up_min,
+            "max": p_up_max,
+            "step": p_up_step,
+        },
+        "probability_column": prediction_column,
+        "p_up_column": p_up_column,
+    }
+    save_json(metadata, "config_dump.json", run_id=run_id_value)
+
+    logger.info(
+        "Generated threshold sweep artefacts",
+        extra={
+            "event": "artefacts",
+            "run_id": run_id_value,
+            "csv": str(csv_report_path),
+            "png": str(png_report_path),
+        },
+    )
 
     top = result.sort_values("ev", ascending=False).head(10)
     typer.echo("Top threshold combinations by expected value:")
     typer.echo(top[["horizon", "p_touch_thr", "p_up_thr", "ev", "pnl", "sharpe", "trades"]])
-    typer.echo(f"Sweep results saved to {csv_path}")
-    typer.echo(f"Heatmap saved to {png_path}")
+    typer.echo(f"Sweep results saved to {csv_report_path}")
+    typer.echo(f"Heatmap saved to {png_report_path}")
 
-    return csv_path, png_path
+    return csv_report_path, png_report_path
 
 
 @app.command()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 """Training entry-point with optional calibration and conformal outputs."""
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any, Optional
 
@@ -38,9 +37,17 @@ from crypto_analyzer.models.conformal import conformal_interval
 from crypto_analyzer.utils.cli import run_cli
 from crypto_analyzer.utils.config import CONFIG, FeatureSettings, override_feature_settings
 from crypto_analyzer.utils.errors import DataValidationError, ModelError
+from crypto_analyzer.utils.io import (
+    build_path,
+    initialize_run,
+    save_json,
+    save_model,
+)
+from crypto_analyzer.utils.logging import get_logger
 
 
 app = typer.Typer(add_completion=False, no_args_is_help=True)
+logger = get_logger(__name__)
 
 
 def _read_table(path: Path) -> pd.DataFrame:
@@ -420,13 +427,19 @@ def _run_training(
     timestamps = pd.to_datetime(df["timestamp"], utc=True)
     realized_volatility = _compute_realized_volatility(df)
 
-    run_id_value = run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
-    run_dir = Path("outputs") / f"run_id={run_id_value}"
-    reports_dir = Path("reports")
-
-    if not dry_run:
-        run_dir.mkdir(parents=True, exist_ok=True)
-        reports_dir.mkdir(parents=True, exist_ok=True)
+    run_id_value, run_dir, reports_dir = initialize_run(
+        run_id,
+        deterministic_torch=True,
+    )
+    logger.info(
+        "Prepared training artefact directories",
+        extra={
+            "event": "initialised",
+            "run_id": run_id_value,
+            "horizon": horizon,
+            "rows": int(len(df)),
+        },
+    )
 
     if cv_strategy == "purged-wf" and not dry_run:
         purged_walkforward_splits(
@@ -444,9 +457,8 @@ def _run_training(
         X_train_full, y_train_full, ts_train_full
     )
 
-    model_output = model_path if model_path != DEFAULT_MODEL_PATH else run_dir / "model.joblib"
-    if not dry_run:
-        model_output.parent.mkdir(parents=True, exist_ok=True)
+    default_model_target = run_dir / "model.joblib"
+    model_output = model_path if model_path != DEFAULT_MODEL_PATH else default_model_target
 
     try:
         model = _fit_model(X_train, y_train, use_gpu=use_gpu, random_state=random_state)
@@ -454,7 +466,13 @@ def _run_training(
         raise ModelError(f"Training failed: {exc}") from exc
 
     if not dry_run:
-        joblib.dump(model, model_output)
+        run_model_path = save_model(model, run_id=run_id_value)
+        if model_path != DEFAULT_MODEL_PATH:
+            model_path.parent.mkdir(parents=True, exist_ok=True)
+            joblib.dump(model, model_path)
+            model_output = model_path
+        else:
+            model_output = run_model_path
 
     proba_test = model.predict_proba(X_test)[:, 1]
     labels_test = (proba_test >= 0.5).astype(int)
@@ -497,12 +515,21 @@ def _run_training(
         }
         reliability_data[f"calibrated_{calibration_method}"] = calibrated_metrics
 
+    coverage_value: float | None = None
+    ev_value: float | None = None
+
     if not dry_run:
-        reliability_path = reports_dir / f"reliability_{run_id_value}.png"
+        reliability_path = build_path(
+            f"reliability_{run_id_value}.png", run_id=run_id_value, location="reports"
+        )
         plot_reliability(y_test, prob_series, reliability_path)
 
-        metrics_by_vol_path = reports_dir / f"metrics_by_vol_{run_id_value}.csv"
-        reliability_by_vol_path = reports_dir / f"reliability_by_vol_{run_id_value}.png"
+        metrics_by_vol_path = build_path(
+            f"metrics_by_vol_{run_id_value}.csv", run_id=run_id_value, location="reports"
+        )
+        reliability_by_vol_path = build_path(
+            f"reliability_by_vol_{run_id_value}.png", run_id=run_id_value, location="reports"
+        )
 
         _export_metrics_by_volatility(
             y_test,
@@ -517,22 +544,6 @@ def _run_training(
             n_quantiles=int(by_vol_bins),
         )
 
-        metrics_report = {
-            "run_id": run_id_value,
-            "raw": metrics_raw,
-            "calibration": calibration_method,
-            "calibrated": calibrated_metrics,
-        }
-
-        metrics_path = reports_dir / f"metrics_{run_id_value}.json"
-        metrics_payload = json.dumps(metrics_report, indent=2)
-        metrics_path.write_text(metrics_payload, encoding="utf-8")
-        (run_dir / "metrics.json").write_text(metrics_payload, encoding="utf-8")
-
-        reliability_copy = run_dir / "reliability.png"
-        if not reliability_copy.exists():
-            reliability_copy.write_bytes(reliability_path.read_bytes())
-
         if conformal_alpha is not None and X_cal is not None and len(X_cal) > 0:
             cal_probs = model.predict_proba(X_cal)[:, 1]
             conformal = conformal_interval(
@@ -541,10 +552,49 @@ def _run_training(
                 (y_test, proba_test),
                 float(conformal_alpha),
             )
-            conformal_path = reports_dir / f"conformal_{run_id_value}.json"
-            conformal_json = json.dumps(conformal, indent=2)
-            conformal_path.write_text(conformal_json, encoding="utf-8")
-            (run_dir / "conformal.json").write_text(conformal_json, encoding="utf-8")
+            coverage_raw = conformal.get("test_coverage")
+            if coverage_raw is not None:
+                coverage_value = float(coverage_raw)
+            conformal_path = save_json(
+                conformal,
+                f"conformal_{run_id_value}.json",
+                run_id=run_id_value,
+                location="reports",
+            )
+            save_json(conformal, "conformal.json", run_id=run_id_value)
+            logger.info(
+                "Stored conformal diagnostics",
+                extra={"event": "conformal", "run_id": run_id_value, "path": str(conformal_path)},
+            )
+
+        metrics_payload = {
+            "horizon": int(horizon),
+            "brier_raw": float(metrics_raw["brier"]),
+            "brier_cal": float(calibrated_metrics["brier"]) if calibrated_metrics else None,
+            "auc": float(
+                calibrated_metrics["roc_auc"]
+                if calibrated_metrics and calibrated_metrics.get("roc_auc") is not None
+                else metrics_raw["roc_auc"]
+            ),
+            "logloss": float(
+                calibrated_metrics["log_loss"]
+                if calibrated_metrics and calibrated_metrics.get("log_loss") is not None
+                else metrics_raw["log_loss"]
+            ),
+            "coverage": coverage_value,
+            "ev": ev_value,
+        }
+        metrics_report_path = save_json(
+            metrics_payload,
+            f"metrics_{run_id_value}.json",
+            run_id=run_id_value,
+            location="reports",
+        )
+        save_json(metrics_payload, "metrics.json", run_id=run_id_value)
+
+        reliability_copy = build_path("reliability.png", run_id=run_id_value)
+        if not reliability_copy.exists():
+            reliability_copy.write_bytes(Path(reliability_path).read_bytes())
 
         args_snapshot = {
             "features": features,
@@ -575,7 +625,16 @@ def _run_training(
             "args": {k: (str(v) if isinstance(v, Path) else v) for k, v in args_snapshot.items()},
             "features": feature_cols,
         }
-        (run_dir / "config_dump.json").write_text(json.dumps(config_dump, indent=2), encoding="utf-8")
+        save_json(config_dump, "config_dump.json", run_id=run_id_value)
+
+        logger.info(
+            "Saved training artefacts",
+            extra={
+                "event": "artefacts",
+                "run_id": run_id_value,
+                "metrics": str(metrics_report_path),
+            },
+        )
     else:
         typer.echo("Dry run requested; metrics and artefacts will not be written.")
 

--- a/src/crypto_analyzer/models/train.py
+++ b/src/crypto_analyzer/models/train.py
@@ -510,6 +510,7 @@ def train_xgb(
         prob_series = {"Raw": preds}
         metrics_report["raw"] = metrics_raw
         metrics_report["class_threshold"] = class_threshold
+        coverage_value: float | None = None
 
         calibrated_probs = None
         calibrated_probs_calibration = None
@@ -600,6 +601,9 @@ def train_xgb(
                         alpha=conformal_alpha,
                     )
                     conformal_payload["calibrated"] = calibrated_report
+                split_report = raw_report.get("methods", {}).get("split")
+                if split_report and "label_coverage" in split_report:
+                    coverage_value = float(split_report["label_coverage"])
                 with conformal_path.open("w", encoding="utf-8") as f:
                     json.dump(conformal_payload, f, indent=2)
                 metrics_report.setdefault("conformal", {})
@@ -618,7 +622,18 @@ def train_xgb(
                     )
 
         metrics_path = reports_dir / f"metrics_{final_run_id}{horizon_suffix}.json"
+        metrics_payload = {
+            "horizon": int(horizon) if horizon is not None else None,
+            "brier_raw": float(raw_brier),
+            "brier_cal": float(cal_brier) if calibration_applied and cal_brier is not None else None,
+            "auc": float(metrics_raw["roc_auc"]),
+            "logloss": float(cal_logloss) if calibration_applied and cal_logloss is not None else float(raw_logloss),
+            "coverage": coverage_value,
+            "ev": None,
+        }
         with metrics_path.open("w", encoding="utf-8") as f:
+            json.dump(metrics_payload, f, indent=2)
+        with (output_dir / "metrics_full.json").open("w", encoding="utf-8") as f:
             json.dump(metrics_report, f, indent=2)
     else:
         from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
@@ -638,7 +653,18 @@ def train_xgb(
         horizon_suffix = f"_{horizon}" if horizon is not None else ""
         metrics_path = reports_dir / f"metrics_{final_run_id}{horizon_suffix}.json"
         reports_dir.mkdir(parents=True, exist_ok=True)
+        metrics_payload = {
+            "horizon": int(horizon) if horizon is not None else None,
+            "brier_raw": None,
+            "brier_cal": None,
+            "auc": None,
+            "logloss": None,
+            "coverage": None,
+            "ev": None,
+        }
         with metrics_path.open("w", encoding="utf-8") as f:
+            json.dump(metrics_payload, f, indent=2)
+        with (output_dir / "metrics_full.json").open("w", encoding="utf-8") as f:
             json.dump(metrics_report, f, indent=2)
 
     # SHAP feature importance

--- a/src/crypto_analyzer/utils/helpers.py
+++ b/src/crypto_analyzer/utils/helpers.py
@@ -1,18 +1,9 @@
 from __future__ import annotations
 
-import logging
 from contextlib import suppress
 from pathlib import Path
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-)
-
-
-def get_logger(name: str | None = None) -> logging.Logger:
-    """Return a module-level logger configured for the project."""
-    return logging.getLogger(name if name else __name__)
+from .logging import get_logger
 
 
 def ensure_dir_exists(path: str | Path) -> Path:

--- a/src/crypto_analyzer/utils/io.py
+++ b/src/crypto_analyzer/utils/io.py
@@ -1,0 +1,208 @@
+"""Utilities for persisting experiment artefacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Literal, overload
+
+import joblib
+import pandas as pd
+
+from .logging import configure_logging, resolve_run_id
+from .repro import set_seeds
+
+Location = Literal["outputs", "reports"]
+
+__all__ = [
+    "build_path",
+    "initialize_run",
+    "save_csv",
+    "save_json",
+    "save_model",
+    "save_png",
+]
+
+
+def build_path(
+    filename: str,
+    *,
+    run_id: str,
+    location: Location = "outputs",
+    base_dir: str | Path | None = None,
+    subdir: str | Path | None = None,
+    ensure_parents: bool = True,
+) -> Path:
+    """Return a path under ``outputs/run_id=...`` or ``reports``."""
+
+    if location == "outputs":
+        root = Path(base_dir or "outputs") / f"run_id={run_id}"
+    elif location == "reports":
+        root = Path(base_dir or "reports")
+    else:  # pragma: no cover - defensive guard
+        raise ValueError(f"Unsupported location: {location}")
+
+    if subdir is not None:
+        root = root / Path(subdir)
+
+    if ensure_parents:
+        root.mkdir(parents=True, exist_ok=True)
+
+    return root / filename
+
+
+def initialize_run(
+    run_id: str | None = None,
+    *,
+    outputs_root: str | Path = "outputs",
+    reports_root: str | Path = "reports",
+    deterministic_torch: bool = False,
+) -> tuple[str, Path, Path]:
+    """Prepare run/report directories, configure logging and set seeds."""
+
+    resolved_run_id = resolve_run_id(run_id)
+    run_dir = Path(outputs_root) / f"run_id={resolved_run_id}"
+    reports_dir = Path(reports_root)
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+    reports_dir.mkdir(parents=True, exist_ok=True)
+
+    configure_logging(resolved_run_id, run_dir=run_dir)
+    set_seeds(resolved_run_id, deterministic=deterministic_torch)
+
+    return resolved_run_id, run_dir, reports_dir
+
+
+def save_json(
+    data: Any,
+    filename: str,
+    *,
+    run_id: str,
+    location: Location = "outputs",
+    base_dir: str | Path | None = None,
+    subdir: str | Path | None = None,
+    indent: int = 2,
+) -> Path:
+    """Persist ``data`` as JSON under the requested location."""
+
+    target = build_path(
+        filename,
+        run_id=run_id,
+        location=location,
+        base_dir=base_dir,
+        subdir=subdir,
+    )
+    with target.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=indent, ensure_ascii=False)
+        handle.write("\n")
+    return target
+
+
+def save_csv(
+    frame: pd.DataFrame,
+    filename: str,
+    *,
+    run_id: str,
+    location: Location = "outputs",
+    base_dir: str | Path | None = None,
+    subdir: str | Path | None = None,
+    index: bool = False,
+    float_format: str | None = None,
+) -> Path:
+    """Persist a :class:`pandas.DataFrame` to CSV."""
+
+    target = build_path(
+        filename,
+        run_id=run_id,
+        location=location,
+        base_dir=base_dir,
+        subdir=subdir,
+    )
+    frame.to_csv(target, index=index, float_format=float_format)
+    return target
+
+
+@overload
+def save_png(
+    image: "pd.Series | pd.DataFrame",
+    filename: str,
+    *,
+    run_id: str,
+    location: Location = "outputs",
+    base_dir: str | Path | None = None,
+    subdir: str | Path | None = None,
+    dpi: int = 300,
+) -> Path: ...
+
+
+@overload
+def save_png(
+    image: "Any",
+    filename: str,
+    *,
+    run_id: str,
+    location: Location = "outputs",
+    base_dir: str | Path | None = None,
+    subdir: str | Path | None = None,
+    dpi: int = 300,
+) -> Path: ...
+
+
+def save_png(
+    image: Any,
+    filename: str,
+    *,
+    run_id: str,
+    location: Location = "outputs",
+    base_dir: str | Path | None = None,
+    subdir: str | Path | None = None,
+    dpi: int = 300,
+) -> Path:
+    """Save a matplotlib ``Figure`` or array-like as PNG."""
+
+    target = build_path(
+        filename,
+        run_id=run_id,
+        location=location,
+        base_dir=base_dir,
+        subdir=subdir,
+    )
+
+    try:
+        from matplotlib.figure import Figure
+    except ModuleNotFoundError:  # pragma: no cover - optional dependency
+        raise RuntimeError("matplotlib is required to save PNG artefacts") from None
+
+    if isinstance(image, Figure):
+        figure = image
+    elif hasattr(image, "get_figure"):
+        figure = image.get_figure()
+        if figure is None:
+            raise ValueError("Unable to resolve figure from provided image object")
+    else:  # pragma: no cover - defensive branch
+        raise TypeError("save_png expects a matplotlib Figure or Axes")
+
+    figure.savefig(target, dpi=dpi, bbox_inches="tight")
+    return target
+
+
+def save_model(
+    model: Any,
+    filename: str = "model.joblib",
+    *,
+    run_id: str,
+    base_dir: str | Path | None = None,
+    subdir: str | Path | None = None,
+) -> Path:
+    """Persist ``model`` using :mod:`joblib` under the run directory."""
+
+    target = build_path(
+        filename,
+        run_id=run_id,
+        location="outputs",
+        base_dir=base_dir,
+        subdir=subdir,
+    )
+    joblib.dump(model, target)
+    return target
+

--- a/src/crypto_analyzer/utils/logging.py
+++ b/src/crypto_analyzer/utils/logging.py
@@ -1,0 +1,149 @@
+"""Project logging helpers with JSON formatting and run context support."""
+
+from __future__ import annotations
+
+import json
+import logging
+from contextvars import ContextVar
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+__all__ = [
+    "JsonLogFormatter",
+    "configure_logging",
+    "current_run_id",
+    "generate_run_id",
+    "get_logger",
+    "resolve_run_id",
+]
+
+
+_ROOT_LOGGER_NAME = "crypto_analyzer"
+_RUN_ID: ContextVar[Optional[str]] = ContextVar("crypto_run_id", default=None)
+_RUN_DIR: ContextVar[Optional[Path]] = ContextVar("crypto_run_dir", default=None)
+_CONFIGURED: ContextVar[bool] = ContextVar("crypto_log_configured", default=False)
+
+
+def generate_run_id() -> str:
+    """Return a timestamp-based identifier used to track experiment runs."""
+
+    return datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+
+
+def resolve_run_id(run_id: str | None = None) -> str:
+    """Normalise ``run_id`` ensuring a valid identifier is returned."""
+
+    return run_id or generate_run_id()
+
+
+class JsonLogFormatter(logging.Formatter):
+    """Emit log records as structured JSON objects."""
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401 - inherited doc
+        payload: dict[str, Any] = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+
+        run_id = _RUN_ID.get()
+        if run_id:
+            payload["run_id"] = run_id
+
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            payload["stack"] = record.stack_info
+
+        for key in ("event", "extra"):
+            if key in record.__dict__:
+                payload[key] = record.__dict__[key]
+
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def _ensure_root_logger(level: int = logging.INFO) -> logging.Logger:
+    configured = _CONFIGURED.get()
+    root_logger = logging.getLogger(_ROOT_LOGGER_NAME)
+    if configured:
+        return root_logger
+
+    root_logger.setLevel(level)
+    root_logger.propagate = False
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonLogFormatter())
+    root_logger.addHandler(handler)
+
+    _CONFIGURED.set(True)
+    return root_logger
+
+
+def _attach_file_handler(logger: logging.Logger, run_dir: Path) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    log_path = run_dir / "run.log"
+    for handler in logger.handlers:
+        if isinstance(handler, logging.FileHandler) and Path(getattr(handler, "baseFilename", "")) == log_path:
+            return
+
+    file_handler = logging.FileHandler(log_path)
+    file_handler.setFormatter(JsonLogFormatter())
+    logger.addHandler(file_handler)
+
+
+def configure_logging(
+    run_id: str,
+    *,
+    run_dir: Path | None = None,
+    level: int = logging.INFO,
+) -> logging.Logger:
+    """Configure project logging for the provided ``run_id``."""
+
+    _RUN_ID.set(run_id)
+    logger = _ensure_root_logger(level=level)
+
+    if run_dir is not None:
+        _RUN_DIR.set(run_dir)
+        _attach_file_handler(logger, run_dir)
+
+    return logger
+
+
+def get_logger(name: str | None = None) -> logging.Logger:
+    """Return a child logger scoped to the Crypto Analyzer namespace."""
+
+    base = _ROOT_LOGGER_NAME
+    if name and not name.startswith(base):
+        full_name = f"{base}.{name}"
+    else:
+        full_name = name or base
+
+    logger = logging.getLogger(full_name)
+    if not _CONFIGURED.get():
+        _ensure_root_logger()
+    return logger
+
+
+def current_run_id() -> str | None:
+    """Return the run identifier associated with the active logging context."""
+
+    return _RUN_ID.get()
+
+
+def current_run_dir() -> Path | None:
+    """Return the active run directory if available."""
+
+    return _RUN_DIR.get()
+
+
+def add_extra_handlers(handlers: Iterable[logging.Handler]) -> None:
+    """Attach additional handlers to the project root logger."""
+
+    logger = _ensure_root_logger()
+    for handler in handlers:
+        logger.addHandler(handler)
+

--- a/src/crypto_analyzer/utils/repro.py
+++ b/src/crypto_analyzer/utils/repro.py
@@ -1,0 +1,41 @@
+"""Reproducibility helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import random
+
+import numpy as np
+
+__all__ = ["set_seeds"]
+
+
+def _seed_from_run_id(run_id: str) -> int:
+    digest = hashlib.sha256(run_id.encode("utf-8")).digest()
+    return int.from_bytes(digest[:4], "big")
+
+
+def set_seeds(run_id: str, *, deterministic: bool = False) -> int:
+    """Seed random number generators using a stable hash of ``run_id``."""
+
+    seed = _seed_from_run_id(run_id)
+    random.seed(seed)
+    np.random.seed(seed % (2**32 - 1))
+
+    try:
+        import torch
+    except ModuleNotFoundError:  # pragma: no cover - optional dependency
+        torch = None  # type: ignore[assignment]
+
+    if torch is not None:
+        torch.manual_seed(seed)
+        if deterministic:
+            try:
+                torch.use_deterministic_algorithms(True)
+            except (RuntimeError, AttributeError):  # pragma: no cover - env dependent
+                pass
+
+    os.environ.setdefault("PYTHONHASHSEED", str(seed))
+    return seed
+


### PR DESCRIPTION
## Summary
- add dedicated logging, IO, and reproducibility helpers to centralize run handling
- refactor CLI scripts to initialize runs, persist artefacts via the new helpers, and emit structured logs
- standardize metrics exports to the new schema and capture detailed reports alongside run metadata

## Testing
- pytest *(fails: missing pydantic dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d03b3a28688327a3dd1112a87b8e28