### PR TITLE
Refactor Typer CLIs to use data store abstraction and add predict command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ forward-filled so that the feature timestamp never exceeds the candle open.
 
 ### Derivátová data
 
-Enable the derivative enrichments while generating features:
+Derivative enrichments are enabled in `config/app.yaml` and can be toggled per
+invocation via the new Typer options:
 
 ```bash
-python scripts/make_features.py --use_derivatives
+python scripts/make_features.py --include-derivatives
 ```
 
 The loader expects either the columns to be present in the raw OHLCV source or
@@ -42,10 +43,11 @@ produced after left-label alignment:
 
 ### Order book signály
 
-Depth snapshots a event stream lze zapojit přes praktický přepínač:
+Depth snapshots a event stream lze zapojit přímo přes konfiguraci a také pomocí
+CLI přepínače:
 
 ```bash
-python scripts/make_features.py --use_orderbook
+python scripts/make_features.py --include-orderbook
 ```
 
 Při zpracování se používá stejná left-label resampling logika – order book depth
@@ -212,10 +214,18 @@ is intended to be scheduled via `cron`.
 ### 7. Run analysis and prediction
 
 ```bash
-python scripts/make_features.py --output data/features.parquet
+python scripts/make_features.py --output data/features.parquet --store auto
 python scripts/train.py --features data/features.parquet --model-path artifacts/meta_model.joblib
 python scripts/backtest.py data/predictions.csv --equity-output reports/equity.csv
+python scripts/predict.py --model-path artifacts/meta_model.joblib --dry-run
 ```
+
+The CLI entry points automatically select the configured data store, but you can
+explicitně choose a backend via `--store sqlite` nebo `--store timescale` when
+working with multiple environments. The `predict.py` helper loads the most
+recent candles, engineers features and reports the probability of an upward
+move using the trained meta-model, making it convenient to embed in cron jobs
+or notebooks.
 
 Cost-aware backtest with latency and probability gates:
 

--- a/scripts/make_features.py
+++ b/scripts/make_features.py
@@ -8,7 +8,7 @@ from typing import Any, Literal, Optional
 import pandas as pd
 import typer
 
-from crypto_analyzer.data.db_connector import get_price_data
+from crypto_analyzer.data.store import PriceDataStore, resolve_data_store
 from crypto_analyzer.features.engineering import create_features
 from crypto_analyzer.utils.config import CONFIG, FeatureSettings, override_feature_settings
 from crypto_analyzer.utils.cli import run_cli
@@ -26,10 +26,12 @@ def _load_price_data(
     *,
     path: Path | None,
     symbol: str,
-    db_path: Path,
+    data_store: PriceDataStore | None,
 ) -> pd.DataFrame:
     if source == "db":
-        return get_price_data(symbol, db_path=db_path)
+        if data_store is None:
+            raise DataValidationError("Database source requested but no data store was configured")
+        return data_store.fetch_prices(symbol)
     if path is None:
         raise DataValidationError("--input must be provided when --source=file")
     if not path.exists():
@@ -136,25 +138,18 @@ def _generate_features(
     output: Path,
     fmt: Literal["parquet", "csv"],
     symbol: str,
-    db_path: Path,
+    data_store: PriceDataStore | None,
     forward_fill_limit: Optional[int],
     fillna_value: Optional[float],
     include_onchain: Optional[bool],
     include_orderbook: Optional[bool],
     include_derivatives: Optional[bool],
     include_sentiment: Optional[bool],
-    use_derivatives: bool,
-    use_orderbook: bool,
-    use_sentiment: bool,
     run_id: str | None,
     dry_run: bool,
 ) -> Path:
     if forward_fill_limit is not None and forward_fill_limit < 0:
         raise DataValidationError("--forward-fill-limit must be non-negative")
-
-    include_derivatives = True if use_derivatives else include_derivatives
-    include_orderbook = True if use_orderbook else include_orderbook
-    include_sentiment = True if use_sentiment else include_sentiment
 
     settings = _prepare_settings(
         forward_fill_limit=forward_fill_limit,
@@ -165,7 +160,7 @@ def _generate_features(
         include_sentiment=include_sentiment,
     )
 
-    df = _load_price_data(source, path=input_path, symbol=symbol, db_path=db_path)
+    df = _load_price_data(source, path=input_path, symbol=symbol, data_store=data_store)
     feature_df = create_features(df, settings=settings)
 
     run_id_value, run_dir, _ = initialize_run(run_id, deterministic_torch=False)
@@ -184,25 +179,34 @@ def _generate_features(
     if target_output != run_output:
         _write_output(feature_df, target_output, fmt)
 
-    _persist_metadata(run_id_value, {
-        "source": source,
-        "input": input_path,
-        "output": output,
-        "format": fmt,
-        "symbol": symbol,
-        "db_path": db_path,
-        "forward_fill_limit": forward_fill_limit,
-        "fillna_value": fillna_value,
-        "include_onchain": include_onchain,
-        "include_orderbook": include_orderbook,
-        "include_derivatives": include_derivatives,
-        "include_sentiment": include_sentiment,
-        "use_derivatives": use_derivatives,
-        "use_orderbook": use_orderbook,
-        "use_sentiment": use_sentiment,
-        "run_id": run_id_value,
-        "dry_run": dry_run,
-    })
+    store_label = getattr(data_store, "label", None)
+    if store_label == "sqlite":
+        store_location = str(getattr(data_store, "path", None))
+    elif store_label == "timescale":
+        store_location = getattr(data_store, "url", None)
+    else:
+        store_location = None
+
+    _persist_metadata(
+        run_id_value,
+        {
+            "source": source,
+            "input": input_path,
+            "output": output,
+            "format": fmt,
+            "symbol": symbol,
+            "data_store": store_label,
+            "store_location": store_location,
+            "forward_fill_limit": forward_fill_limit,
+            "fillna_value": fillna_value,
+            "include_onchain": include_onchain,
+            "include_orderbook": include_orderbook,
+            "include_derivatives": include_derivatives,
+            "include_sentiment": include_sentiment,
+            "run_id": run_id_value,
+            "dry_run": dry_run,
+        },
+    )
 
     logger.info(
         "Persisted engineered features",
@@ -238,7 +242,12 @@ def main(
         "parquet", "--format", help="Output file format."
     ),
     symbol: str = typer.Option(CONFIG.symbol, "--symbol", help="Trading symbol to load."),
-    db_path: Path = typer.Option(
+    store_choice: Literal["auto", "sqlite", "timescale"] = typer.Option(
+        "auto",
+        "--store",
+        help="Database backend to use when --source=db. 'auto' follows config defaults.",
+    ),
+    db_path: Path | None = typer.Option(
         CONFIG.db_path,
         "--db-path",
         exists=False,
@@ -246,7 +255,12 @@ def main(
         dir_okay=False,
         readable=True,
         resolve_path=True,
-        help="SQLite database path when source=db.",
+        help="Override SQLite database path when using the local store.",
+    ),
+    db_url: str | None = typer.Option(
+        CONFIG.db_url,
+        "--db-url",
+        help="Override SQLAlchemy URL for Timescale/PostgreSQL connections.",
     ),
     include_onchain: Optional[bool] = typer.Option(
         None,
@@ -268,15 +282,6 @@ def main(
         "--include-sentiment/--exclude-sentiment",
         help="Override sentiment features toggle.",
     ),
-    use_derivatives: bool = typer.Option(
-        False, "--use-derivatives", help="Convenience flag to enable derivative features."
-    ),
-    use_orderbook: bool = typer.Option(
-        False, "--use-orderbook", help="Convenience flag to enable orderbook features."
-    ),
-    use_sentiment: bool = typer.Option(
-        False, "--use-sentiment", help="Convenience flag to enable sentiment features."
-    ),
     forward_fill_limit: Optional[int] = typer.Option(
         None, help="Override forward-fill window for NaN handling."
     ),
@@ -291,22 +296,27 @@ def main(
     if source == "db" and input_path is not None:
         typer.secho("Ignoring --input because --source=db", fg=typer.colors.YELLOW)
 
+    data_store: PriceDataStore | None = None
+    if source == "db":
+        data_store = resolve_data_store(
+            store_choice,
+            sqlite_path=db_path,
+            timescale_url=db_url,
+        )
+
     _generate_features(
         source=source,
         input_path=input_path,
         output=output,
         fmt=fmt,
         symbol=symbol,
-        db_path=db_path,
+        data_store=data_store,
         forward_fill_limit=forward_fill_limit,
         fillna_value=fillna_value,
         include_onchain=include_onchain,
         include_orderbook=include_orderbook,
         include_derivatives=include_derivatives,
         include_sentiment=include_sentiment,
-        use_derivatives=use_derivatives,
-        use_orderbook=use_orderbook,
-        use_sentiment=use_sentiment,
         run_id=run_id,
         dry_run=dry_run,
     )

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python
+"""Generate real-time predictions from the latest feature snapshot."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal, Optional
+
+import json
+import joblib
+import numpy as np
+import pandas as pd
+import typer
+
+from crypto_analyzer.data.store import PriceDataStore, resolve_data_store
+from crypto_analyzer.features.engineering import create_features
+from crypto_analyzer.models.utils import match_model_features
+from crypto_analyzer.utils.cli import run_cli
+from crypto_analyzer.utils.config import CONFIG, FeatureSettings, override_feature_settings
+from crypto_analyzer.utils.errors import DataValidationError
+from crypto_analyzer.utils.io import initialize_run, save_json
+from crypto_analyzer.utils.logging import get_logger
+
+
+app = typer.Typer(add_completion=False, no_args_is_help=True)
+logger = get_logger(__name__)
+
+
+def _prepare_settings(
+    *,
+    include_onchain: Optional[bool],
+    include_orderbook: Optional[bool],
+    include_derivatives: Optional[bool],
+    include_sentiment: Optional[bool],
+    forward_fill_limit: Optional[int],
+    fillna_value: Optional[float],
+) -> FeatureSettings:
+    settings = CONFIG.features
+    overrides: dict[str, bool] = {}
+    if include_onchain is not None:
+        overrides["include_onchain"] = include_onchain
+    if include_orderbook is not None:
+        overrides["include_orderbook"] = include_orderbook
+    if include_derivatives is not None:
+        overrides["include_derivatives"] = include_derivatives
+    if include_sentiment is not None:
+        overrides["include_sentiment"] = include_sentiment
+    if overrides:
+        settings = override_feature_settings(settings, **overrides)
+
+    if forward_fill_limit is not None or fillna_value is not None:
+        settings = FeatureSettings(
+            include_onchain=settings.include_onchain,
+            include_orderbook=settings.include_orderbook,
+            include_derivatives=settings.include_derivatives,
+            include_sentiment=settings.include_sentiment,
+            forward_fill_limit=(
+                forward_fill_limit if forward_fill_limit is not None else settings.forward_fill_limit
+            ),
+            fillna_value=fillna_value if fillna_value is not None else settings.fillna_value,
+        )
+    return settings
+
+
+def _predict_probability(model: object, X: pd.DataFrame) -> float:
+    if hasattr(model, "predict_proba"):
+        proba = model.predict_proba(X)
+        arr = np.asarray(proba)
+        if arr.ndim == 2 and arr.shape[1] > 1:
+            return float(arr[0, 1])
+        if arr.size:
+            return float(arr.ravel()[0])
+    preds = model.predict(X)
+    return float(np.asarray(preds).ravel()[0])
+
+
+def _store_metadata(data_store: PriceDataStore) -> dict[str, str | None]:
+    label = getattr(data_store, "label", None)
+    if label == "sqlite":
+        location = str(getattr(data_store, "path", None))
+    elif label == "timescale":
+        location = getattr(data_store, "url", None)
+    else:
+        location = None
+    return {"data_store": label, "store_location": location}
+
+
+@app.command()
+def main(
+    symbol: str = typer.Option(CONFIG.symbol, "--symbol", help="Trading symbol to score."),
+    store_choice: Literal["auto", "sqlite", "timescale"] = typer.Option(
+        "auto",
+        "--store",
+        help="Database backend used to fetch candles (auto follows configuration).",
+    ),
+    db_path: Path | None = typer.Option(
+        CONFIG.db_path,
+        "--db-path",
+        exists=False,
+        file_okay=True,
+        dir_okay=False,
+        resolve_path=True,
+        help="Override SQLite database path when using the local store.",
+    ),
+    db_url: str | None = typer.Option(
+        CONFIG.db_url,
+        "--db-url",
+        help="Override SQLAlchemy URL when using Timescale/PostgreSQL.",
+    ),
+    history_days: int = typer.Option(
+        CONFIG.core.history_days,
+        "--history-days",
+        min=1,
+        help="Number of trailing days to load before generating features.",
+    ),
+    model_path: Path = typer.Option(
+        Path("artifacts/meta_model.joblib"),
+        "--model-path",
+        resolve_path=True,
+        help="Model artefact used for prediction.",
+    ),
+    threshold: float = typer.Option(0.5, "--threshold", help="Decision threshold for the positive class."),
+    output: Path | None = typer.Option(
+        None,
+        "--output",
+        resolve_path=True,
+        help="Optional JSON file receiving the prediction result.",
+    ),
+    include_onchain: Optional[bool] = typer.Option(
+        None,
+        "--include-onchain/--exclude-onchain",
+        help="Override on-chain feature toggle before scoring.",
+    ),
+    include_orderbook: Optional[bool] = typer.Option(
+        None,
+        "--include-orderbook/--exclude-orderbook",
+        help="Override orderbook feature toggle before scoring.",
+    ),
+    include_derivatives: Optional[bool] = typer.Option(
+        None,
+        "--include-derivatives/--exclude-derivatives",
+        help="Override derivative feature toggle before scoring.",
+    ),
+    include_sentiment: Optional[bool] = typer.Option(
+        None,
+        "--include-sentiment/--exclude-sentiment",
+        help="Override sentiment feature toggle before scoring.",
+    ),
+    forward_fill_limit: Optional[int] = typer.Option(
+        None,
+        "--forward-fill-limit",
+        min=0,
+        help="Override forward-fill limit applied during preprocessing.",
+    ),
+    fillna_value: Optional[float] = typer.Option(
+        None,
+        "--fillna-value",
+        help="Override fillna fallback applied after forward fills.",
+    ),
+    run_id: Optional[str] = typer.Option(None, "--run-id", help="Optional run identifier for artefact storage."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Compute the prediction without writing artefacts."),
+) -> None:
+    if threshold <= 0 or threshold >= 1:
+        raise DataValidationError("--threshold must lie in (0, 1)")
+
+    data_store = resolve_data_store(
+        store_choice,
+        sqlite_path=db_path,
+        timescale_url=db_url,
+    )
+
+    history_start = pd.Timestamp.utcnow() - pd.Timedelta(days=int(history_days))
+    start_ts = int(history_start.timestamp() * 1000)
+    price_frame = data_store.fetch_prices(symbol, start_ts=start_ts)
+    if price_frame.empty:
+        raise DataValidationError("No price data available for the requested window")
+
+    settings = _prepare_settings(
+        include_onchain=include_onchain,
+        include_orderbook=include_orderbook,
+        include_derivatives=include_derivatives,
+        include_sentiment=include_sentiment,
+        forward_fill_limit=forward_fill_limit,
+        fillna_value=fillna_value,
+    )
+    feature_frame = create_features(price_frame, settings=settings)
+    feature_frame = feature_frame.dropna().sort_values("timestamp")
+    if feature_frame.empty:
+        raise DataValidationError("Generated feature matrix is empty after preprocessing")
+
+    model = joblib.load(model_path)
+    feature_payload = match_model_features(
+        feature_frame.drop(columns=["timestamp"], errors="ignore"),
+        model,
+    )
+    latest_features = feature_payload.tail(1)
+    probability = _predict_probability(model, latest_features)
+    prediction = int(probability >= threshold)
+    latest_timestamp = pd.to_datetime(feature_frame["timestamp"].iloc[-1], utc=True)
+
+    result = {
+        "symbol": symbol,
+        "timestamp": latest_timestamp.isoformat(),
+        "probability": probability,
+        "prediction": prediction,
+        "threshold": threshold,
+        **_store_metadata(data_store),
+        "model_path": str(model_path),
+    }
+
+    typer.echo(
+        f"Prediction for {symbol} at {result['timestamp']}: prob_up={probability:.4f} -> {prediction}"
+    )
+
+    if dry_run:
+        if output is not None:
+            typer.echo(f"Dry run requested; prediction would be written to {output}")
+        return
+
+    run_id_value, _, _ = initialize_run(run_id, deterministic_torch=False)
+    save_json(result, "prediction.json", run_id=run_id_value)
+    if output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(result, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    run_cli(app)
+

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 import joblib
 import numpy as np
@@ -17,7 +17,7 @@ from sklearn import metrics
 
 import typer
 
-from crypto_analyzer.data.db_connector import get_price_data
+from crypto_analyzer.data.store import PriceDataStore, resolve_data_store
 from crypto_analyzer.features.engineering import (
     FEATURE_COLUMNS,
     create_features,
@@ -102,7 +102,7 @@ def _load_features(
     *,
     features: Optional[Path],
     symbol: str,
-    db_path: Path,
+    data_store: PriceDataStore | None,
     settings: FeatureSettings,
 ) -> pd.DataFrame:
     if features is not None:
@@ -111,7 +111,9 @@ def _load_features(
             df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
         return df
 
-    raw = get_price_data(symbol, db_path=db_path)
+    if data_store is None:
+        raise DataValidationError("Database store is required when --features is not provided")
+    raw = data_store.fetch_prices(symbol)
     return create_features(raw, settings=settings)
 
 
@@ -371,7 +373,7 @@ def _run_training(
     *,
     features: Optional[Path],
     symbol: str,
-    db_path: Path,
+    data_store: PriceDataStore | None,
     horizon: int,
     label: Optional[str],
     model_path: Path,
@@ -416,7 +418,7 @@ def _run_training(
     df = _load_features(
         features=features,
         symbol=symbol,
-        db_path=db_path,
+        data_store=data_store,
         settings=settings,
     )
 
@@ -604,10 +606,19 @@ def _run_training(
         if not reliability_copy.exists():
             reliability_copy.write_bytes(Path(reliability_path).read_bytes())
 
+        store_label = getattr(data_store, "label", None)
+        if store_label == "sqlite":
+            store_location = str(getattr(data_store, "path", None))
+        elif store_label == "timescale":
+            store_location = getattr(data_store, "url", None)
+        else:
+            store_location = None
+
         args_snapshot = {
             "features": features,
             "symbol": symbol,
-            "db_path": db_path,
+            "data_store": store_label,
+            "store_location": store_location,
             "horizon": horizon,
             "label": label,
             "model_path": model_path,
@@ -663,14 +674,24 @@ def main(
         help="Optional engineered feature table (CSV/Parquet).",
     ),
     symbol: str = typer.Option(CONFIG.symbol, "--symbol", help="Trading symbol used when sourcing data."),
-    db_path: Path = typer.Option(
+    store_choice: Literal["auto", "sqlite", "timescale"] = typer.Option(
+        "auto",
+        "--store",
+        help="Database backend to use when sourcing raw candles (auto follows config).",
+    ),
+    db_path: Path | None = typer.Option(
         CONFIG.db_path,
         "--db-path",
         exists=False,
         file_okay=True,
         dir_okay=False,
         resolve_path=True,
-        help="SQLite database file to read raw price data from.",
+        help="Override SQLite database path when using the local store.",
+    ),
+    db_url: str | None = typer.Option(
+        CONFIG.db_url,
+        "--db-url",
+        help="Override SQLAlchemy URL when using Timescale/PostgreSQL.",
     ),
     horizon: int = typer.Option(120, "--horizon", help="Target horizon in minutes for label generation."),
     label: Optional[str] = typer.Option(None, "--label", help="Existing label column to use."),
@@ -737,10 +758,18 @@ def main(
 ) -> None:
     cv_normalised = cv_strategy.lower() if cv_strategy else None
     calibration_normalised = calibration.lower()
+    data_store: PriceDataStore | None = None
+    if features is None:
+        data_store = resolve_data_store(
+            store_choice,
+            sqlite_path=db_path,
+            timescale_url=db_url,
+        )
+
     _run_training(
         features=features,
         symbol=symbol,
-        db_path=db_path,
+        data_store=data_store,
         horizon=horizon,
         label=label,
         model_path=model_path,

--- a/src/crypto_analyzer/data/store.py
+++ b/src/crypto_analyzer/data/store.py
@@ -1,0 +1,135 @@
+"""Abstractions for accessing historical price data.
+
+The original CLI entrypoints interacted with :func:`get_price_data` directly
+and required the caller to know whether a local SQLite file or a remote
+TimescaleDB instance should be used.  The new Typer applications rely on a
+lightweight :class:`PriceDataStore` interface instead which centralises the
+selection logic and keeps the command implementations free from backend
+concerns.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Protocol
+
+import pandas as pd
+
+from crypto_analyzer.data.db_connector import get_latest_open_time, get_price_data
+from crypto_analyzer.utils.config import CONFIG
+
+
+class PriceDataStore(Protocol):
+    """Protocol implemented by concrete price data stores."""
+
+    label: str
+
+    def fetch_prices(
+        self,
+        symbol: str,
+        *,
+        start_ts: int | None = None,
+        end_ts: int | None = None,
+    ) -> pd.DataFrame:
+        """Return OHLCV candles for ``symbol`` between ``start_ts`` and ``end_ts``."""
+
+    def latest_open_time(
+        self,
+        *,
+        symbol: str | None = None,
+        interval: str | None = None,
+    ) -> int | None:
+        """Return the newest ``open_time`` available for the requested filters."""
+
+
+@dataclass(slots=True)
+class SQLiteDataStore:
+    """Adapter that sources data from a SQLite database file."""
+
+    path: Path
+    label: str = "sqlite"
+
+    def fetch_prices(
+        self,
+        symbol: str,
+        *,
+        start_ts: int | None = None,
+        end_ts: int | None = None,
+    ) -> pd.DataFrame:
+        return get_price_data(symbol, start_ts=start_ts, end_ts=end_ts, db_path=self.path)
+
+    def latest_open_time(
+        self,
+        *,
+        symbol: str | None = None,
+        interval: str | None = None,
+    ) -> int | None:
+        return get_latest_open_time(symbol=symbol, interval=interval, db_path=self.path)
+
+
+@dataclass(slots=True)
+class TimescaleDataStore:
+    """Adapter that connects to a TimescaleDB/PostgreSQL instance via SQLAlchemy."""
+
+    url: str
+    label: str = "timescale"
+
+    def fetch_prices(
+        self,
+        symbol: str,
+        *,
+        start_ts: int | None = None,
+        end_ts: int | None = None,
+    ) -> pd.DataFrame:
+        return get_price_data(symbol, start_ts=start_ts, end_ts=end_ts, db_path=self.url)
+
+    def latest_open_time(
+        self,
+        *,
+        symbol: str | None = None,
+        interval: str | None = None,
+    ) -> int | None:
+        return get_latest_open_time(symbol=symbol, interval=interval, db_path=self.url)
+
+
+def _is_sqlite_url(url: str | None) -> bool:
+    if not url:
+        return False
+    return url.startswith("sqlite:")
+
+
+def resolve_data_store(
+    preference: Literal["auto", "sqlite", "timescale"] = "auto",
+    *,
+    sqlite_path: Path | None = None,
+    timescale_url: str | None = None,
+) -> PriceDataStore:
+    """Instantiate a :class:`PriceDataStore` based on configuration and overrides."""
+
+    cfg = CONFIG.database
+    sqlite_default = sqlite_path or cfg.price_store
+    timescale_default = timescale_url or cfg.url
+
+    if preference == "sqlite":
+        return SQLiteDataStore(Path(sqlite_default))
+
+    if preference == "timescale":
+        if not timescale_default:
+            raise ValueError("Timescale store requested but no database URL was configured")
+        return TimescaleDataStore(timescale_default)
+
+    # Automatic resolution: prefer Timescale when a non-SQLite URL is configured.
+    if timescale_default and not _is_sqlite_url(timescale_default):
+        return TimescaleDataStore(timescale_default)
+
+    return SQLiteDataStore(Path(sqlite_default))
+
+
+__all__ = [
+    "PriceDataStore",
+    "SQLiteDataStore",
+    "TimescaleDataStore",
+    "resolve_data_store",
+]
+

--- a/tests/test_cli_entrypoints.py
+++ b/tests/test_cli_entrypoints.py
@@ -1,0 +1,45 @@
+"""Smoke tests covering the Typer CLI entrypoints."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+typer = pytest.importorskip("typer")
+from typer.testing import CliRunner
+
+
+RUNNER = CliRunner()
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _load_app(script: str):
+    module_path = SCRIPTS_DIR / f"{script}.py"
+    spec = importlib.util.spec_from_file_location(f"cli_{script}", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)  # type: ignore[call-arg]
+    return getattr(module, "app")
+
+
+def test_make_features_help():
+    app = _load_app("make_features")
+    result = RUNNER.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "--store" in result.stdout
+
+
+def test_train_help():
+    app = _load_app("train")
+    result = RUNNER.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "--store" in result.stdout
+
+
+def test_predict_help():
+    app = _load_app("predict")
+    result = RUNNER.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "--threshold" in result.stdout


### PR DESCRIPTION
## Summary
- introduce a PriceDataStore abstraction to pick between SQLite and Timescale backends automatically
- update make_features and train Typer CLIs to rely on the new store, streamline feature toggles, and document the new flags
- add a predict Typer command for on-demand scoring and lightweight tests that ensure the CLIs register correctly

## Testing
- pytest tests/test_cli_entrypoints.py

------
https://chatgpt.com/codex/tasks/task_e_68f63119f7408327bbfa01fbaad3257b