### PR TITLE
Limit Python version to avoid pandas build issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ python scripts/train.py --features data/features.parquet --cv purged-wf --embarg
 
 ## Requirements
 
-* Python 3.13
+* Python 3.11 or 3.12
 * [See `requirements.txt`](./requirements.txt) – all runtime dependencies are
   version pinned for reproducibility.
 * Regenerate dependency pins with `tools/update_dependencies.sh` when bumping

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "crypto-analyzer"
 version = "0.1.0"
 description = "Utilities for crypto market analysis"
-requires-python = ">=3.13"
+requires-python = ">=3.11,<3.13"
 dependencies = [
     "numpy==2.1.1",
     "pandas==2.2.2",
@@ -87,7 +87,7 @@ DEP002 = [
 
 [tool.ruff]
 line-length = 100
-target-version = "py313"
+target-version = "py311"
 extend-exclude = ["archive/**/*", "src/crypto_analyzer/legacy/**/*"]
 
 [tool.ruff.lint]
@@ -102,7 +102,7 @@ extend-ignore = ["D1", "D2", "D4"]
 convention = "numpy"
 
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.11"
 warn_unused_ignores = true
 no_implicit_optional = true
 warn_redundant_casts = true
@@ -123,7 +123,7 @@ ignore_errors = true
 
 [tool.black]
 line-length = 100
-target-version = ["py313"]
+target-version = ["py311"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
## Summary
- restrict the supported Python version range to 3.11-3.12 to ensure binary wheels are used for pandas
- update tooling configurations (ruff, mypy, black) to target Python 3.11
- refresh the README to document the supported Python versions

## Testing
- pytest *(fails: missing optional dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d04e0a0a848327acc5dff289fc887c