### PR TITLE
Refactor price storage to SQLAlchemy

### DIFF
--- a/config/app.example.yaml
+++ b/config/app.example.yaml
@@ -17,6 +17,8 @@ core:
 database:
   # Primary SQLite database containing OHLCV candles
   price_store: data/crypto_data.sqlite
+  # Optional SQLAlchemy connection URL (e.g. postgresql+psycopg://user:pass@host/db)
+  url: null
   # Table for persisting model predictions
   predictions_table: predictions
   # Table containing on-chain metrics aligned to the candle grid
@@ -25,6 +27,9 @@ database:
   feature_store: null
   # Chunk size used when streaming large tables from disk
   read_chunksize: 100000
+  # Connection pool sizing when using SQLAlchemy engines
+  pool_size: 5
+  max_overflow: 10
 
 runtime:
   # Maximum number of CPU cores to use (integer or "auto" for all available)

--- a/config/app.yaml
+++ b/config/app.yaml
@@ -7,10 +7,13 @@ core:
 
 database:
   price_store: data/crypto_data.sqlite
+  url: null
   predictions_table: predictions
   onchain_table: onchain_1d
   feature_store: null
   read_chunksize: 100000
+  pool_size: 5
+  max_overflow: 10
 
 runtime:
   cpu_limit: auto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ dependencies = [
     "python-dotenv==1.0.1",
     "psutil==6.0.0",
     "pandera==0.20.3",
+    "SQLAlchemy==2.0.35",
+    "psycopg[binary]==3.1.12",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,8 @@ ta==0.10.3
 torch==2.4.1
 psutil==6.0.0
 pandera==0.20.3
+SQLAlchemy==2.0.35
+psycopg[binary]==3.1.12
 
 # Formatting & linting
 black==24.4.2

--- a/src/crypto_analyzer/config/schema.py
+++ b/src/crypto_analyzer/config/schema.py
@@ -24,10 +24,13 @@ class CoreSettings(_BaseModel):
 
 class DatabaseSettings(_BaseModel):
     price_store: Path = Path("data/crypto_data.sqlite")
+    url: str | None = None
     predictions_table: str = "predictions"
     onchain_table: str = "onchain_1d"
     feature_store: Path | None = None
     read_chunksize: int = Field(default=100_000, ge=1)
+    pool_size: int = Field(default=5, ge=1)
+    max_overflow: int = Field(default=10, ge=0)
 
 
 class RuntimeSettings(_BaseModel):
@@ -171,6 +174,10 @@ class AppConfig(_BaseModel):
     @property
     def db_path(self) -> Path:
         return self.database.price_store
+
+    @property
+    def db_url(self) -> str | None:
+        return self.database.url
 
     @property
     def table_pred(self) -> str:

--- a/src/crypto_analyzer/data/binance_import.py
+++ b/src/crypto_analyzer/data/binance_import.py
@@ -1,4 +1,3 @@
-import sqlite3
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -7,11 +6,17 @@ import requests
 
 from crypto_analyzer.utils.config import CONFIG
 from crypto_analyzer.utils.helpers import ensure_dir_exists, get_logger
+from crypto_analyzer.data.db_connector import (
+    get_latest_open_time,
+    init_timescale,
+    save_to_db,
+)
 
 logger = get_logger(__name__)
 
 DB_PATH = Path(CONFIG.db_path)
 ensure_dir_exists(DB_PATH.parent)
+DB_TARGET = getattr(CONFIG, "db_url", None) or str(DB_PATH)
 TABLE_NAME = "prices"
 SYMBOL = CONFIG.symbol
 INTERVAL = CONFIG.interval
@@ -35,56 +40,7 @@ def get_klines(symbol, interval, start_ts, end_ts, limit=1000):
     return response.json()
 
 def create_db():
-    conn = sqlite3.connect(DB_PATH)
-    c = conn.cursor()
-    c.execute(
-        f"""
-    CREATE TABLE IF NOT EXISTS {TABLE_NAME} (
-        open_time INTEGER PRIMARY KEY,
-        symbol TEXT,
-        interval TEXT,
-        open REAL,
-        high REAL,
-        low REAL,
-        close REAL,
-        volume REAL,
-        close_time INTEGER,
-        quote_asset_volume REAL,
-        number_of_trades INTEGER,
-        taker_buy_base REAL,
-        taker_buy_quote REAL
-    )"""
-    )
-    conn.commit()
-    conn.close()
-
-def save_to_db(rows, symbol, interval):
-    conn = sqlite3.connect(DB_PATH)
-    c = conn.cursor()
-    for row in rows:
-        c.execute(
-            f"""
-        INSERT OR IGNORE INTO {TABLE_NAME}
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """,
-            (
-                int(row[0]),
-                symbol,
-                interval,
-                float(row[1]),
-                float(row[2]),
-                float(row[3]),
-                float(row[4]),
-                float(row[5]),
-                int(row[6]),
-                float(row[7]),
-                int(row[8]),
-                float(row[9]),
-                float(row[10]),
-            ),
-        )
-    conn.commit()
-    conn.close()
+    init_timescale()
 
 def import_latest_data():
     create_db()
@@ -95,13 +51,7 @@ def import_latest_data():
     lookback_ts = int((now_utc - timedelta(days=LOOKBACK_DAYS)).timestamp() * 1000)
 
     # pokračuj od posledního záznamu, ale nikdy ne dřív než lookback
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-    cur.execute(f"SELECT MAX(open_time) FROM {TABLE_NAME}")
-    row = cur.fetchone()
-    conn.close()
-
-    last_db_ts = row[0] if row and row[0] is not None else None
+    last_db_ts = get_latest_open_time(symbol=SYMBOL, interval=INTERVAL)
     if last_db_ts is None:
         start_ts = lookback_ts
     else:
@@ -130,7 +80,7 @@ def import_latest_data():
         curr_ts = klines[-1][0] + 1
         time.sleep(0.4)
 
-    logger.info("Import hotov", extra={"db_path": str(DB_PATH)})
+    logger.info("Import hotov", extra={"db_target": DB_TARGET})
 
 def main():
     import_latest_data()

--- a/src/crypto_analyzer/data/db_connector.py
+++ b/src/crypto_analyzer/data/db_connector.py
@@ -1,13 +1,64 @@
+"""Database access helpers backed by SQLAlchemy engines.
+
+The original implementation relied on SQLite ``sqlite3`` connections.  To
+support TimescaleDB and other SQL backends efficiently we now delegate all
+database interactions to SQLAlchemy.  Engines are cached to avoid repeatedly
+opening new connections and both inserts and selects are fully parameterised
+to prevent SQL injection.
+"""
+
 from __future__ import annotations
 
+from itertools import chain
 from pathlib import Path
-import sqlite3
-from typing import Iterable
+from typing import Iterable, Iterator, Sequence
 
 import pandas as pd
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    Float,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    create_engine,
+    func,
+    select,
+    text,
+)
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.engine import Engine
 
-# Resolve database path relative to the project root so callers don't depend on CWD
+try:  # pragma: no cover - optional dependency for tests
+    from crypto_analyzer.utils.config import CONFIG
+except ModuleNotFoundError:  # pragma: no cover - config is optional in tests
+    CONFIG = None  # type: ignore[assignment]
+
+
 DEFAULT_DB_PATH = Path(__file__).resolve().parents[3] / "data" / "crypto_data.sqlite"
+
+_METADATA = MetaData()
+PRICES_TABLE = Table(
+    "prices",
+    _METADATA,
+    Column("open_time", BigInteger, primary_key=True),
+    Column("symbol", String(20), nullable=False),
+    Column("interval", String(10), nullable=False),
+    Column("open", Float, nullable=False),
+    Column("high", Float, nullable=False),
+    Column("low", Float, nullable=False),
+    Column("close", Float, nullable=False),
+    Column("volume", Float, nullable=False),
+    Column("close_time", BigInteger, nullable=False),
+    Column("quote_asset_volume", Float, nullable=False),
+    Column("number_of_trades", Integer, nullable=False),
+    Column("taker_buy_base", Float, nullable=False),
+    Column("taker_buy_quote", Float, nullable=False),
+)
+
+_ENGINES: dict[str, Engine] = {}
 
 
 def _normalise_timestamp(value: int | None) -> int | None:
@@ -16,53 +67,203 @@ def _normalise_timestamp(value: int | None) -> int | None:
     return None if value is None else int(value)
 
 
-def _build_price_query(start_ts: int | None, end_ts: int | None) -> tuple[str, list[int]]:
-    """Return parametrised SQL query and params for the prices lookup."""
+def _path_to_sqlite_url(db_path: Path) -> str:
+    return f"sqlite:///{db_path.expanduser().resolve()}"
 
-    query = "SELECT * FROM prices WHERE symbol = ?"
-    params: list[int] = []
-    if start_ts is not None:
-        query += " AND open_time >= ?"
-        params.append(start_ts)
-    if end_ts is not None:
-        query += " AND open_time <= ?"
-        params.append(end_ts)
-    query += " ORDER BY open_time"
-    return query, params
+
+def _default_config_url() -> str:
+    if CONFIG is not None:
+        db_cfg = getattr(CONFIG, "database", None)
+        if db_cfg is not None and getattr(db_cfg, "url", None):
+            return str(db_cfg.url)
+        cfg_path = getattr(CONFIG, "db_path", None)
+        if cfg_path is not None:
+            return _path_to_sqlite_url(Path(cfg_path))
+    return _path_to_sqlite_url(DEFAULT_DB_PATH)
+
+
+def _resolve_db_url(db_path: str | Path | None) -> str:
+    if db_path is None:
+        return _default_config_url()
+    if isinstance(db_path, Path):
+        return _path_to_sqlite_url(db_path)
+    if "://" in db_path:
+        return db_path
+    return _path_to_sqlite_url(Path(db_path))
+
+
+def _pool_kwargs(url: str) -> dict[str, object]:
+    if CONFIG is None:
+        return {"pool_pre_ping": True}
+    db_cfg = getattr(CONFIG, "database", None)
+    if db_cfg is None:
+        return {"pool_pre_ping": True}
+    kwargs: dict[str, object] = {"pool_pre_ping": True}
+    if url.startswith("sqlite"):
+        return kwargs
+    kwargs["pool_size"] = getattr(db_cfg, "pool_size", 5)
+    kwargs["max_overflow"] = getattr(db_cfg, "max_overflow", 10)
+    return kwargs
+
+
+def get_engine(db_path: str | Path | None = None) -> Engine:
+    """Return a cached SQLAlchemy :class:`Engine` for ``db_path``."""
+
+    url = _resolve_db_url(db_path)
+    engine = _ENGINES.get(url)
+    if engine is None:
+        engine = create_engine(url, future=True, **_pool_kwargs(url))
+        _ENGINES[url] = engine
+    return engine
+
+
+def init_timescale(db_path: str | Path | None = None) -> None:
+    """Create the ``prices`` table and promote it to a hypertable when possible."""
+
+    engine = get_engine(db_path)
+    with engine.begin() as conn:
+        _METADATA.create_all(conn)
+        if engine.dialect.name == "postgresql":
+            conn.execute(
+                text(
+                    "SELECT create_hypertable('prices', 'open_time', if_not_exists => TRUE, "
+                    "migrate_data => TRUE)"
+                )
+            )
+
+
+def _batched(
+    iterable: Sequence[Sequence[object]] | Iterable[Sequence[object]], size: int
+) -> Iterator[list[Sequence[object]]]:
+    batch: list[Sequence[object]] = []
+    for row in iterable:
+        batch.append(row)
+        if len(batch) >= size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def _coerce_row(row: Sequence[object], symbol: str, interval: str) -> dict[str, object]:
+    return {
+        "open_time": int(row[0]),
+        "symbol": symbol,
+        "interval": interval,
+        "open": float(row[1]),
+        "high": float(row[2]),
+        "low": float(row[3]),
+        "close": float(row[4]),
+        "volume": float(row[5]),
+        "close_time": int(row[6]),
+        "quote_asset_volume": float(row[7]),
+        "number_of_trades": int(row[8]),
+        "taker_buy_base": float(row[9]),
+        "taker_buy_quote": float(row[10]),
+    }
+
+
+def _build_insert(engine: Engine):
+    if engine.dialect.name == "postgresql":
+        stmt = pg_insert(PRICES_TABLE)
+    elif engine.dialect.name == "sqlite":
+        stmt = sqlite_insert(PRICES_TABLE)
+    else:
+        stmt = PRICES_TABLE.insert()
+        return stmt
+
+    update_cols = {
+        col.name: getattr(stmt.excluded, col.name)
+        for col in PRICES_TABLE.c
+        if col.name != "open_time"
+    }
+    return stmt.on_conflict_do_update(index_elements=[PRICES_TABLE.c.open_time], set_=update_cols)
+
+
+def save_to_db(
+    rows: Sequence[Sequence[object]] | Iterable[Sequence[object]],
+    symbol: str,
+    interval: str,
+    *,
+    db_path: str | Path | None = None,
+    batch_size: int = 1000,
+) -> None:
+    """Insert or update OHLCV rows for ``symbol`` in batches."""
+
+    engine = get_engine(db_path)
+    insert_stmt = _build_insert(engine)
+
+    iterator = iter(rows)
+    try:
+        first = next(iterator)
+    except StopIteration:
+        return
+
+    with engine.begin() as conn:
+        stream = _batched(chain([first], iterator), max(1, batch_size))
+        for chunk in stream:
+            payload = [_coerce_row(row, symbol, interval) for row in chunk]
+            conn.execute(insert_stmt, payload)
 
 
 def get_price_data(
     symbol: str,
     start_ts: int | None = None,
     end_ts: int | None = None,
-    db_path: str | Path = DEFAULT_DB_PATH,
+    db_path: str | Path | None = None,
 ) -> pd.DataFrame:
-    """Load price (and optional on-chain) data for ``symbol`` from SQLite.
-
-    The function selects all columns from the ``prices`` table so that any
-    additional features (e.g. on-chain metrics prefixed ``onch_``) are loaded as
-    well.  The ``open_time`` column is renamed to ``timestamp`` and converted to
-    a timezone-aware ``datetime``.  Non-price helper columns such as ``symbol``
-    and ``interval`` are dropped if present.
-    """
+    """Load price (and optional on-chain) data for ``symbol`` using SQLAlchemy."""
 
     start = _normalise_timestamp(start_ts)
     end = _normalise_timestamp(end_ts)
-    query, extra_params = _build_price_query(start, end)
-    params: list[object] = [symbol, *extra_params]
 
-    with sqlite3.connect(str(db_path)) as conn:
-        df = pd.read_sql(query, conn, params=params)
+    engine = get_engine(db_path)
+    stmt = select(PRICES_TABLE).where(PRICES_TABLE.c.symbol == symbol)
+    if start is not None:
+        stmt = stmt.where(PRICES_TABLE.c.open_time >= start)
+    if end is not None:
+        stmt = stmt.where(PRICES_TABLE.c.open_time <= end)
+    stmt = stmt.order_by(PRICES_TABLE.c.open_time)
+
+    with engine.connect() as conn:
+        df = pd.read_sql(stmt, conn)
 
     if "open_time" in df.columns:
         df = df.rename(columns={"open_time": "timestamp"})
     df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms", utc=True)
 
-    drop_cols: Iterable[str] = (
-        col for col in ("symbol", "interval", "close_time") if col in df.columns
-    )
-    if drop := list(drop_cols):
-        df = df.drop(columns=drop)
+    drop_cols = [col for col in ("symbol", "interval", "close_time") if col in df.columns]
+    if drop_cols:
+        df = df.drop(columns=drop_cols)
 
     df = df.sort_values("timestamp").reset_index(drop=True)
     return df
+
+
+def get_latest_open_time(
+    *, symbol: str | None = None, interval: str | None = None, db_path: str | Path | None = None
+) -> int | None:
+    """Return the newest ``open_time`` value present in the prices table."""
+
+    engine = get_engine(db_path)
+    stmt = select(func.max(PRICES_TABLE.c.open_time))
+    if symbol is not None:
+        stmt = stmt.where(PRICES_TABLE.c.symbol == symbol)
+    if interval is not None:
+        stmt = stmt.where(PRICES_TABLE.c.interval == interval)
+
+    with engine.connect() as conn:
+        result = conn.execute(stmt).scalar_one_or_none()
+    return int(result) if result is not None else None
+
+
+__all__ = [
+    "DEFAULT_DB_PATH",
+    "PRICES_TABLE",
+    "get_engine",
+    "get_latest_open_time",
+    "get_price_data",
+    "init_timescale",
+    "save_to_db",
+]
+

--- a/src/crypto_analyzer/eval/comparison.py
+++ b/src/crypto_analyzer/eval/comparison.py
@@ -1,31 +1,31 @@
 from __future__ import annotations
 
-import sqlite3
 from pathlib import Path
 from typing import Iterable
 
 import pandas as pd
 
+from sqlalchemy import select, text
+
 from crypto_analyzer.utils.config import CONFIG
 from crypto_analyzer.utils.helpers import get_logger
+from crypto_analyzer.data.db_connector import PRICES_TABLE, get_engine
 
 logger = get_logger(__name__)
 
 
-def _build_prices_query(symbol: str, target_times: Iterable[int]) -> tuple[str, list[int]]:
-    """Return SQL query and parameters for the prices lookup."""
+def _build_prices_query(symbol: str, target_times: Iterable[int]):
+    """Return a parametrised SQLAlchemy statement for the prices lookup."""
 
     unique_times = sorted({int(ts) for ts in target_times})
     if not unique_times:
-        return "SELECT NULL AS ts_ms, NULL AS close WHERE 0", []
+        return select(text("NULL AS ts_ms"), text("NULL AS close")).where(text("0=1"))
 
-    placeholders = ",".join("?" for _ in unique_times)
-    query = (
-        "SELECT open_time AS ts_ms, close FROM prices "
-        f"WHERE symbol = ? AND open_time IN ({placeholders})"
+    return (
+        select(PRICES_TABLE.c.open_time.label("ts_ms"), PRICES_TABLE.c.close)
+        .where(PRICES_TABLE.c.symbol == symbol)
+        .where(PRICES_TABLE.c.open_time.in_(unique_times))
     )
-    params = [symbol, *unique_times]
-    return query, params
 
 
 def backfill_actuals_and_errors(
@@ -39,22 +39,25 @@ def backfill_actuals_and_errors(
     memory usage small even for large tables.
     """
 
-    with sqlite3.connect(str(db_path)) as conn:
+    engine = get_engine(db_path)
+    with engine.begin() as conn:
         preds = pd.read_sql(
-            f"""
-            SELECT id, target_time_ms, p_hat
-            FROM {table_pred}
-            WHERE y_true_hat IS NULL AND symbol = ?
-            """,
+            text(
+                f"""
+                SELECT id, target_time_ms, p_hat
+                FROM {table_pred}
+                WHERE y_true_hat IS NULL AND symbol = :symbol
+                """
+            ),
             conn,
-            params=(symbol,),
+            params={"symbol": symbol},
         ).dropna(subset=["target_time_ms"])
         if preds.empty:
             logger.info("No predictions to backfill")
             return
 
-        query, params = _build_prices_query(symbol, preds["target_time_ms"].to_list())
-        actuals = pd.read_sql(query, conn, params=params)
+        query = _build_prices_query(symbol, preds["target_time_ms"].to_list())
+        actuals = pd.read_sql(query, conn)
 
         merged = preds.merge(
             actuals,
@@ -64,7 +67,11 @@ def backfill_actuals_and_errors(
         ).rename(columns={"close": "y_true_hat"})
 
         updates = [
-            (float(row.y_true_hat), float(abs(row.p_hat - row.y_true_hat)), int(row.id))
+            {
+                "y_true_hat": float(row.y_true_hat),
+                "abs_error": float(abs(row.p_hat - row.y_true_hat)),
+                "id": int(row.id),
+            }
             for row in merged.itertuples(index=False)
             if pd.notna(row.y_true_hat)
         ]
@@ -72,9 +79,14 @@ def backfill_actuals_and_errors(
             logger.info("No matching price data found for pending predictions")
             return
 
-        conn.executemany(
-            f"UPDATE {table_pred} SET y_true_hat = ?, abs_error = ? WHERE id = ?",
+        conn.execute(
+            text(
+                f"""
+                UPDATE {table_pred}
+                SET y_true_hat = :y_true_hat, abs_error = :abs_error
+                WHERE id = :id
+                """
+            ),
             updates,
         )
-        conn.commit()
         logger.info("Backfill complete")

--- a/src/crypto_analyzer/models/train.py
+++ b/src/crypto_analyzer/models/train.py
@@ -837,7 +837,7 @@ def main_cli(args) -> Path:
     run_id = args.run_id or pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
     out_dir = Path("outputs") / run_id
 
-    df = get_price_data(CONFIG.symbol, db_path=CONFIG.db_path)
+    df = get_price_data(CONFIG.symbol)
     df = create_features(df)
     steps = args.horizon // 5
     df["target_cls"] = (df["close"].shift(-steps) > df["close"]).astype(int)

--- a/src/crypto_analyzer/pipeline.py
+++ b/src/crypto_analyzer/pipeline.py
@@ -182,7 +182,7 @@ def run_pipeline(
         )
     horizon_steps = max(1, horizon // interval_minutes)
 
-    df = get_price_data(cfg.symbol, db_path=cfg.db_path)
+    df = get_price_data(cfg.symbol)
     df = create_features(df, settings=feature_settings)
     df = make_targets(df, horizons_min=[horizon], txn_cost_bps=txn_cost_bps)
     target_col = f"cls_sign_{horizon}m"

--- a/src/crypto_analyzer/utils/config.py
+++ b/src/crypto_analyzer/utils/config.py
@@ -150,6 +150,7 @@ def _build_core_settings(data: dict[str, Any]) -> CoreSettings:
 def _build_database_settings(data: dict[str, Any]) -> DatabaseSettings:
     defaults = DatabaseSettings()
     db_path = os.getenv("DB_PATH") or _as_str(data.get("price_store"), str(defaults.price_store))
+    db_url = os.getenv("DATABASE_URL") or _as_str(data.get("url"), defaults.url)
     table_pred = os.getenv("TABLE_PRED") or _as_str(
         data.get("predictions_table"), defaults.predictions_table
     )
@@ -161,12 +162,17 @@ def _build_database_settings(data: dict[str, Any]) -> DatabaseSettings:
         else defaults.feature_store
     )
     read_chunksize = _as_int(data.get("read_chunksize"), defaults.read_chunksize)
+    pool_size = _as_int(os.getenv("DB_POOL_SIZE"), defaults.pool_size)
+    max_overflow = _as_int(os.getenv("DB_MAX_OVERFLOW"), defaults.max_overflow)
     return DatabaseSettings(
         price_store=Path(db_path),
+        url=db_url,
         predictions_table=table_pred,
         onchain_table=onchain_table,
         feature_store=Path(feature_store) if feature_store else None,
         read_chunksize=read_chunksize,
+        pool_size=pool_size,
+        max_overflow=max_overflow,
     )
 
 

--- a/tests/test_db_connector.py
+++ b/tests/test_db_connector.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from crypto_analyzer.data import db_connector
+
+
+def _build_rows() -> list[list[float]]:
+    return [
+        [
+            1_700_000_000_000,
+            100.0,
+            110.0,
+            90.0,
+            105.0,
+            1_000.0,
+            1_700_000_050_000,
+            2_000.0,
+            1_234,
+            500.0,
+            600.0,
+        ],
+        [
+            1_700_000_600_000,
+            105.0,
+            115.0,
+            95.0,
+            110.0,
+            1_200.0,
+            1_700_000_650_000,
+            2_100.0,
+            1_300,
+            550.0,
+            650.0,
+        ],
+    ]
+
+
+def test_save_and_get_price_data(tmp_path: Path) -> None:
+    db_url = f"sqlite:///{tmp_path / 'prices.sqlite'}"
+    symbol = "BTCUSDT"
+    interval = "1h"
+
+    db_connector.init_timescale(db_path=db_url)
+    db_connector.save_to_db(_build_rows(), symbol, interval, db_path=db_url, batch_size=1)
+
+    updated_first = _build_rows()[0].copy()
+    updated_first[4] = 106.0
+    updated_first[8] = 1_500
+    db_connector.save_to_db([updated_first], symbol, interval, db_path=db_url)
+
+    frame = db_connector.get_price_data(symbol, db_path=db_url)
+    assert len(frame) == 2
+    assert pd.api.types.is_datetime64tz_dtype(frame["timestamp"])
+    assert frame.loc[0, "close"] == 106.0
+    assert frame.loc[0, "number_of_trades"] == 1_500
+    assert db_connector.get_latest_open_time(symbol=symbol, interval=interval, db_path=db_url) == 1_700_000_600_000


### PR DESCRIPTION
## Summary
- replace the SQLite-specific price connector with a SQLAlchemy engine that supports Timescale hypertables and batched upserts
- update Binance import and prediction backfill utilities to use the shared SQLAlchemy infrastructure and expose new database config options
- add SQLAlchemy dependencies, configuration options, and regression tests for the new connector

## Testing
- pytest tests/test_db_connector.py tests/test_compare_predictions.py

------
https://chatgpt.com/codex/tasks/task_e_68f6193a1710832784b62ea276dd5110