### PR TITLE
Add sentiment feature configuration and CLI toggles

### DIFF
--- a/config/app.example.yaml
+++ b/config/app.example.yaml
@@ -45,10 +45,17 @@ features:
   include_onchain: true
   include_orderbook: true
   include_derivatives: true
+  include_sentiment: false
   # Maximum number of forward-fill steps for sparse series
   forward_fill_limit: 12
   # Value used to replace remaining NaNs after preprocessing
   fillna_value: 0.0
+
+sentiment:
+  # Control ingestion of external sentiment data
+  use_sentiment: false
+  sentiment_source: api
+  sentiment_api_key: ""
 
 models:
   # Directory storing trained base and meta-model artefacts

--- a/config/app.yaml
+++ b/config/app.yaml
@@ -24,8 +24,14 @@ features:
   include_onchain: true
   include_orderbook: false
   include_derivatives: true
+  include_sentiment: false
   forward_fill_limit: 12
   fillna_value: 0.0
+
+sentiment:
+  use_sentiment: false
+  sentiment_source: api
+  sentiment_api_key: ""
 
 models:
   directory: artifacts/models

--- a/scripts/ablation.py
+++ b/scripts/ablation.py
@@ -57,6 +57,7 @@ def _prepare_settings(
     include_onchain: bool | None,
     include_orderbook: bool | None,
     include_derivatives: bool | None,
+    include_sentiment: bool | None,
 ) -> FeatureSettings:
     settings = CONFIG.features
     overrides: dict[str, Any] = {}
@@ -66,6 +67,8 @@ def _prepare_settings(
         overrides["include_orderbook"] = include_orderbook
     if include_derivatives is not None:
         overrides["include_derivatives"] = include_derivatives
+    if include_sentiment is not None:
+        overrides["include_sentiment"] = include_sentiment
     if overrides:
         settings = override_feature_settings(settings, **overrides)
     return settings
@@ -125,6 +128,7 @@ def _execute_ablation(
     include_onchain: Optional[bool],
     include_orderbook: Optional[bool],
     include_derivatives: Optional[bool],
+    include_sentiment: Optional[bool],
     dry_run: bool,
 ) -> Path:
     if horizon <= 0:
@@ -134,6 +138,7 @@ def _execute_ablation(
         include_onchain=include_onchain,
         include_orderbook=include_orderbook,
         include_derivatives=include_derivatives,
+        include_sentiment=include_sentiment,
     )
     df = _load_features(
         features_path=features,
@@ -260,6 +265,7 @@ def _execute_ablation(
         "include_onchain": include_onchain,
         "include_orderbook": include_orderbook,
         "include_derivatives": include_derivatives,
+        "include_sentiment": include_sentiment,
         "label": label,
         "features_path": str(features) if features else None,
         "symbol": symbol,
@@ -320,6 +326,11 @@ def main(
         "--include-derivatives/--exclude-derivatives",
         help="Override derivative features toggle.",
     ),
+    include_sentiment: Optional[bool] = typer.Option(
+        None,
+        "--include-sentiment/--exclude-sentiment",
+        help="Override sentiment features toggle.",
+    ),
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview actions without writing."),
 ) -> None:
     _execute_ablation(
@@ -332,6 +343,7 @@ def main(
         include_onchain=include_onchain,
         include_orderbook=include_orderbook,
         include_derivatives=include_derivatives,
+        include_sentiment=include_sentiment,
         dry_run=dry_run,
     )
 

--- a/scripts/make_features.py
+++ b/scripts/make_features.py
@@ -49,6 +49,7 @@ def _configure_features(
     include_onchain: bool | None,
     include_orderbook: bool | None,
     include_derivatives: bool | None,
+    include_sentiment: bool | None,
 ) -> FeatureSettings:
     overrides: dict[str, bool] = {}
     if include_onchain is not None:
@@ -57,6 +58,8 @@ def _configure_features(
         overrides["include_orderbook"] = include_orderbook
     if include_derivatives is not None:
         overrides["include_derivatives"] = include_derivatives
+    if include_sentiment is not None:
+        overrides["include_sentiment"] = include_sentiment
     if overrides:
         settings = override_feature_settings(settings, **overrides)
     return settings
@@ -77,6 +80,7 @@ def _prepare_settings(
     include_onchain: Optional[bool],
     include_orderbook: Optional[bool],
     include_derivatives: Optional[bool],
+    include_sentiment: Optional[bool],
 ) -> FeatureSettings:
     settings = CONFIG.features
     if forward_fill_limit is not None or fillna_value is not None:
@@ -84,6 +88,7 @@ def _prepare_settings(
             include_onchain=settings.include_onchain,
             include_orderbook=settings.include_orderbook,
             include_derivatives=settings.include_derivatives,
+            include_sentiment=settings.include_sentiment,
             forward_fill_limit=
             forward_fill_limit if forward_fill_limit is not None else settings.forward_fill_limit,
             fillna_value=fillna_value if fillna_value is not None else settings.fillna_value,
@@ -93,6 +98,7 @@ def _prepare_settings(
         include_onchain=include_onchain,
         include_orderbook=include_orderbook,
         include_derivatives=include_derivatives,
+        include_sentiment=include_sentiment,
     )
 
 
@@ -136,8 +142,10 @@ def _generate_features(
     include_onchain: Optional[bool],
     include_orderbook: Optional[bool],
     include_derivatives: Optional[bool],
+    include_sentiment: Optional[bool],
     use_derivatives: bool,
     use_orderbook: bool,
+    use_sentiment: bool,
     run_id: str | None,
     dry_run: bool,
 ) -> Path:
@@ -146,6 +154,7 @@ def _generate_features(
 
     include_derivatives = True if use_derivatives else include_derivatives
     include_orderbook = True if use_orderbook else include_orderbook
+    include_sentiment = True if use_sentiment else include_sentiment
 
     settings = _prepare_settings(
         forward_fill_limit=forward_fill_limit,
@@ -153,6 +162,7 @@ def _generate_features(
         include_onchain=include_onchain,
         include_orderbook=include_orderbook,
         include_derivatives=include_derivatives,
+        include_sentiment=include_sentiment,
     )
 
     df = _load_price_data(source, path=input_path, symbol=symbol, db_path=db_path)
@@ -186,8 +196,10 @@ def _generate_features(
         "include_onchain": include_onchain,
         "include_orderbook": include_orderbook,
         "include_derivatives": include_derivatives,
+        "include_sentiment": include_sentiment,
         "use_derivatives": use_derivatives,
         "use_orderbook": use_orderbook,
+        "use_sentiment": use_sentiment,
         "run_id": run_id_value,
         "dry_run": dry_run,
     })
@@ -251,11 +263,19 @@ def main(
         "--include-derivatives/--exclude-derivatives",
         help="Override derivative features toggle.",
     ),
+    include_sentiment: Optional[bool] = typer.Option(
+        None,
+        "--include-sentiment/--exclude-sentiment",
+        help="Override sentiment features toggle.",
+    ),
     use_derivatives: bool = typer.Option(
         False, "--use-derivatives", help="Convenience flag to enable derivative features."
     ),
     use_orderbook: bool = typer.Option(
         False, "--use-orderbook", help="Convenience flag to enable orderbook features."
+    ),
+    use_sentiment: bool = typer.Option(
+        False, "--use-sentiment", help="Convenience flag to enable sentiment features."
     ),
     forward_fill_limit: Optional[int] = typer.Option(
         None, help="Override forward-fill window for NaN handling."
@@ -283,8 +303,10 @@ def main(
         include_onchain=include_onchain,
         include_orderbook=include_orderbook,
         include_derivatives=include_derivatives,
+        include_sentiment=include_sentiment,
         use_derivatives=use_derivatives,
         use_orderbook=use_orderbook,
+        use_sentiment=use_sentiment,
         run_id=run_id,
         dry_run=dry_run,
     )

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -63,6 +63,7 @@ def _prepare_settings(
     include_onchain: Optional[bool],
     include_orderbook: Optional[bool],
     include_derivatives: Optional[bool],
+    include_sentiment: Optional[bool],
     forward_fill_limit: Optional[int],
     fillna_value: Optional[float],
 ) -> FeatureSettings:
@@ -74,6 +75,8 @@ def _prepare_settings(
         overrides["include_orderbook"] = include_orderbook
     if include_derivatives is not None:
         overrides["include_derivatives"] = include_derivatives
+    if include_sentiment is not None:
+        overrides["include_sentiment"] = include_sentiment
     if overrides:
         settings = override_feature_settings(settings, **overrides)
 
@@ -82,6 +85,7 @@ def _prepare_settings(
             include_onchain=settings.include_onchain,
             include_orderbook=settings.include_orderbook,
             include_derivatives=settings.include_derivatives,
+            include_sentiment=settings.include_sentiment,
             forward_fill_limit=(
                 forward_fill_limit
                 if forward_fill_limit is not None
@@ -378,6 +382,7 @@ def _run_training(
     include_onchain: Optional[bool],
     include_orderbook: Optional[bool],
     include_derivatives: Optional[bool],
+    include_sentiment: Optional[bool],
     forward_fill_limit: Optional[int],
     fillna_value: Optional[float],
     cv_strategy: Optional[str],
@@ -404,6 +409,7 @@ def _run_training(
         include_onchain=include_onchain,
         include_orderbook=include_orderbook,
         include_derivatives=include_derivatives,
+        include_sentiment=include_sentiment,
         forward_fill_limit=forward_fill_limit,
         fillna_value=fillna_value,
     )
@@ -612,6 +618,7 @@ def _run_training(
             "include_onchain": include_onchain,
             "include_orderbook": include_orderbook,
             "include_derivatives": include_derivatives,
+            "include_sentiment": include_sentiment,
             "forward_fill_limit": forward_fill_limit,
             "fillna_value": fillna_value,
             "cv_strategy": cv_strategy,
@@ -692,6 +699,11 @@ def main(
         "--include-derivatives/--exclude-derivatives",
         help="Override derivative features regardless of config defaults.",
     ),
+    include_sentiment: Optional[bool] = typer.Option(
+        None,
+        "--include-sentiment/--exclude-sentiment",
+        help="Override sentiment features regardless of config defaults.",
+    ),
     forward_fill_limit: Optional[int] = typer.Option(
         None, "--forward-fill-limit", help="Override forward-fill window for NaN handling."
     ),
@@ -739,6 +751,7 @@ def main(
         include_onchain=include_onchain,
         include_orderbook=include_orderbook,
         include_derivatives=include_derivatives,
+        include_sentiment=include_sentiment,
         forward_fill_limit=forward_fill_limit,
         fillna_value=fillna_value,
         cv_strategy=cv_normalised,

--- a/src/crypto_analyzer/config/schema.py
+++ b/src/crypto_analyzer/config/schema.py
@@ -43,6 +43,7 @@ class FeatureSettings(_BaseModel):
     include_onchain: bool = True
     include_orderbook: bool = True
     include_derivatives: bool = True
+    include_sentiment: bool = False
     forward_fill_limit: int = Field(default=12)
     fillna_value: float = 0.0
 
@@ -74,6 +75,12 @@ class OnChainSettings(_BaseModel):
     exchange_flow_path: Path | None = None
     request_timeout: int = Field(default=10, ge=0)
     request_retries: int = Field(default=5, ge=0)
+
+
+class SentimentSettings(_BaseModel):
+    use_sentiment: bool = False
+    sentiment_source: Literal["api", "csv"] = "api"
+    sentiment_api_key: str | None = None
 
 
 class CVSettings(_BaseModel):
@@ -115,6 +122,7 @@ class AppConfig(_BaseModel):
     database: DatabaseSettings
     runtime: RuntimeSettings
     features: FeatureSettings
+    sentiment: SentimentSettings
     models: ModelSettings
     backtest: BacktestSettings
     onchain: OnChainSettings
@@ -189,6 +197,7 @@ __all__ = [
     "FeatureSettings",
     "ModelSettings",
     "OnChainSettings",
+    "SentimentSettings",
     "OrderbookSettings",
     "RuntimeSettings",
 ]

--- a/src/crypto_analyzer/features/engineering.py
+++ b/src/crypto_analyzer/features/engineering.py
@@ -63,6 +63,8 @@ ONCHAIN_FEATURES = (
     "onch_diff_change_pct",
 )
 
+SENTIMENT_COLUMN_PREFIXES: tuple[str, ...] = ("sent_", "sentiment_")
+
 
 @dataclass(frozen=True)
 class FeatureColumnRegistry:
@@ -72,6 +74,7 @@ class FeatureColumnRegistry:
     orderbook: tuple[str, ...]
     derivatives: tuple[str, ...]
     onchain: tuple[str, ...]
+    sentiment: tuple[str, ...] = ()
 
     def active(self, settings: FeatureSettings) -> list[str]:
         """Return feature names enabled under *settings*."""
@@ -83,6 +86,8 @@ class FeatureColumnRegistry:
             columns.extend(self.derivatives)
         if settings.include_onchain:
             columns.extend(self.onchain)
+        if settings.include_sentiment and CONFIG.sentiment.use_sentiment:
+            columns.extend(self.sentiment)
         return columns
 
 
@@ -178,6 +183,7 @@ REGISTRY = FeatureColumnRegistry(
         "deriv_liq_to_oi",
     ),
     onchain=ONCHAIN_FEATURES,
+    sentiment=(),
 )
 
 
@@ -491,6 +497,23 @@ def create_features(
         drop_cols = [c for c in df.columns if c.startswith("onch_")]
         if drop_cols:
             df = df.drop(columns=drop_cols)
+
+    include_sentiment = bool(
+        settings.include_sentiment and CONFIG.sentiment.use_sentiment
+    )
+    sentiment_cols = [
+        c for c in df.columns if c.startswith(SENTIMENT_COLUMN_PREFIXES)
+    ]
+    if include_sentiment:
+        if sentiment_cols:
+            numeric_sentiment = df[sentiment_cols].apply(
+                pd.to_numeric, errors="coerce"
+            )
+            df[sentiment_cols] = (
+                numeric_sentiment.fillna(fill_value).astype(np.float32)
+            )
+    elif sentiment_cols:
+        df = df.drop(columns=sentiment_cols)
 
     ts = pd.to_datetime(df["timestamp"], utc=True)
     timeframe_info = _build_timeframe_info(ts, MULTI_TF_MINUTES)

--- a/src/crypto_analyzer/utils/config.py
+++ b/src/crypto_analyzer/utils/config.py
@@ -22,6 +22,7 @@ from crypto_analyzer.config.schema import (
     ModelSettings,
     OnChainSettings,
     OrderbookSettings,
+    SentimentSettings,
     RuntimeSettings,
 )
 from crypto_analyzer.utils.errors import ConfigError
@@ -193,17 +194,24 @@ def _build_runtime_settings(data: dict[str, Any]) -> RuntimeSettings:
     )
 
 
-def _build_feature_settings(data: dict[str, Any]) -> FeatureSettings:
+def _build_feature_settings(
+    data: dict[str, Any], sentiment: SentimentSettings | None = None
+) -> FeatureSettings:
     defaults = FeatureSettings()
+    default_sentiment = (
+        sentiment.use_sentiment if sentiment is not None else defaults.include_sentiment
+    )
     include_onchain = _as_bool(data.get("include_onchain"), defaults.include_onchain)
     include_orderbook = _as_bool(data.get("include_orderbook"), defaults.include_orderbook)
     include_derivatives = _as_bool(data.get("include_derivatives"), defaults.include_derivatives)
+    include_sentiment = _as_bool(data.get("include_sentiment"), default_sentiment)
     forward_fill_limit = _as_int(data.get("forward_fill_limit"), defaults.forward_fill_limit)
     fillna_value = _as_float(data.get("fillna_value"), defaults.fillna_value)
     return FeatureSettings(
         include_onchain=include_onchain,
         include_orderbook=include_orderbook,
         include_derivatives=include_derivatives,
+        include_sentiment=include_sentiment,
         forward_fill_limit=forward_fill_limit,
         fillna_value=fillna_value,
     )
@@ -331,13 +339,34 @@ def _build_orderbook_settings(data: dict[str, Any]) -> OrderbookSettings:
     return OrderbookSettings(depth_levels=depth_levels)
 
 
+def _build_sentiment_settings(data: dict[str, Any]) -> SentimentSettings:
+    defaults = SentimentSettings()
+    use_sentiment = _as_bool(data.get("use_sentiment"), defaults.use_sentiment)
+    source = _as_str(data.get("sentiment_source"), defaults.sentiment_source)
+    if source not in {"api", "csv"}:
+        source = defaults.sentiment_source
+    api_key_raw = data.get("sentiment_api_key")
+    if api_key_raw in (None, ""):
+        api_key = None
+    else:
+        api_key = str(api_key_raw)
+    return SentimentSettings(
+        use_sentiment=use_sentiment,
+        sentiment_source=source,  # type: ignore[arg-type]
+        sentiment_api_key=api_key,
+    )
+
+
 def _build_config() -> AppConfig:
     raw_config, path = _read_config_file()
     try:
         core = _build_core_settings(raw_config.get("core", {}))
         database = _build_database_settings(raw_config.get("database", {}))
         runtime = _build_runtime_settings(raw_config.get("runtime", {}))
-        features = _build_feature_settings(raw_config.get("features", {}))
+        sentiment = _build_sentiment_settings(raw_config.get("sentiment", {}))
+        features = _build_feature_settings(
+            raw_config.get("features", {}), sentiment=sentiment
+        )
         models = _build_model_settings(raw_config.get("models", {}))
         backtest = _build_backtest_settings(raw_config.get("backtest", {}))
         onchain = _build_onchain_settings(raw_config.get("onchain", {}), runtime)
@@ -360,6 +389,7 @@ def _build_config() -> AppConfig:
             database=database,
             runtime=runtime,
             features=features,
+            sentiment=sentiment,
             models=models,
             backtest=backtest,
             onchain=onchain,
@@ -386,6 +416,7 @@ def override_feature_settings(
     include_onchain: bool | None = None,
     include_orderbook: bool | None = None,
     include_derivatives: bool | None = None,
+    include_sentiment: bool | None = None,
     forward_fill_limit: int | None = None,
     fillna_value: float | None = None,
 ) -> FeatureSettings:
@@ -398,6 +429,8 @@ def override_feature_settings(
         updates["include_orderbook"] = bool(include_orderbook)
     if include_derivatives is not None:
         updates["include_derivatives"] = bool(include_derivatives)
+    if include_sentiment is not None:
+        updates["include_sentiment"] = bool(include_sentiment)
     if forward_fill_limit is not None:
         updates["forward_fill_limit"] = int(forward_fill_limit)
     if fillna_value is not None:
@@ -422,6 +455,7 @@ __all__ = [
     "FeatureSettings",
     "ModelSettings",
     "OnChainSettings",
+    "SentimentSettings",
     "RuntimeSettings",
     "override_feature_settings",
     "config_to_dict",

--- a/tests/test_features_types.py
+++ b/tests/test_features_types.py
@@ -9,7 +9,7 @@ from crypto_analyzer.features.engineering import (
     get_feature_columns,
     validate_feature_inputs,
 )
-from crypto_analyzer.utils.config import FeatureSettings
+from crypto_analyzer.utils.config import CONFIG, FeatureSettings
 
 
 def test_features_types():
@@ -70,6 +70,7 @@ def test_feature_toggles_respected():
             "lob_ask_price_1": rng.random(n) + 101,
             "lob_ask_size_1": rng.random(n),
             "onch_fee_fast_satvb": rng.random(n),
+            "sent_score": rng.random(n),
         }
     )
 
@@ -77,6 +78,7 @@ def test_feature_toggles_respected():
         include_onchain=False,
         include_orderbook=False,
         include_derivatives=False,
+        include_sentiment=False,
         forward_fill_limit=0,
         fillna_value=-1.0,
     )
@@ -85,16 +87,56 @@ def test_feature_toggles_respected():
     assert not any(col.startswith("onch_") for col in feat_df.columns)
     assert not any(col.startswith("lob_") or col.startswith("wall_") for col in feat_df.columns)
     assert {"basis_annualized", "oi_delta_1d"}.isdisjoint(feat_df.columns)
+    assert "sent_score" not in feat_df.columns
 
     active_cols = get_feature_columns(settings)
     assert all(col in feat_df.columns for col in active_cols)
     assert "basis_annualized" not in active_cols
     assert "lob_imbalance_L1" not in active_cols
     assert all(not col.startswith("onch_") for col in active_cols)
+    assert all(not col.startswith("sent_") for col in active_cols)
 
     numeric_cols = feat_df.select_dtypes(include=[np.number]).columns
     assert not feat_df[numeric_cols].isna().any().any()
     assert np.isclose(float(feat_df["ret3"].iloc[0]), settings.fillna_value)
+
+
+def test_create_features_includes_sentiment_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    ts = pd.date_range("2024-01-01", periods=5, freq="1D", tz="UTC")
+    base = pd.DataFrame(
+        {
+            "timestamp": ts,
+            "open": 1.0,
+            "high": 1.5,
+            "low": 0.5,
+            "close": 1.1,
+            "volume": 100.0,
+            "quote_asset_volume": 200.0,
+            "taker_buy_base": 50.0,
+            "taker_buy_quote": 110.0,
+            "sent_score": [0.1, np.nan, 0.3, 0.4, 0.5],
+        }
+    )
+
+    settings = FeatureSettings(
+        include_onchain=False,
+        include_orderbook=False,
+        include_derivatives=False,
+        include_sentiment=True,
+        forward_fill_limit=0,
+        fillna_value=-1.0,
+    )
+
+    sentiment_enabled = CONFIG.sentiment.model_copy(update={"use_sentiment": True})
+    config_override = CONFIG.model_copy(update={"sentiment": sentiment_enabled})
+    monkeypatch.setattr(
+        "crypto_analyzer.features.engineering.CONFIG", config_override
+    )
+
+    feat_df = create_features(base, settings=settings)
+    assert "sent_score" in feat_df.columns
+    assert feat_df["sent_score"].dtype == np.float32
+    assert not feat_df["sent_score"].isna().any()
 
 
 def test_create_features_rejects_missing_columns():


### PR DESCRIPTION
## Summary
- introduce SentimentSettings to the application schema and configuration loader, and provide default values in the sample configs
- wire sentiment inclusion through feature engineering so sentiment columns are retained only when both global and run-time toggles enable them
- extend CLI entrypoints and feature-setting helpers to expose sentiment options and add regression tests covering the new behaviour

## Testing
- `pytest tests/test_features_types.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68f2329fa0d48327b952382d3952d901