### PR TITLE
Ensure XGBoostModel predictions return class labels

### DIFF
--- a/src/crypto_analyzer/models/core.py
+++ b/src/crypto_analyzer/models/core.py
@@ -230,6 +230,12 @@ class XGBoostModel(BaseModel):
             else:
                 raise
 
+    def _predict(self, estimator: Any, X: np.ndarray) -> np.ndarray:
+        """Preserve the classifier's discrete predictions for evaluation."""
+
+        predictions = estimator.predict(X)
+        return np.asarray(predictions).ravel()
+
 
 class EnsembleModel(BaseModel):
     """Aggregate predictions of multiple :class:`BaseModel` instances."""


### PR DESCRIPTION
## Summary
- override the XGBoostModel prediction hook to return discrete class labels for evaluation

## Testing
- pytest tests/models/test_core.py

------
https://chatgpt.com/codex/tasks/task_e_68f62bd0a0388327836d7a8e5c3463f5