### PR TITLE
Add UTC time utilities and schema validations for leakage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ env/
 .DS_Store
 
 data/
+!src/
+!src/crypto_analyzer/
+!src/crypto_analyzer/data/
+!src/crypto_analyzer/data/schema.py
 datasets/
 outputs/
 /models/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "structlog==24.4.0",
     "python-dotenv==1.0.1",
     "psutil==6.0.0",
+    "pandera==0.20.3",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ httpx==0.27.0
 ta==0.10.3
 torch==2.4.1
 psutil==6.0.0
+pandera==0.20.3
 
 # Tooling
 vulture==2.11

--- a/src/crypto_analyzer/data/schema.py
+++ b/src/crypto_analyzer/data/schema.py
@@ -1,0 +1,85 @@
+"""Pandera schemas for validating market data inputs."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pandera as pa
+from pandera import Check, Column, DataFrameSchema
+
+from crypto_analyzer.utils.time import assert_no_future_leak, ensure_utc_series
+
+__all__ = ["OHLCV_SCHEMA", "FEATURE_FRAME_SCHEMA"]
+
+
+def _is_utc_series(series: pd.Series, *, allow_na: bool) -> bool:
+    try:
+        coerced = ensure_utc_series(series, allow_na=True)
+    except ValueError:
+        return False
+
+    invalid = coerced.isna() & series.notna()
+    if invalid.any():
+        return False
+
+    if not allow_na and coerced.isna().any():
+        return False
+
+    tz = coerced.dt.tz
+    return tz is not None and str(tz) == "UTC"
+
+
+def _timestamp_checks(monotonic: bool = True) -> list[Check]:
+    checks = [Check(lambda s: _is_utc_series(s, allow_na=False), name="tz_utc")]
+    if monotonic:
+        checks.append(Check(lambda s: s.is_monotonic_increasing, name="monotonic_time"))
+    return checks
+
+
+def _left_label_check(df: pd.DataFrame) -> bool:
+    try:
+        assert_no_future_leak(
+            df, target_time_col="timestamp_target_open", feature_time_col="timestamp_feature"
+        )
+    except AssertionError:
+        return False
+    return True
+
+
+OHLCV_SCHEMA = DataFrameSchema(
+    {
+        "timestamp": Column(pa.DateTime, checks=_timestamp_checks(), nullable=False, coerce=True),
+        "open": Column(pa.Float, nullable=False, coerce=True),
+        "high": Column(pa.Float, nullable=False, coerce=True),
+        "low": Column(pa.Float, nullable=False, coerce=True),
+        "close": Column(pa.Float, nullable=False, coerce=True),
+        "volume": Column(pa.Float, nullable=False, coerce=True),
+        "quote_asset_volume": Column(pa.Float, nullable=False, coerce=True),
+        "taker_buy_base": Column(pa.Float, nullable=False, coerce=True),
+        "taker_buy_quote": Column(pa.Float, nullable=False, coerce=True),
+        "number_of_trades": Column(pa.Int, nullable=True, coerce=True, required=False),
+    },
+    index=None,
+    strict=False,
+    coerce=True,
+    unique=["timestamp"],
+)
+
+
+FEATURE_FRAME_SCHEMA = DataFrameSchema(
+    {
+        "timestamp_target_open": Column(
+            pa.DateTime, checks=_timestamp_checks(monotonic=True), nullable=False, coerce=True
+        ),
+        "timestamp_feature": Column(
+            pa.DateTime,
+            checks=[Check(lambda s: _is_utc_series(s, allow_na=True), name="tz_utc")],
+            nullable=True,
+            coerce=True,
+            required=True,
+        ),
+    },
+    strict=False,
+    coerce=True,
+    checks=[Check(_left_label_check, name="left_label_no_leak")],
+)
+

--- a/src/crypto_analyzer/utils/merge.py
+++ b/src/crypto_analyzer/utils/merge.py
@@ -6,6 +6,8 @@ from typing import Sequence
 
 import pandas as pd
 
+from crypto_analyzer.utils.time import assert_no_future_leak, ensure_utc_series
+
 __all__ = ["merge_left_labeled", "validate_left_label_alignment"]
 
 
@@ -22,24 +24,9 @@ def validate_left_label_alignment(
     if feature_ts_col not in df.columns:
         raise KeyError(f"Column '{feature_ts_col}' missing from dataframe")
 
-    target_ts = pd.to_datetime(df[target_ts_col], utc=True, errors="coerce")
-    if target_ts.isna().any():
-        raise ValueError(f"Column '{target_ts_col}' contains non-parsable timestamps")
-
-    feature_ts = pd.to_datetime(df[feature_ts_col], utc=True, errors="coerce")
-
-    valid = feature_ts.notna()
-    if not valid.any():
-        return
-
-    violations = valid & (feature_ts > target_ts)
-    if violations.any():
-        offending = df.loc[violations, [target_ts_col, feature_ts_col]].head()
-        raise AssertionError(
-            "Left-label merge invariant violated: feature timestamps must not "
-            "exceed target open times. Offending rows:\n"
-            + offending.to_string(index=False)
-        )
+    assert_no_future_leak(
+        df, target_time_col=target_ts_col, feature_time_col=feature_ts_col
+    )
 
 
 def merge_left_labeled(
@@ -60,13 +47,13 @@ def merge_left_labeled(
 
     left = targets.copy()
     left["__orig_order"] = range(len(left))
-    left[target_ts_col] = pd.to_datetime(left[target_ts_col], utc=True, errors="coerce")
-    if left[target_ts_col].isna().any():
-        raise ValueError(f"Column '{target_ts_col}' contains non-parsable timestamps")
+    left[target_ts_col] = ensure_utc_series(left[target_ts_col], column_name=target_ts_col)
     left = left.sort_values(target_ts_col).reset_index(drop=True)
 
     right = features.copy()
-    right[feature_ts_col] = pd.to_datetime(right[feature_ts_col], utc=True, errors="coerce")
+    right[feature_ts_col] = ensure_utc_series(
+        right[feature_ts_col], column_name=feature_ts_col, allow_na=True
+    )
     right = right.dropna(subset=[feature_ts_col]).sort_values(feature_ts_col).reset_index(drop=True)
 
     if feature_columns is None:

--- a/src/crypto_analyzer/utils/time.py
+++ b/src/crypto_analyzer/utils/time.py
@@ -1,0 +1,188 @@
+"""Time handling utilities with strict UTC semantics."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+import pandas as pd
+
+__all__ = [
+    "ensure_utc_series",
+    "ensure_utc_index",
+    "resample_left_label_last",
+    "assert_no_future_leak",
+]
+
+
+def _format_invalid_samples(values: Iterable[object], *, limit: int = 3) -> str:
+    sample = list(values)[:limit]
+    if not sample:
+        return ""
+    formatted = ", ".join(map(str, sample))
+    if len(sample) == limit:
+        return f" ({formatted}, ...)"
+    return f" ({formatted})"
+
+
+def _coerce_single_timestamp(value: object) -> pd.Timestamp | pd.NaT:
+    if value is pd.NaT or pd.isna(value):
+        return pd.NaT
+    if isinstance(value, pd.Timestamp):
+        return value.tz_localize("UTC") if value.tz is None else value.tz_convert("UTC")
+    try:
+        return pd.Timestamp(value, tz="UTC")
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        ts = pd.Timestamp(value)
+        if ts.tz is None:
+            return ts.tz_localize("UTC")
+        return ts.tz_convert("UTC")
+
+
+def ensure_utc_series(
+    series: pd.Series,
+    *,
+    allow_na: bool = False,
+    column_name: str | None = None,
+) -> pd.Series:
+    """Return a timezone-aware copy of *series* normalized to UTC."""
+
+    if not isinstance(series, pd.Series):  # pragma: no cover - defensive guard
+        raise TypeError("ensure_utc_series expects a pandas Series")
+
+    converted = pd.to_datetime(series, utc=True, errors="coerce")
+    if isinstance(converted, pd.Series):
+        result = converted.copy()
+    else:  # pragma: no cover - pandas guarantees Series in practice
+        result = pd.Series(converted, index=series.index, name=series.name)
+
+    original_not_na = series.notna()
+    invalid = result.isna() & original_not_na
+    if invalid.any():
+        recovered = series.loc[invalid].apply(_coerce_single_timestamp)
+        result.loc[invalid] = recovered.to_numpy()
+        invalid = result.isna() & original_not_na
+
+    if invalid.any() and not allow_na:
+        bad_values = series.loc[invalid].tolist()
+        hint = _format_invalid_samples(bad_values)
+        col = column_name or series.name or "timestamp"
+        raise ValueError(f"Column '{col}' contains non-parsable timestamps{hint}")
+
+    return result
+
+
+def ensure_utc_index(index: Sequence[pd.Timestamp] | pd.Index) -> pd.DatetimeIndex:
+    """Normalize *index* to a :class:`~pandas.DatetimeIndex` with UTC tz."""
+
+    idx = pd.Index(index)
+    name = getattr(index, "name", idx.name)
+    series = pd.Series(idx, name=name)
+    coerced = ensure_utc_series(series, column_name=name or "timestamp")
+    invalid = coerced.isna() & series.notna()
+    if invalid.any():
+        hint = _format_invalid_samples(series.loc[invalid].tolist())
+        raise ValueError(f"Index contains non-parsable timestamps{hint}")
+    return pd.DatetimeIndex(coerced.array, name=name)
+
+
+def resample_left_label_last(
+    df: pd.DataFrame,
+    *,
+    timestamp_col: str,
+    freq: str,
+    columns: Sequence[str] | None = None,
+    target_index: Sequence[pd.Timestamp] | pd.Index | None = None,
+    fill_method: str | None = "ffill",
+    limit: int | None = None,
+) -> pd.DataFrame:
+    """Resample *df* using left-label semantics without introducing leakage."""
+
+    if timestamp_col not in df.columns:
+        raise KeyError(f"Column '{timestamp_col}' missing from dataframe")
+
+    if columns is None:
+        columns = [c for c in df.columns if c != timestamp_col]
+
+    missing = [c for c in columns if c not in df.columns]
+    if missing:
+        joined = ", ".join(missing)
+        raise KeyError(f"Columns {joined!r} missing from dataframe")
+
+    working = df.loc[:, [timestamp_col, *columns]].copy()
+    working[timestamp_col] = ensure_utc_series(
+        working[timestamp_col], column_name=timestamp_col
+    )
+    working = working.sort_values(timestamp_col)
+    indexed = working.set_index(timestamp_col)[columns]
+
+    if target_index is None:
+        base_index = indexed.index
+        if base_index.empty:
+            idx = base_index
+        else:
+            idx = pd.date_range(
+                start=base_index.min(),
+                end=base_index.max(),
+                freq=freq,
+                tz=base_index.tz,
+            )
+    else:
+        idx = ensure_utc_index(target_index)
+
+    combined_idx = idx.union(indexed.index)
+    aligned = indexed.reindex(combined_idx).sort_index()
+
+    if fill_method is None or fill_method == "none":
+        filled = aligned
+    elif fill_method == "ffill":
+        filled = aligned.ffill(limit=limit)
+    else:
+        raise ValueError(f"Unsupported fill method: {fill_method!r}")
+
+    trimmed = filled.reindex(idx)
+    trimmed.index.name = timestamp_col
+    result = trimmed.reset_index()
+    return result
+
+
+def assert_no_future_leak(
+    df: pd.DataFrame,
+    *,
+    target_time_col: str,
+    feature_time_col: str,
+) -> None:
+    """Assert that feature timestamps never peek into the future."""
+
+    if target_time_col not in df.columns:
+        raise KeyError(f"Column '{target_time_col}' missing from dataframe")
+    if feature_time_col not in df.columns:
+        raise KeyError(f"Column '{feature_time_col}' missing from dataframe")
+
+    target_ts = ensure_utc_series(df[target_time_col], column_name=target_time_col)
+    feature_ts = ensure_utc_series(
+        df[feature_time_col], column_name=feature_time_col, allow_na=True
+    )
+
+    valid = feature_ts.notna()
+    if not valid.any():
+        return
+
+    aligned_target = target_ts.loc[valid]
+    aligned_feature = feature_ts.loc[valid]
+    violations = aligned_feature > aligned_target
+    if violations.any():
+        offending = (
+            pd.DataFrame(
+                {
+                    target_time_col: aligned_target.loc[violations],
+                    feature_time_col: aligned_feature.loc[violations],
+                }
+            )
+            .head()
+            .to_string(index=False)
+        )
+        raise AssertionError(
+            "Feature timestamps exceed their corresponding target timestamps. "
+            f"Offending rows:\n{offending}"
+        )
+

--- a/tests/test_no_leakage.py
+++ b/tests/test_no_leakage.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import warnings
+
+import pandera as pa
 import pandas as pd
 import pytest
 
+from crypto_analyzer.data.schema import FEATURE_FRAME_SCHEMA
 from crypto_analyzer.utils.merge import merge_left_labeled, validate_left_label_alignment
+from crypto_analyzer.utils.time import assert_no_future_leak
+
+warnings.filterwarnings("error", category=FutureWarning, module="pandas.core.reshape.merge")
 
 
 def test_merge_left_labeled_respects_left_label_alignment() -> None:
@@ -42,6 +49,18 @@ def test_merge_left_labeled_respects_left_label_alignment() -> None:
     aligned_targets = merged.loc[valid, "timestamp_target_open"]
     assert (aligned_features <= aligned_targets).all()
 
+    assert_no_future_leak(
+        merged,
+        target_time_col="timestamp_target_open",
+        feature_time_col="timestamp_feature",
+    )
+
+    validated = FEATURE_FRAME_SCHEMA.validate(merged, lazy=True)
+    converted = validated.copy()
+    for col in ["timestamp_target_open", "timestamp_feature"]:
+        converted[col] = pd.to_datetime(converted[col], utc=True)
+    pd.testing.assert_frame_equal(converted, merged)
+
 
 def test_validate_left_label_alignment_detects_future_features() -> None:
     df = pd.DataFrame(
@@ -57,4 +76,14 @@ def test_validate_left_label_alignment_detects_future_features() -> None:
 
     with pytest.raises(AssertionError):
         validate_left_label_alignment(df)
+
+    with pytest.raises(AssertionError):
+        assert_no_future_leak(
+            df,
+            target_time_col="timestamp_target_open",
+            feature_time_col="timestamp_feature",
+        )
+
+    with pytest.raises(pa.errors.SchemaErrors):
+        FEATURE_FRAME_SCHEMA.validate(df, lazy=True)
 

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import warnings
+
+import pandas as pd
+import pytest
+
+from crypto_analyzer.utils.time import (
+    assert_no_future_leak,
+    ensure_utc_series,
+    resample_left_label_last,
+)
+
+warnings.filterwarnings("error", category=FutureWarning, module="pandas")
+
+
+def test_ensure_utc_series_normalizes_timezones() -> None:
+    series = pd.Series(["2024-01-01T00:00:00", "2024-01-01T00:05:00Z"])
+    coerced = ensure_utc_series(series, column_name="timestamp")
+    assert str(coerced.dt.tz) == "UTC"
+
+    aware = pd.Series(pd.date_range("2024-01-01", periods=2, freq="5min", tz="UTC"))
+    coerced_aware = ensure_utc_series(aware, column_name="timestamp")
+    pd.testing.assert_series_equal(coerced_aware, aware)
+
+
+def test_resample_left_label_last_respects_left_label_semantics() -> None:
+    ts = pd.to_datetime(
+        [
+            "2024-01-01T00:00:00Z",
+            "2024-01-01T00:07:00Z",
+            "2024-01-01T00:14:00Z",
+        ]
+    )
+    df = pd.DataFrame({"timestamp": ts, "value": [1.0, 2.0, 3.0]})
+
+    target_index = pd.date_range("2024-01-01", periods=6, freq="5min", tz="UTC")
+
+    resampled = resample_left_label_last(
+        df,
+        timestamp_col="timestamp",
+        freq="5min",
+        columns=["value"],
+        target_index=target_index,
+    )
+
+    assert list(resampled["timestamp"]) == list(target_index)
+    assert str(resampled["timestamp"].dt.tz) == "UTC"
+
+    expected = pd.Series([1.0, 1.0, 2.0, 3.0, 3.0, 3.0], index=target_index)
+    expected.index.name = "timestamp"
+    expected.name = "value"
+    observed = resampled.set_index("timestamp")["value"]
+    pd.testing.assert_series_equal(observed, expected, check_freq=False)
+
+
+def test_assert_no_future_leak_rejects_future_rows() -> None:
+    df = pd.DataFrame(
+        {
+            "timestamp_target_open": pd.to_datetime(
+                ["2024-01-01T00:00:00Z", "2024-01-01T00:05:00Z"], utc=True
+            ),
+            "timestamp_feature": pd.to_datetime(
+                ["2024-01-01T00:00:00Z", "2024-01-01T00:06:00Z"], utc=True
+            ),
+        }
+    )
+
+    with pytest.raises(AssertionError):
+        assert_no_future_leak(
+            df,
+            target_time_col="timestamp_target_open",
+            feature_time_col="timestamp_feature",
+        )
+


### PR DESCRIPTION
## Summary
- add dedicated UTC-centric time helpers for coercion, resampling, and leakage checks
- validate OHLCV and feature frames with new Pandera schemas and integrate the leakage assertion into merge utilities
- expand leakage-focused tests and add coverage for the new time helpers while enforcing warning-to-error policies

## Testing
- `pytest tests/test_time_utils.py tests/test_no_leakage.py`


------
https://chatgpt.com/codex/tasks/task_e_68d04003ae008327a071b802f82a4602