### PR TITLE
Add data validation for price data and features

### DIFF
--- a/src/crypto_analyzer/features/engineering.py
+++ b/src/crypto_analyzer/features/engineering.py
@@ -9,6 +9,7 @@ import pandas as pd
 from pandas.api.types import is_datetime64_any_dtype, is_numeric_dtype
 
 from crypto_analyzer.utils.config import CONFIG, FeatureSettings
+from crypto_analyzer.utils.validation import validate_features, validate_price_data
 
 # Lehký FE laděný pro 2h BTCUSDT. Bez těžkých závislostí, vše float32.
 
@@ -482,6 +483,7 @@ def create_features(
     """
 
     settings = _resolve_feature_settings(settings)
+    validate_price_data(df)
     df = df.copy()
     validate_feature_inputs(df, settings)
     fill_value = np.float32(settings.fillna_value)
@@ -934,6 +936,8 @@ def create_features(
     if len(numeric_cols) > 0:
         df[numeric_cols] = df[numeric_cols].astype(np.float32)
         df[numeric_cols] = df[numeric_cols].fillna(fill_value)
+
+    validate_features(df)
 
     # --- validace typů --------------------------------------------------------
     feature_only = df

--- a/src/crypto_analyzer/utils/__init__.py
+++ b/src/crypto_analyzer/utils/__init__.py
@@ -14,4 +14,5 @@ __all__ = [
     "splitting",
     "time",
     "timeframes",
+    "validation",
 ]

--- a/src/crypto_analyzer/utils/validation.py
+++ b/src/crypto_analyzer/utils/validation.py
@@ -1,0 +1,106 @@
+"""Data validation helpers for pipeline processing."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+from crypto_analyzer.utils.config import CONFIG
+from crypto_analyzer.utils.errors import DataValidationError
+
+__all__ = ["validate_price_data", "validate_features"]
+
+
+def _ensure_required_columns(df: pd.DataFrame, columns: Iterable[str]) -> None:
+    missing = [col for col in columns if col not in df.columns]
+    if missing:
+        joined = ", ".join(sorted(missing))
+        raise DataValidationError(f"Missing required column(s): {joined}.")
+
+
+def validate_price_data(df: pd.DataFrame) -> None:
+    """Validate continuity and integrity of raw OHLCV price data.
+
+    Parameters
+    ----------
+    df:
+        Data frame expected to contain at least ``timestamp`` and OHLCV columns.
+
+    Raises
+    ------
+    DataValidationError
+        If timestamps are not strictly increasing, intervals are missing, or
+        if any price/volume values are negative.
+    """
+
+    if df.empty:
+        raise DataValidationError("Price data is empty.")
+
+    _ensure_required_columns(df, ["timestamp"])
+
+    try:
+        timestamps = pd.to_datetime(df["timestamp"], utc=True)
+    except (TypeError, ValueError) as exc:
+        raise DataValidationError("Unable to parse timestamps in price data.") from exc
+
+    if timestamps.isna().any():
+        raise DataValidationError("Price data contains invalid or missing timestamps.")
+
+    if not timestamps.is_monotonic_increasing:
+        raise DataValidationError("Timestamps must be strictly increasing.")
+
+    if not timestamps.is_unique:
+        raise DataValidationError("Duplicate timestamps detected in price data.")
+
+    try:
+        expected_delta = pd.to_timedelta(CONFIG.interval)
+    except ValueError as exc:
+        raise DataValidationError("Invalid interval configuration for validation.") from exc
+
+    for idx in range(1, len(timestamps)):
+        delta = timestamps.iloc[idx] - timestamps.iloc[idx - 1]
+        if delta != expected_delta:
+            raise DataValidationError(
+                "Detected missing or irregular interval between "
+                f"{timestamps.iloc[idx - 1]} and {timestamps.iloc[idx]}."
+            )
+
+    numeric_columns = [
+        col for col in ("open", "high", "low", "close", "volume") if col in df.columns
+    ]
+    if numeric_columns:
+        for column in numeric_columns:
+            values = pd.to_numeric(df[column], errors="coerce")
+            if np.isnan(values).any():
+                raise DataValidationError(
+                    f"Column '{column}' contains non-numeric or missing values in price data."
+                )
+            if not np.isfinite(values).all():
+                raise DataValidationError(
+                    f"Column '{column}' contains non-finite values in price data."
+                )
+            if (values < 0).any():
+                raise DataValidationError(
+                    f"Column '{column}' contains negative values in price data."
+                )
+
+
+def validate_features(df: pd.DataFrame) -> None:
+    """Validate engineered features for downstream model consumption."""
+
+    if df.empty:
+        raise DataValidationError("Feature data is empty after engineering.")
+
+    numeric_df = df.select_dtypes(include=[np.number])
+    if numeric_df.empty:
+        return
+
+    invalid_mask = ~np.isfinite(numeric_df.values)
+    if invalid_mask.any():
+        bad_row, bad_col = np.argwhere(invalid_mask)[0]
+        column_name = numeric_df.columns[bad_col]
+        raise DataValidationError(
+            f"Feature column '{column_name}' contains NaN or infinite values."
+        )

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from crypto_analyzer.utils.config import CONFIG
+from crypto_analyzer.utils.errors import DataValidationError
+from crypto_analyzer.utils.validation import validate_features, validate_price_data
+
+
+def _build_price_frame() -> pd.DataFrame:
+    timestamps = pd.date_range(
+        "2024-01-01", periods=4, freq=CONFIG.interval, tz="UTC"
+    )
+    return pd.DataFrame(
+        {
+            "timestamp": timestamps,
+            "open": np.linspace(10.0, 13.0, len(timestamps)),
+            "high": np.linspace(11.0, 14.0, len(timestamps)),
+            "low": np.linspace(9.0, 12.0, len(timestamps)),
+            "close": np.linspace(10.5, 13.5, len(timestamps)),
+            "volume": np.full(len(timestamps), 1000.0),
+        }
+    )
+
+
+def test_validate_price_data_allows_regular_intervals() -> None:
+    df = _build_price_frame()
+    validate_price_data(df)
+
+
+def test_validate_price_data_detects_missing_interval() -> None:
+    df = _build_price_frame().iloc[:3].copy()
+    df.loc[2, "timestamp"] = df.loc[1, "timestamp"] + 2 * pd.to_timedelta(CONFIG.interval)
+    with pytest.raises(DataValidationError, match="missing or irregular interval"):
+        validate_price_data(df)
+
+
+def test_validate_price_data_detects_duplicate_timestamps() -> None:
+    df = _build_price_frame().iloc[:3].copy()
+    df.loc[2, "timestamp"] = df.loc[1, "timestamp"]
+    with pytest.raises(DataValidationError, match="Duplicate timestamps"):
+        validate_price_data(df)
+
+
+def test_validate_price_data_detects_negative_values() -> None:
+    df = _build_price_frame()
+    df.loc[1, "close"] = -5.0
+    with pytest.raises(DataValidationError, match="negative values"):
+        validate_price_data(df)
+
+
+def test_validate_features_accepts_finite_values() -> None:
+    df = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2024-01-01", periods=3, freq="D", tz="UTC"),
+            "feature_a": [0.0, -1.0, 2.0],
+            "feature_b": [0.5, 0.75, 1.0],
+        }
+    )
+    validate_features(df)
+
+
+def test_validate_features_detects_nan() -> None:
+    df = pd.DataFrame({"feature_a": [0.0, np.nan]})
+    with pytest.raises(DataValidationError, match="Feature column 'feature_a'"):
+        validate_features(df)
+
+
+def test_validate_features_detects_infinite_values() -> None:
+    df = pd.DataFrame({"feature_a": [0.0, np.inf]})
+    with pytest.raises(DataValidationError, match="Feature column 'feature_a'"):
+        validate_features(df)


### PR DESCRIPTION
## Summary
- add utility helpers to validate raw price inputs and engineered feature outputs
- enforce validation in the feature engineering pipeline and expose the utilities
- cover the new validators with targeted pytest cases

## Testing
- pytest tests/test_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68f235f4f308832782e41aa9c65bef24