### PR TITLE
Add configurable backtest engine and metric registry

### DIFF
--- a/src/crypto_analyzer/eval/__init__.py
+++ b/src/crypto_analyzer/eval/__init__.py
@@ -1,6 +1,15 @@
 """Evaluation helpers."""
 
 from .cv import purged_walkforward_splits
+from .engine import BacktestEngine, EvaluationSummary
+from .metrics import METRICS
 from .threshold_sweep import SweepParams, sweep_threshold_grid
 
-__all__ = ["purged_walkforward_splits", "SweepParams", "sweep_threshold_grid"]
+__all__ = [
+    "BacktestEngine",
+    "EvaluationSummary",
+    "METRICS",
+    "purged_walkforward_splits",
+    "SweepParams",
+    "sweep_threshold_grid",
+]

--- a/src/crypto_analyzer/eval/engine.py
+++ b/src/crypto_analyzer/eval/engine.py
@@ -1,0 +1,207 @@
+"""Backtesting evaluation engine with pluggable metrics and split strategies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from importlib.util import find_spec
+from typing import TYPE_CHECKING, Iterable, TypedDict
+
+import numpy as np
+from sklearn.base import clone
+
+from crypto_analyzer.eval.metrics import METRICS, MetricFunc
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from crypto_analyzer.utils.config import AppConfig
+
+
+class EvaluationSummary(TypedDict, total=False):
+    """Typed dictionary describing the evaluation report returned by the engine."""
+
+    metrics: dict[str, float]
+    details: list[dict[str, float]]
+
+
+@dataclass(frozen=True)
+class _MetricDefinition:
+    name: str
+    func: MetricFunc
+
+
+def _slice_frame(data: object, start: int, end: int):
+    if hasattr(data, "iloc"):
+        return data.iloc[start:end]
+    return data[start:end]
+
+
+@dataclass(frozen=True)
+class _BacktestSettings:
+    metrics: tuple[str, ...]
+    validation_fraction: float
+    walkforward_window_days: int
+
+
+_DEFAULT_SETTINGS = _BacktestSettings(
+    metrics=("accuracy", "precision", "recall"),
+    validation_fraction=0.2,
+    walkforward_window_days=30,
+)
+
+
+def _resolve_backtest_settings(config: "AppConfig | None") -> _BacktestSettings:
+    if config is not None:
+        backtest_cfg = config.backtest
+        return _BacktestSettings(
+            metrics=tuple(backtest_cfg.metrics),
+            validation_fraction=float(backtest_cfg.validation_fraction),
+            walkforward_window_days=int(backtest_cfg.walkforward_window_days),
+        )
+
+    if find_spec("pydantic") is None:
+        return _DEFAULT_SETTINGS
+    if find_spec("crypto_analyzer.utils.config") is None:
+        return _DEFAULT_SETTINGS
+
+    module = import_module("crypto_analyzer.utils.config")
+    backtest_cfg = module.CONFIG.backtest  # type: ignore[attr-defined]
+    return _BacktestSettings(
+        metrics=tuple(backtest_cfg.metrics),
+        validation_fraction=float(backtest_cfg.validation_fraction),
+        walkforward_window_days=int(backtest_cfg.walkforward_window_days),
+    )
+
+
+class BacktestEngine:
+    """Evaluate models using configurable holdout or walk-forward strategies."""
+
+    def __init__(
+        self,
+        mode: str,
+        *,
+        metrics: Iterable[str] | None = None,
+        validation_fraction: float | None = None,
+        walkforward_window: int | None = None,
+        config: "AppConfig | None" = None,
+    ) -> None:
+        backtest_cfg = _resolve_backtest_settings(config)
+        self.mode = mode.lower()
+        if self.mode not in {"holdout", "walkforward"}:
+            raise ValueError("mode must be either 'holdout' or 'walkforward'")
+
+        metric_names = tuple(metrics) if metrics is not None else backtest_cfg.metrics
+        if not metric_names:
+            raise ValueError("At least one metric must be specified")
+        metric_defs: list[_MetricDefinition] = []
+        for name in metric_names:
+            try:
+                func = METRICS[name]
+            except KeyError as exc:  # pragma: no cover - defensive branch
+                raise ValueError(f"Unknown metric '{name}'") from exc
+            metric_defs.append(_MetricDefinition(name=name, func=func))
+        self._metric_defs = tuple(metric_defs)
+
+        if validation_fraction is None:
+            validation_fraction = float(backtest_cfg.validation_fraction)
+        if walkforward_window is None:
+            walkforward_window = int(backtest_cfg.walkforward_window_days)
+
+        if validation_fraction <= 0.0 or validation_fraction >= 1.0:
+            raise ValueError("validation_fraction must be between 0 and 1 (exclusive)")
+        if walkforward_window <= 0:
+            raise ValueError("walkforward_window must be a positive integer")
+
+        self.validation_fraction = validation_fraction
+        self.walkforward_window = walkforward_window
+
+    def run(self, model, X, y) -> EvaluationSummary:
+        """Run the configured evaluation strategy for *model* on ``(X, y)``."""
+
+        if self.mode == "holdout":
+            metrics = self._run_holdout(model, X, y)
+            return {"metrics": metrics, "details": [metrics]}
+        return self._run_walkforward(model, X, y)
+
+    def evaluate(self, model, X, y) -> dict[str, float]:
+        """Convenience wrapper returning only the aggregated metrics dictionary."""
+
+        summary = self.run(model, X, y)
+        return summary.get("metrics", {})
+
+    def _run_holdout(self, model, X, y) -> dict[str, float]:
+        n_samples = len(y)
+        if n_samples < 2:
+            raise ValueError("Holdout evaluation requires at least two samples")
+        validation_size = max(1, int(round(n_samples * self.validation_fraction)))
+        train_end = n_samples - validation_size
+        if train_end <= 0:
+            raise ValueError("Not enough samples for the requested validation fraction")
+
+        X_train = _slice_frame(X, 0, train_end)
+        y_train = _slice_frame(y, 0, train_end)
+        X_val = _slice_frame(X, train_end, n_samples)
+        y_val = _slice_frame(y, train_end, n_samples)
+
+        estimator = clone(model)
+        estimator.fit(X_train, y_train)
+        y_pred, y_proba = self._predict(estimator, X_val)
+        return self._compute_metrics(y_val, y_pred, y_proba)
+
+    def _run_walkforward(self, model, X, y) -> EvaluationSummary:
+        n_samples = len(y)
+        window = self.walkforward_window
+        if n_samples <= window:
+            raise ValueError("Walk-forward evaluation requires more samples than the window size")
+
+        fold_metrics: list[dict[str, float]] = []
+        train_end = window
+        while train_end < n_samples:
+            test_end = min(train_end + window, n_samples)
+            X_train = _slice_frame(X, 0, train_end)
+            y_train = _slice_frame(y, 0, train_end)
+            X_test = _slice_frame(X, train_end, test_end)
+            y_test = _slice_frame(y, train_end, test_end)
+            if len(y_test) == 0:
+                break
+
+            estimator = clone(model)
+            estimator.fit(X_train, y_train)
+            y_pred, y_proba = self._predict(estimator, X_test)
+            fold_metrics.append(self._compute_metrics(y_test, y_pred, y_proba))
+            if test_end == n_samples:
+                break
+            train_end = test_end
+
+        if not fold_metrics:
+            raise ValueError("Walk-forward evaluation did not generate any folds")
+
+        aggregate = {
+            definition.name: float(np.mean([fold[definition.name] for fold in fold_metrics]))
+            for definition in self._metric_defs
+        }
+        return {"metrics": aggregate, "details": fold_metrics}
+
+    def _predict(self, estimator, X):
+        y_pred = estimator.predict(X)
+        if hasattr(estimator, "predict_proba"):
+            proba = estimator.predict_proba(X)
+            y_proba = np.asarray(proba)
+        else:
+            y_proba = None
+        return np.asarray(y_pred), y_proba
+
+    def _compute_metrics(
+        self,
+        y_true,
+        y_pred: np.ndarray,
+        y_proba: np.ndarray | None,
+    ) -> dict[str, float]:
+        y_true_arr = np.asarray(y_true)
+        metric_values: dict[str, float] = {}
+        for definition in self._metric_defs:
+            metric_values[definition.name] = definition.func(y_true_arr, y_pred, y_proba)
+        return metric_values
+
+
+__all__ = ["BacktestEngine", "EvaluationSummary"]
+

--- a/src/crypto_analyzer/eval/metrics.py
+++ b/src/crypto_analyzer/eval/metrics.py
@@ -1,0 +1,151 @@
+"""Reusable evaluation metric helpers.
+
+The goal of this module is to keep metric implementations self-contained so
+that new metrics can be registered by simply adding a function here and
+referencing it from :data:`METRICS`.  Each metric function receives the ground
+truth labels, the predicted labels and, optionally, the predicted probabilities
+for the positive class.  Returning the final value as ``float`` keeps the
+results JSON-serialisable which mirrors the behaviour of the previous
+evaluation utilities.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+import numpy as np
+from sklearn.metrics import (
+    accuracy_score,
+    f1_score,
+    log_loss,
+    precision_score,
+    recall_score,
+    roc_auc_score,
+)
+
+
+class MetricFunc(Protocol):
+    """Protocol describing the callable signature expected for metrics."""
+
+    def __call__(
+        self,
+        y_true: np.ndarray,
+        y_pred: np.ndarray,
+        y_proba: np.ndarray | None = None,
+    ) -> float:
+        ...
+
+
+def _ensure_array(values: np.ndarray | list | tuple) -> np.ndarray:
+    """Return *values* as a ``numpy.ndarray`` with ``float64`` dtype."""
+
+    array = np.asarray(values)
+    if array.dtype.kind in {"i", "b"}:
+        return array.astype(np.float64, copy=False)
+    return array
+
+
+def _positive_class_scores(proba: np.ndarray) -> np.ndarray:
+    """Return the positive-class scores from *proba*.
+
+    The helper accepts probability arrays in either 1-D (already representing
+    positive-class probabilities) or 2-D form ``(n_samples, 2)`` where column 1
+    is assumed to be the positive class.  This mirrors the conventions used by
+    scikit-learn estimators.
+    """
+
+    arr = np.asarray(proba, dtype=np.float64)
+    if arr.ndim == 1:
+        return arr
+    if arr.ndim == 2 and arr.shape[1] == 2:
+        return arr[:, 1]
+    raise ValueError(
+        "Probability array must be 1-D or have shape (n_samples, 2) for binary metrics"
+    )
+
+
+def accuracy(y_true: np.ndarray, y_pred: np.ndarray, y_proba: np.ndarray | None = None) -> float:
+    """Return the classification accuracy."""
+
+    return float(accuracy_score(_ensure_array(y_true), _ensure_array(y_pred)))
+
+
+def precision(y_true: np.ndarray, y_pred: np.ndarray, y_proba: np.ndarray | None = None) -> float:
+    """Return the precision score with zero-division safety."""
+
+    return float(
+        precision_score(
+            _ensure_array(y_true),
+            _ensure_array(y_pred),
+            zero_division=0,
+        )
+    )
+
+
+def recall(y_true: np.ndarray, y_pred: np.ndarray, y_proba: np.ndarray | None = None) -> float:
+    """Return the recall score with zero-division safety."""
+
+    return float(
+        recall_score(
+            _ensure_array(y_true),
+            _ensure_array(y_pred),
+            zero_division=0,
+        )
+    )
+
+
+def f1(y_true: np.ndarray, y_pred: np.ndarray, y_proba: np.ndarray | None = None) -> float:
+    """Return the F1 score with zero-division safety."""
+
+    return float(
+        f1_score(
+            _ensure_array(y_true),
+            _ensure_array(y_pred),
+            zero_division=0,
+        )
+    )
+
+
+def roc_auc(
+    y_true: np.ndarray, y_pred: np.ndarray, y_proba: np.ndarray | None = None
+) -> float:
+    """Return the ROC-AUC score.
+
+    This metric requires probability estimates.  The helper extracts the
+    positive-class probabilities regardless of whether they are provided as a
+    1-D array of scores or in the two-column format produced by
+    ``predict_proba``.
+    """
+
+    if y_proba is None:
+        raise ValueError("roc_auc metric requires probability estimates")
+    scores = _positive_class_scores(y_proba)
+    return float(roc_auc_score(_ensure_array(y_true), scores))
+
+
+def log_loss_metric(
+    y_true: np.ndarray, y_pred: np.ndarray, y_proba: np.ndarray | None = None
+) -> float:
+    """Return the log loss (cross-entropy) metric."""
+
+    if y_proba is None:
+        raise ValueError("log_loss metric requires probability estimates")
+    arr = np.asarray(y_proba, dtype=np.float64)
+    if arr.ndim == 1:
+        arr = np.column_stack([1.0 - arr, arr])
+    clipped = np.clip(arr, 1e-9, 1.0 - 1e-9)
+    return float(log_loss(_ensure_array(y_true), clipped))
+
+
+METRICS: dict[str, MetricFunc] = {
+    "accuracy": accuracy,
+    "precision": precision,
+    "recall": recall,
+    "f1": f1,
+    "roc_auc": roc_auc,
+    "log_loss": log_loss_metric,
+}
+
+
+__all__ = ["METRICS", "MetricFunc", "accuracy", "precision", "recall", "f1", "roc_auc", "log_loss_metric"]
+

--- a/tests/test_eval_engine.py
+++ b/tests/test_eval_engine.py
@@ -1,0 +1,73 @@
+import numpy as np
+import pytest
+
+from crypto_analyzer.eval.engine import BacktestEngine
+
+
+class MajorityClassifier:
+    """Simple classifier that predicts the majority class observed during fit."""
+
+    def __init__(self) -> None:
+        self._fitted = False
+
+    def fit(self, X, y):
+        y_arr = np.asarray(y)
+        self._positive_prob = float(y_arr.mean())
+        self._prediction = 1 if self._positive_prob > 0.5 else 0
+        self._fitted = True
+        return self
+
+    def predict(self, X):
+        if not self._fitted:
+            raise RuntimeError("Model must be fitted before predicting")
+        return np.full(len(X), self._prediction, dtype=int)
+
+    def predict_proba(self, X):
+        if not self._fitted:
+            raise RuntimeError("Model must be fitted before predicting")
+        probs = np.array([1.0 - self._positive_prob, self._positive_prob], dtype=float)
+        return np.tile(probs, (len(X), 1))
+
+    def get_params(self, deep: bool = True):  # pragma: no cover - sklearn clone support
+        return {}
+
+    def set_params(self, **params):  # pragma: no cover - sklearn clone support
+        return self
+
+
+def test_holdout_engine_returns_expected_metrics():
+    X = np.arange(20, dtype=np.float32).reshape(-1, 1)
+    y = np.array([0, 1] * 10, dtype=int)
+    engine = BacktestEngine(
+        mode="holdout",
+        metrics=("accuracy", "precision", "recall"),
+        validation_fraction=0.5,
+    )
+
+    model = MajorityClassifier()
+    metrics = engine.evaluate(model, X, y)
+
+    assert set(metrics) == {"accuracy", "precision", "recall"}
+    assert metrics["accuracy"] == pytest.approx(0.5)
+    assert metrics["precision"] == pytest.approx(0.0)
+    assert metrics["recall"] == pytest.approx(0.0)
+    assert not hasattr(model, "_positive_prob")
+
+
+def test_walkforward_engine_aggregates_fold_metrics():
+    X = np.arange(24, dtype=np.float32).reshape(-1, 1)
+    y = np.array([0, 1, 0, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 0])
+
+    engine = BacktestEngine(
+        mode="walkforward",
+        metrics=("accuracy", "precision"),
+        walkforward_window=6,
+    )
+
+    result = engine.run(MajorityClassifier(), X, y)
+
+    assert set(result["metrics"]) == {"accuracy", "precision"}
+    assert len(result["details"]) >= 2
+    precisions = [fold["precision"] for fold in result["details"]]
+    assert result["metrics"]["precision"] == pytest.approx(np.mean(precisions))
+


### PR DESCRIPTION
## Summary
- add a BacktestEngine capable of holdout and walk-forward evaluation with pluggable metrics
- expose reusable metric helpers via a central METRICS registry
- cover the new engine behaviour with unit tests for holdout and walk-forward modes

## Testing
- pytest tests/test_eval_engine.py tests/test_backtest.py tests/test_backtest_costs.py tests/test_backtest_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68f62c601c9c8327895a9eebfe6eaf15