### PR TITLE
Add tests for on-chain fetchers and feature engineering

### DIFF
--- a/src/crypto_analyzer/utils/helpers.py
+++ b/src/crypto_analyzer/utils/helpers.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from contextlib import suppress
 from pathlib import Path
 
-__all__ = ["ensure_dir_exists", "set_cpu_limit"]
+from crypto_analyzer.utils.logging import get_logger
+
+__all__ = ["ensure_dir_exists", "set_cpu_limit", "get_logger"]
 
 
 def ensure_dir_exists(path: str | Path) -> Path:

--- a/tests/test_features_types.py
+++ b/tests/test_features_types.py
@@ -139,6 +139,126 @@ def test_create_features_includes_sentiment_when_enabled(monkeypatch: pytest.Mon
     assert not feat_df["sent_score"].isna().any()
 
 
+def test_create_features_excludes_sentiment_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    ts = pd.date_range("2024-01-01", periods=5, freq="1D", tz="UTC")
+    base = pd.DataFrame(
+        {
+            "timestamp": ts,
+            "open": 1.0,
+            "high": 1.5,
+            "low": 0.5,
+            "close": 1.1,
+            "volume": 100.0,
+            "quote_asset_volume": 200.0,
+            "taker_buy_base": 50.0,
+            "taker_buy_quote": 110.0,
+            "sent_score": [0.1, 0.2, 0.3, 0.4, 0.5],
+        }
+    )
+
+    settings = FeatureSettings(
+        include_onchain=False,
+        include_orderbook=False,
+        include_derivatives=False,
+        include_sentiment=True,
+        forward_fill_limit=0,
+        fillna_value=-1.0,
+    )
+
+    sentiment_disabled = CONFIG.sentiment.model_copy(update={"use_sentiment": False})
+    config_override = CONFIG.model_copy(update={"sentiment": sentiment_disabled})
+    monkeypatch.setattr(
+        "crypto_analyzer.features.engineering.CONFIG", config_override
+    )
+
+    feat_df = create_features(base, settings=settings)
+    assert "sent_score" not in feat_df.columns
+
+
+def test_create_features_computes_expected_core_metrics() -> None:
+    n = 15
+    ts = pd.date_range("2024-01-01", periods=n, freq="1D", tz="UTC")
+    close = pd.Series(100.0 + np.arange(n), index=ts)
+    open_ = close - 1.0
+    high = close + 2.0
+    low = close - 2.0
+    volume = pd.Series(10.0 + np.arange(n), index=ts)
+    quote_volume = (volume * (close + 0.5)).astype(float)
+    taker_buy_base = (volume * 0.6).astype(float)
+    taker_buy_quote = (quote_volume * 0.55).astype(float)
+
+    base = pd.DataFrame(
+        {
+            "timestamp": ts,
+            "open": open_.to_numpy(),
+            "high": high.to_numpy(),
+            "low": low.to_numpy(),
+            "close": close.to_numpy(),
+            "volume": volume.to_numpy(),
+            "quote_asset_volume": quote_volume.to_numpy(),
+            "taker_buy_base": taker_buy_base.to_numpy(),
+            "taker_buy_quote": taker_buy_quote.to_numpy(),
+        }
+    )
+
+    settings = FeatureSettings(
+        include_onchain=False,
+        include_orderbook=False,
+        include_derivatives=False,
+        include_sentiment=False,
+        forward_fill_limit=0,
+        fillna_value=-1.0,
+    )
+
+    feat_df = create_features(base, settings=settings)
+
+    expected_tbr_base = (taker_buy_base / volume).astype(np.float32).reset_index(drop=True)
+    expected_tbr_base.name = "tbr_base"
+    pd.testing.assert_series_equal(feat_df["tbr_base"], expected_tbr_base)
+
+    expected_ofi_base = (2.0 * expected_tbr_base - 1.0).astype(np.float32)
+    expected_ofi_base.name = "ofi_base"
+    pd.testing.assert_series_equal(feat_df["ofi_base"], expected_ofi_base)
+
+    expected_tbr_quote = (taker_buy_quote / quote_volume).astype(np.float32).reset_index(drop=True)
+    expected_ofi_quote = (2.0 * expected_tbr_quote - 1.0).astype(np.float32)
+    expected_ofi_quote.name = "ofi_quote"
+    pd.testing.assert_series_equal(feat_df["ofi_quote"], expected_ofi_quote)
+
+    expected_ret1 = np.log(close).diff().astype(np.float32).reset_index(drop=True)
+    expected_ret3 = (
+        expected_ret1.rolling(3).sum().astype(np.float32).fillna(np.float32(settings.fillna_value))
+    )
+    expected_ret3.name = "ret3"
+    pd.testing.assert_series_equal(feat_df["ret3"], expected_ret3, rtol=1e-6, atol=1e-6)
+
+    expected_volatility = (
+        expected_ret1.rolling(12).std().astype(np.float32).fillna(np.float32(settings.fillna_value))
+    )
+    expected_volatility.name = "volatility_12d"
+    pd.testing.assert_series_equal(
+        feat_df["volatility_12d"], expected_volatility, rtol=1e-6, atol=1e-6
+    )
+
+    expected_roll_1d = expected_ofi_base.rolling(1).mean().astype(np.float32)
+    expected_roll_1d.name = "ofi_base_roll_1d"
+    pd.testing.assert_series_equal(feat_df["ofi_base_roll_1d"], expected_roll_1d)
+
+    expected_roll_7d = (
+        expected_ofi_base.rolling(7)
+        .mean()
+        .astype(np.float32)
+        .fillna(np.float32(settings.fillna_value))
+    )
+    expected_roll_7d.name = "ofi_base_roll_7d"
+    pd.testing.assert_series_equal(
+        feat_df["ofi_base_roll_7d"], expected_roll_7d, rtol=1e-6, atol=1e-6
+    )
+
+    expected_ratio = (taker_buy_base / (volume - taker_buy_base)).astype(np.float32).reset_index(drop=True)
+    expected_ratio.name = "taker_buy_sell_ratio"
+    pd.testing.assert_series_equal(feat_df["taker_buy_sell_ratio"], expected_ratio)
+
 def test_create_features_rejects_missing_columns():
     ts = pd.date_range("2024-01-01", periods=10, freq="1D", tz="UTC")
     df = pd.DataFrame({"timestamp": ts, "open": 1.0, "high": 1.0, "low": 1.0, "close": 1.0})

--- a/tests/test_onchain_fetcher.py
+++ b/tests/test_onchain_fetcher.py
@@ -1,0 +1,171 @@
+"""Tests for on-chain fetcher utilities."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pandas as pd
+import pytest
+import requests
+
+from crypto_analyzer.data.onchain_fetcher import (
+    GLASSNODE_EXCHANGE_INFLOW_ENDPOINT,
+    GLASSNODE_EXCHANGE_OUTFLOW_ENDPOINT,
+    fetch_exchange_flows,
+    fetch_mempool_stats,
+)
+
+
+@pytest.fixture(autouse=True)
+def freeze_timestamp(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure :func:`pd.Timestamp.utcnow` returns a naive timestamp for tests."""
+
+    def _fake_utcnow(_: type[pd.Timestamp]) -> pd.Timestamp:
+        return pd.Timestamp("2024-01-01 00:00:00")
+
+    monkeypatch.setattr(
+        pd.Timestamp,
+        "utcnow",
+        classmethod(_fake_utcnow),
+    )
+
+
+class DummyResponse:
+    """Simple stand-in for ``requests.Response``."""
+
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+        self.status_code = 200
+
+    def json(self) -> Any:
+        return self._payload
+
+    def raise_for_status(self) -> None:  # pragma: no cover - nothing to do on success
+        return None
+
+
+class QueueSession:
+    """Session that returns predetermined responses in order."""
+
+    def __init__(self, responses: Iterator[DummyResponse] | list[DummyResponse]) -> None:
+        self._responses = list(responses)
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get(self, url: str, **kwargs: Any) -> DummyResponse:
+        self.calls.append((url, kwargs))
+        if not self._responses:
+            raise RuntimeError("No more responses queued")
+        return self._responses.pop(0)
+
+
+def test_fetch_mempool_stats_returns_expected_frame() -> None:
+    stats_payload = {"count": "10", "vsize": "200", "total_fee": "300"}
+    fees_payload = {
+        "fastestFee": "25",
+        "halfHourFee": "20",
+        "hourFee": "15",
+        "economyFee": "12",
+        "minimumFee": "5",
+    }
+    session = QueueSession([DummyResponse(stats_payload), DummyResponse(fees_payload)])
+
+    frame = fetch_mempool_stats(session=session)
+
+    expected_columns = {
+        "onch_mempool_count",
+        "onch_mempool_vsize",
+        "onch_mempool_total_fee",
+        "onch_mempool_fee_fastest",
+        "onch_mempool_fee_half_hour",
+        "onch_mempool_fee_hour",
+        "onch_mempool_fee_economy",
+        "onch_mempool_fee_minimum",
+    }
+    assert set(frame.columns) == expected_columns
+    assert frame.shape[0] == 1
+
+    row = frame.iloc[0]
+    assert row["onch_mempool_count"] == pytest.approx(10.0)
+    assert row["onch_mempool_vsize"] == pytest.approx(200.0)
+    assert row["onch_mempool_total_fee"] == pytest.approx(300.0)
+    assert row["onch_mempool_fee_fastest"] == pytest.approx(25.0)
+    assert row["onch_mempool_fee_half_hour"] == pytest.approx(20.0)
+    assert row["onch_mempool_fee_hour"] == pytest.approx(15.0)
+    assert row["onch_mempool_fee_economy"] == pytest.approx(12.0)
+    assert row["onch_mempool_fee_minimum"] == pytest.approx(5.0)
+    assert frame.index.name == "timestamp"
+    assert frame.index.tz is not None
+
+
+def test_fetch_mempool_stats_handles_request_errors() -> None:
+    class FailingSession:
+        def get(self, *_: Any, **__: Any) -> Any:
+            raise requests.RequestException("boom")
+
+    frame = fetch_mempool_stats(session=FailingSession())
+
+    assert frame.empty
+    assert frame.index.name == "timestamp"
+    assert frame.index.tz is not None
+    assert list(frame.columns) == [
+        "onch_mempool_count",
+        "onch_mempool_vsize",
+        "onch_mempool_total_fee",
+        "onch_mempool_fee_fastest",
+        "onch_mempool_fee_half_hour",
+        "onch_mempool_fee_hour",
+        "onch_mempool_fee_economy",
+        "onch_mempool_fee_minimum",
+    ]
+
+
+def test_fetch_exchange_flows_returns_expected_series() -> None:
+    inflow_payload = [
+        {"t": 1_700_000_000, "v": 1.5},
+        {"t": 1_700_086_400, "v": 2.5},
+    ]
+    outflow_payload = [
+        {"t": 1_700_000_000, "v": 0.5},
+        {"t": 1_700_086_400, "v": 0.75},
+    ]
+
+    responses = {
+        GLASSNODE_EXCHANGE_INFLOW_ENDPOINT: DummyResponse(inflow_payload),
+        GLASSNODE_EXCHANGE_OUTFLOW_ENDPOINT: DummyResponse(outflow_payload),
+    }
+
+    class MappingSession:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def get(self, url: str, **kwargs: Any) -> DummyResponse:
+            self.calls.append(url)
+            return responses[url]
+
+    session = MappingSession()
+
+    frame = fetch_exchange_flows("key", session=session)
+
+    assert list(frame.columns) == ["onch_exchange_inflow", "onch_exchange_outflow"]
+    assert frame.index.name == "timestamp"
+    assert frame.index.tz is not None
+    assert frame.loc[pd.Timestamp(1_700_000_000, unit="s", tz="UTC"), "onch_exchange_inflow"] == pytest.approx(
+        1.5
+    )
+    assert frame.loc[pd.Timestamp(1_700_086_400, unit="s", tz="UTC"), "onch_exchange_outflow"] == pytest.approx(
+        0.75
+    )
+
+
+def test_fetch_exchange_flows_handles_request_errors() -> None:
+    class FailingSession:
+        def get(self, *_: Any, **__: Any) -> Any:
+            raise requests.RequestException("nope")
+
+    frame = fetch_exchange_flows("key", session=FailingSession())
+
+    assert frame.empty
+    assert frame.index.name == "timestamp"
+    assert frame.index.tz is not None
+    assert list(frame.columns) == ["onch_exchange_inflow", "onch_exchange_outflow"]


### PR DESCRIPTION
## Summary
- add dedicated tests covering success and error paths for the on-chain data fetcher helpers
- extend feature engineering tests to cover sentiment toggles and validate refactored feature calculations
- re-export `get_logger` from the helpers module to preserve backwards compatibility with existing imports

## Testing
- pytest tests/test_onchain_fetcher.py tests/test_features_types.py
- pytest --cov *(fails: coverage 78.34% with several pre-existing test failures in the full suite)*

------
https://chatgpt.com/codex/tasks/task_e_68f2388fd6f08327af754d2df33bdb4a