### PR TITLE
Add fetchers for Binance order book, Reddit sentiment, and external indices

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "SQLAlchemy==2.0.35",
     "psycopg[binary]==3.1.12",
     "psycopg2-binary==2.9.9",
+    "vaderSentiment==3.3.2",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ pandera==0.20.3
 SQLAlchemy==2.0.35
 psycopg[binary]==3.1.12
 psycopg2-binary==2.9.9
+vaderSentiment==3.3.2
 
 # Formatting & linting
 black==24.4.2

--- a/src/crypto_analyzer/data/data_collector.py
+++ b/src/crypto_analyzer/data/data_collector.py
@@ -35,6 +35,7 @@ logger = get_logger(__name__)
 
 GLASSNODE_ENDPOINT = "https://api.glassnode.com/v1/metrics/addresses/active_count"
 BINANCE_FUNDING_ENDPOINT = "https://fapi.binance.com/fapi/v1/fundingRate"
+BINANCE_ORDERBOOK_ENDPOINT = "https://fapi.binance.com/fapi/v1/depth"
 BINANCE_OPEN_INTEREST_ENDPOINT = "https://fapi.binance.com/futures/data/openInterestHist"
 
 
@@ -193,6 +194,122 @@ def fetch_binance_funding_rates(
     return frame.loc[:, ["timestamp", "funding_rate"]].reset_index(drop=True)
 
 
+def fetch_binance_order_book(
+    symbol: str,
+    *,
+    depth: int = 20,
+    session: requests.Session | None = None,
+) -> pd.DataFrame:
+    """Fetch a futures order book snapshot for ``symbol`` from Binance.
+
+    Parameters
+    ----------
+    symbol:
+        Trading pair in Binance notation, e.g. ``"BTCUSDT"``.
+    depth:
+        Number of price levels to request from each side of the book.  Binance
+        accepts a discrete set of values; the closest supported depth greater
+        than or equal to the requested value is used.
+    session:
+        Optional :class:`requests.Session` to reuse across invocations.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Frame with a single row describing top-of-book statistics.  When the
+        exchange returns an empty book the function yields an empty frame with
+        the expected columns instead of raising an exception.
+    """
+
+    allowed_depths = (5, 10, 20, 50, 100, 500, 1000)
+    if depth <= 0:
+        raise ValueError("Depth must be a positive integer")
+    limit = next((value for value in allowed_depths if value >= depth), allowed_depths[-1])
+
+    sess = session or requests.Session()
+    params = {"symbol": symbol, "limit": limit}
+    response = sess.get(BINANCE_ORDERBOOK_ENDPOINT, params=params, timeout=10)
+    response.raise_for_status()
+    payload = response.json() or {}
+
+    bids = payload.get("bids") or []
+    asks = payload.get("asks") or []
+
+    def _parse_side(levels: list[list[object]] | list[tuple[object, object]]) -> list[tuple[float, float]]:
+        parsed: list[tuple[float, float]] = []
+        for level in levels[:limit]:
+            if not isinstance(level, (list, tuple)) or len(level) < 2:
+                continue
+            price_raw, qty_raw = level[0], level[1]
+            try:
+                price = float(price_raw)
+                quantity = float(qty_raw)
+            except (TypeError, ValueError):
+                continue
+            parsed.append((price, quantity))
+        return parsed
+
+    parsed_bids = _parse_side(bids)
+    parsed_asks = _parse_side(asks)
+
+    columns = [
+        "timestamp",
+        "bid_price",
+        "bid_volume",
+        "ask_price",
+        "ask_volume",
+        "spread",
+        "mid_price",
+        "bid_volume_total",
+        "ask_volume_total",
+        "bid_notional_total",
+        "ask_notional_total",
+        "depth_imbalance",
+    ]
+
+    if not parsed_bids or not parsed_asks:
+        return pd.DataFrame(columns=columns)
+
+    best_bid_price, best_bid_volume = parsed_bids[0]
+    best_ask_price, best_ask_volume = parsed_asks[0]
+
+    bid_volume_total = sum(qty for _, qty in parsed_bids)
+    ask_volume_total = sum(qty for _, qty in parsed_asks)
+    bid_notional_total = sum(price * qty for price, qty in parsed_bids)
+    ask_notional_total = sum(price * qty for price, qty in parsed_asks)
+
+    spread = best_ask_price - best_bid_price
+    mid_price = (best_bid_price + best_ask_price) / 2
+
+    depth_sum = bid_volume_total + ask_volume_total
+    depth_imbalance = (
+        (bid_volume_total - ask_volume_total) / depth_sum if depth_sum else float("nan")
+    )
+
+    timestamp = pd.Timestamp.utcnow()
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.tz_localize("UTC")
+    else:
+        timestamp = timestamp.tz_convert("UTC")
+    frame = pd.DataFrame(
+        {
+            "timestamp": [timestamp],
+            "bid_price": [best_bid_price],
+            "bid_volume": [best_bid_volume],
+            "ask_price": [best_ask_price],
+            "ask_volume": [best_ask_volume],
+            "spread": [spread],
+            "mid_price": [mid_price],
+            "bid_volume_total": [bid_volume_total],
+            "ask_volume_total": [ask_volume_total],
+            "bid_notional_total": [bid_notional_total],
+            "ask_notional_total": [ask_notional_total],
+            "depth_imbalance": [depth_imbalance],
+        }
+    )
+    return frame
+
+
 def fetch_binance_open_interest(
     symbol: str,
     start: datetime,
@@ -270,6 +387,7 @@ def load_enriched_market_data(
             raise RuntimeError("Application configuration is unavailable; pass config explicitly")
         cfg = CONFIG
     market_symbol = symbol or cfg.symbol
+    onchain_cfg = getattr(cfg, "onchain", None)
 
     start_ms = int(_as_timestamp(start).timestamp() * 1000) if start else None
     end_ms = int(_as_timestamp(end).timestamp() * 1000) if end else None
@@ -290,7 +408,7 @@ def load_enriched_market_data(
         glassnode = pd.DataFrame(columns=["timestamp", "onch_active_addresses"])
 
     mempool = pd.DataFrame()
-    if getattr(cfg.onchain, "use_mempool", False):
+    if getattr(onchain_cfg, "use_mempool", False):
         try:
             mempool = fetch_mempool_stats()
         except Exception as exc:  # pragma: no cover - defensive logging
@@ -298,8 +416,8 @@ def load_enriched_market_data(
             mempool = pd.DataFrame()
 
     exchange_flows = pd.DataFrame()
-    if getattr(cfg.onchain, "use_exchange_flows", False):
-        api_key = getattr(cfg.onchain, "glassnode_api_key", None)
+    if getattr(onchain_cfg, "use_exchange_flows", False):
+        api_key = getattr(onchain_cfg, "glassnode_api_key", None)
         if api_key:
             try:
                 exchange_flows = fetch_exchange_flows(api_key, start=span_start, end=span_end)
@@ -375,6 +493,7 @@ def load_enriched_market_data(
 __all__ = [
     "fetch_glassnode_active_addresses",
     "fetch_binance_funding_rates",
+    "fetch_binance_order_book",
     "fetch_binance_open_interest",
     "fetch_exchange_flows",
     "fetch_mempool_stats",

--- a/src/crypto_analyzer/data/db.py
+++ b/src/crypto_analyzer/data/db.py
@@ -23,7 +23,7 @@ from contextlib import contextmanager
 from typing import Iterable, Iterator
 
 import psycopg2
-from psycopg2 import OperationalError
+from psycopg2 import OperationalError, sql
 from psycopg2.extensions import connection as PGConnection
 
 from crypto_analyzer.utils.config import CONFIG
@@ -253,6 +253,36 @@ def _execute_statements(conn: PGConnection, statements: Iterable[str]) -> None:
             cursor.execute(statement)
 
 
+def _ensure_column_exists(
+    conn: PGConnection,
+    table_name: str,
+    column_name: str,
+    column_definition: str,
+) -> None:
+    """Ensure that a table contains a specific column, adding it if required."""
+
+    with conn.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = %s
+              AND column_name = %s
+            """,
+            (table_name, column_name),
+        )
+        if cursor.fetchone() is None:
+            LOGGER.info("Adding missing column %s.%s", table_name, column_name)
+            cursor.execute(
+                sql.SQL("ALTER TABLE {} ADD COLUMN {} {}").format(
+                    sql.Identifier(table_name),
+                    sql.Identifier(column_name),
+                    sql.SQL(column_definition),
+                )
+            )
+
+
 def initialize_schema(conn: PGConnection) -> None:
     """Create TimescaleDB tables, hypertables and views if they do not exist."""
 
@@ -262,6 +292,9 @@ def initialize_schema(conn: PGConnection) -> None:
 
         LOGGER.info("Creating base tables")
         _execute_statements(conn, TABLE_DEFINITIONS.values())
+
+        LOGGER.info("Applying schema migrations")
+        _ensure_column_exists(conn, "sentiment_index", "classification", "TEXT")
 
         LOGGER.info("Converting tables to hypertables")
         _execute_statements(conn, HYPERTABLE_STATEMENTS)

--- a/src/crypto_analyzer/data/db.py
+++ b/src/crypto_analyzer/data/db.py
@@ -63,6 +63,7 @@ TABLE_DEFINITIONS: dict[str, str] = {
         CREATE TABLE IF NOT EXISTS sentiment_index (
             timestamp TIMESTAMPTZ NOT NULL,
             value SMALLINT CHECK (value BETWEEN 0 AND 100),
+            classification TEXT,
             PRIMARY KEY (timestamp)
         )
     """,
@@ -128,6 +129,7 @@ COMBINED_FEATURES_VIEW = """
         oc.exchange_outflow,
         oc.whale_transactions,
         si.value AS fear_greed_index,
+        si.classification AS fear_greed_classification,
         ss.reddit_score,
         ss.twitter_score,
         ss.mentions,

--- a/src/crypto_analyzer/data/news_fetcher.py
+++ b/src/crypto_analyzer/data/news_fetcher.py
@@ -1,0 +1,173 @@
+"""Download cryptocurrency news from the CryptoPanic API."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import pandas as pd
+import requests
+
+from crypto_analyzer.utils.logging import get_logger
+
+LOGGER = get_logger(__name__)
+
+_CRYPTO_PANIC_ENDPOINT = "https://cryptopanic.com/api/v1/posts/"
+
+
+def _serialise_list(values: Sequence[str] | None) -> str:
+    if not values:
+        return ""
+    unique = {value for value in values if value}
+    return ",".join(sorted(unique))
+
+
+def fetch_cryptopanic_news(
+    auth_token: str,
+    *,
+    filter: str | None = None,
+    currencies: Sequence[str] | None = None,
+    kind: str | None = None,
+    limit: int = 50,
+    max_pages: int = 1,
+    session: requests.Session | None = None,
+) -> pd.DataFrame:
+    """Fetch latest news posts along with sentiment cues from CryptoPanic."""
+
+    if not auth_token:
+        raise ValueError("A CryptoPanic auth token is required")
+    if limit <= 0:
+        raise ValueError("limit must be a positive integer")
+    if max_pages <= 0:
+        raise ValueError("max_pages must be a positive integer")
+
+    params: dict[str, Any] = {"auth_token": auth_token, "public": "true"}
+    if filter:
+        params["filter"] = filter
+    if kind:
+        params["kind"] = kind
+    if currencies:
+        params["currencies"] = _serialise_list(currencies)
+    params["limit"] = min(limit, 100)
+
+    sess = session or requests.Session()
+    records: list[dict[str, Any]] = []
+    next_url: str | None = _CRYPTO_PANIC_ENDPOINT
+    pages_fetched = 0
+
+    try:
+        while next_url and pages_fetched < max_pages and len(records) < limit:
+            response = sess.get(next_url, params=params if pages_fetched == 0 else None, timeout=10)
+            response.raise_for_status()
+            payload = response.json() or {}
+            results = payload.get("results", [])
+            if results:
+                records.extend(results)
+            next_url = payload.get("next")
+            params = None
+            pages_fetched += 1
+    except (requests.RequestException, ValueError) as exc:
+        LOGGER.warning("Failed to fetch CryptoPanic news", exc_info=exc)
+        return pd.DataFrame(
+            columns=[
+                "timestamp",
+                "title",
+                "url",
+                "source",
+                "sentiment",
+                "positive_votes",
+                "negative_votes",
+                "tags",
+                "currencies",
+            ]
+        )
+
+    if not records:
+        return pd.DataFrame(
+            columns=[
+                "timestamp",
+                "title",
+                "url",
+                "source",
+                "sentiment",
+                "positive_votes",
+                "negative_votes",
+                "tags",
+                "currencies",
+            ]
+        )
+
+    rows: list[dict[str, Any]] = []
+    for entry in records[:limit]:
+        published = entry.get("published_at") or entry.get("created_at")
+        timestamp = pd.to_datetime(published, utc=True, errors="coerce")
+        if pd.isna(timestamp):
+            continue
+        votes = entry.get("votes", {})
+        positive = votes.get("positive") or entry.get("positive_votes") or 0
+        negative = votes.get("negative") or entry.get("negative_votes") or 0
+        tags = entry.get("tags")
+        if isinstance(tags, list):
+            tags_serialised = _serialise_list([str(tag) for tag in tags])
+        elif tags:
+            tags_serialised = str(tags)
+        else:
+            tags_serialised = ""
+        currencies_payload = entry.get("currencies")
+        if isinstance(currencies_payload, list):
+            currency_codes = [item.get("code") for item in currencies_payload if item.get("code")]
+            currencies_serialised = _serialise_list(currency_codes)
+        else:
+            currencies_serialised = ""
+
+        source_info = entry.get("source") or {}
+        source = (
+            source_info.get("title")
+            or source_info.get("name")
+            or entry.get("domain")
+            or ""
+        )
+
+        sentiment_score = float(positive or 0) - float(negative or 0)
+        if isinstance(tags, list):
+            tag_lower = {str(tag).lower() for tag in tags}
+            if "bullish" in tag_lower and "bearish" not in tag_lower:
+                sentiment_score = max(sentiment_score, 1.0)
+            elif "bearish" in tag_lower and "bullish" not in tag_lower:
+                sentiment_score = min(sentiment_score, -1.0)
+
+        rows.append(
+            {
+                "timestamp": timestamp,
+                "title": entry.get("title", ""),
+                "url": entry.get("url") or entry.get("link") or "",
+                "source": source,
+                "sentiment": sentiment_score,
+                "positive_votes": float(positive or 0),
+                "negative_votes": float(negative or 0),
+                "tags": tags_serialised,
+                "currencies": currencies_serialised,
+            }
+        )
+
+    if not rows:
+        return pd.DataFrame(
+            columns=[
+                "timestamp",
+                "title",
+                "url",
+                "source",
+                "sentiment",
+                "positive_votes",
+                "negative_votes",
+                "tags",
+                "currencies",
+            ]
+        )
+
+    frame = pd.DataFrame(rows)
+    frame = frame.sort_values("timestamp").reset_index(drop=True)
+    return frame
+
+
+__all__ = ["fetch_cryptopanic_news"]

--- a/src/crypto_analyzer/data/onchain_fetcher.py
+++ b/src/crypto_analyzer/data/onchain_fetcher.py
@@ -16,6 +16,15 @@ MEMPOOL_STATS_ENDPOINT = "https://mempool.space/api/mempool"
 MEMPOOL_FEES_ENDPOINT = "https://mempool.space/api/v1/fees/recommended"
 GLASSNODE_EXCHANGE_INFLOW_ENDPOINT = "https://api.glassnode.com/v1/metrics/exchanges/inflow_sum"
 GLASSNODE_EXCHANGE_OUTFLOW_ENDPOINT = "https://api.glassnode.com/v1/metrics/exchanges/outflow_sum"
+COINMETRICS_ASSET_METRICS_ENDPOINT = (
+    "https://community-api.coinmetrics.io/v4/timeseries/asset-metrics"
+)
+
+_COINMETRICS_COLUMN_MAP = {
+    "ExchgNetFlow": "onch_exchange_net_flow",
+    "ExchgInflowVolume": "onch_exchange_inflow",
+    "ExchgOutflowVolume": "onch_exchange_outflow",
+}
 
 
 def _empty_timestamp_frame(columns: list[str]) -> pd.DataFrame:
@@ -174,4 +183,96 @@ def fetch_exchange_flows(
     return frame
 
 
-__all__ = ["fetch_mempool_stats", "fetch_exchange_flows"]
+def _format_coinmetrics_timestamp(value: Any) -> str:
+    ts = _ensure_utc_timestamp(value)
+    return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def fetch_coinmetrics_exchange_flows(
+    *,
+    asset: str = "btc",
+    start: pd.Timestamp | None = None,
+    end: pd.Timestamp | None = None,
+    metrics: tuple[str, ...] = tuple(_COINMETRICS_COLUMN_MAP.keys()),
+    session: requests.Session | None = None,
+) -> pd.DataFrame:
+    """Fetch exchange flow metrics from the CoinMetrics community API."""
+
+    if not metrics:
+        raise ValueError("At least one metric must be requested from CoinMetrics")
+
+    params: dict[str, Any] = {
+        "assets": asset.lower(),
+        "metrics": ",".join(metrics),
+        "frequency": "1d",
+    }
+    if start is not None:
+        params["start_time"] = _format_coinmetrics_timestamp(start)
+    if end is not None:
+        params["end_time"] = _format_coinmetrics_timestamp(end)
+
+    sess = session or requests.Session()
+    collected: list[dict[str, Any]] = []
+    next_token: str | None = None
+
+    try:
+        for _ in range(16):  # defensive guard against endless pagination loops
+            request_params = params.copy()
+            if next_token:
+                request_params["page_token"] = next_token
+            response = sess.get(
+                COINMETRICS_ASSET_METRICS_ENDPOINT,
+                params=request_params,
+                timeout=10,
+            )
+            response.raise_for_status()
+            payload = response.json() or {}
+            data_chunk = payload.get("data", [])
+            if data_chunk:
+                collected.extend(data_chunk)
+            next_token = payload.get("next_page_token")
+            if not next_token:
+                break
+        else:
+            logger.warning("CoinMetrics pagination exceeded iteration guard; aborting fetch")
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning("Failed to fetch CoinMetrics exchange flows", exc_info=exc)
+        target_cols = [_COINMETRICS_COLUMN_MAP.get(metric, metric) for metric in metrics]
+        return _empty_timestamp_frame(target_cols)
+
+    if not collected:
+        target_cols = [_COINMETRICS_COLUMN_MAP.get(metric, metric) for metric in metrics]
+        return _empty_timestamp_frame(target_cols)
+
+    frame = pd.DataFrame(collected)
+    if frame.empty or "time" not in frame.columns:
+        target_cols = [_COINMETRICS_COLUMN_MAP.get(metric, metric) for metric in metrics]
+        return _empty_timestamp_frame(target_cols)
+
+    frame["timestamp"] = pd.to_datetime(frame["time"], utc=True, errors="coerce")
+    frame = frame.dropna(subset=["timestamp"])  # drop rows with invalid timestamps
+
+    rename_map = {metric: _COINMETRICS_COLUMN_MAP.get(metric, metric) for metric in metrics}
+    available_metrics = [metric for metric in metrics if metric in frame.columns]
+    if not available_metrics:
+        target_cols = list(rename_map.values())
+        return _empty_timestamp_frame(target_cols)
+
+    frame = frame.rename(columns=rename_map)
+    for column in rename_map.values():
+        if column in frame.columns:
+            frame[column] = pd.to_numeric(frame[column], errors="coerce")
+
+    desired_columns = [rename_map[metric] for metric in available_metrics]
+    frame = frame.set_index("timestamp")
+    frame = frame.loc[:, desired_columns]
+    frame.index.name = "timestamp"
+    frame = frame.sort_index()
+    return frame
+
+
+__all__ = [
+    "fetch_mempool_stats",
+    "fetch_exchange_flows",
+    "fetch_coinmetrics_exchange_flows",
+]

--- a/src/crypto_analyzer/data/sentiment_index_fetcher.py
+++ b/src/crypto_analyzer/data/sentiment_index_fetcher.py
@@ -1,0 +1,54 @@
+"""Retrieve Crypto Fear & Greed index values from alternative.me."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+import requests
+
+from crypto_analyzer.utils.logging import get_logger
+
+LOGGER = get_logger(__name__)
+
+_FEAR_GREED_ENDPOINT = "https://api.alternative.me/fng/"
+
+
+def fetch_fear_greed_index(
+    *, limit: int = 1, session: requests.Session | None = None
+) -> pd.DataFrame:
+    """Fetch historical Fear & Greed index readings."""
+
+    if limit <= 0:
+        raise ValueError("limit must be a positive integer")
+
+    params = {"limit": limit, "format": "json"}
+    sess = session or requests.Session()
+    try:
+        response = sess.get(_FEAR_GREED_ENDPOINT, params=params, timeout=10)
+        response.raise_for_status()
+        payload: dict[str, Any] = response.json() or {}
+    except (requests.RequestException, ValueError) as exc:
+        LOGGER.warning("Failed to fetch Fear & Greed index", exc_info=exc)
+        return pd.DataFrame(columns=["timestamp", "value", "classification", "time_until_update"])
+
+    data = payload.get("data", [])
+    frame = pd.DataFrame(data)
+    if frame.empty:
+        return pd.DataFrame(columns=["timestamp", "value", "classification", "time_until_update"])
+
+    frame["timestamp"] = pd.to_datetime(frame["timestamp"], unit="s", utc=True, errors="coerce")
+    frame["value"] = pd.to_numeric(frame["value"], errors="coerce")
+    frame.rename(columns={"value_classification": "classification"}, inplace=True)
+    if "time_until_update" in frame:
+        frame["time_until_update"] = pd.to_numeric(frame["time_until_update"], errors="coerce")
+    desired_columns = ["timestamp", "value", "classification", "time_until_update"]
+    for column in desired_columns:
+        if column not in frame.columns:
+            frame[column] = pd.NA
+    frame = frame[desired_columns]
+    frame = frame.sort_values("timestamp").reset_index(drop=True)
+    return frame
+
+
+__all__ = ["fetch_fear_greed_index"]

--- a/src/crypto_analyzer/data/social_sentiment.py
+++ b/src/crypto_analyzer/data/social_sentiment.py
@@ -1,0 +1,172 @@
+"""Fetch Reddit sentiment aggregates from Pushshift and VADER."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime
+from typing import Any
+
+import pandas as pd
+import requests
+from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+
+from crypto_analyzer.utils.logging import get_logger
+
+LOGGER = get_logger(__name__)
+
+_PUSHSHIFT_BASE_URL = "https://api.pushshift.io/reddit"
+_VALID_CONTENT_TYPES = {"comment", "submission"}
+
+
+def _normalise_pushshift_time(value: Any) -> Any:
+    """Convert ``value`` to a Pushshift-compatible timestamp representation."""
+
+    if value is None:
+        return None
+    if isinstance(value, pd.Timestamp):
+        ts = value.tz_convert("UTC") if value.tzinfo else value.tz_localize("UTC")
+        return int(ts.timestamp())
+    if isinstance(value, datetime):
+        ts = pd.Timestamp(value)
+        if ts.tzinfo is None:
+            ts = ts.tz_localize("UTC")
+        else:
+            ts = ts.tz_convert("UTC")
+        return int(ts.timestamp())
+    return value
+
+
+def _extract_text(entry: dict[str, Any], *, content_type: str) -> str:
+    if content_type == "comment":
+        return str(entry.get("body") or "")
+    title = str(entry.get("title") or "")
+    body = str(entry.get("selftext") or "")
+    if title and body:
+        return f"{title}\n{body}"
+    return title or body
+
+
+def fetch_reddit_sentiment(
+    *,
+    subreddit: str | None = None,
+    query: str | None = None,
+    after: datetime | pd.Timestamp | int | str | None = None,
+    before: datetime | pd.Timestamp | int | str | None = None,
+    size: int = 100,
+    content_type: str = "comment",
+    session: requests.Session | None = None,
+    analyzer: SentimentIntensityAnalyzer | None = None,
+) -> pd.DataFrame:
+    """Aggregate Reddit sentiment for the specified query parameters."""
+
+    if content_type not in _VALID_CONTENT_TYPES:
+        raise ValueError(f"Unsupported content type: {content_type}")
+
+    params: dict[str, Any] = {"size": max(1, min(size, 500))}
+    if subreddit:
+        params["subreddit"] = subreddit
+    if query:
+        params["q"] = query
+    after_value = _normalise_pushshift_time(after)
+    before_value = _normalise_pushshift_time(before)
+    if after_value is not None:
+        params["after"] = after_value
+    if before_value is not None:
+        params["before"] = before_value
+
+    url = f"{_PUSHSHIFT_BASE_URL}/{content_type}/search/"
+
+    sess = session or requests.Session()
+    try:
+        response = sess.get(url, params=params, timeout=10)
+        response.raise_for_status()
+        payload = response.json() or {}
+    except (requests.RequestException, ValueError) as exc:
+        LOGGER.warning("Failed to fetch Reddit sentiment", exc_info=exc)
+        return pd.DataFrame(
+            columns=[
+                "timestamp",
+                "reddit_score",
+                "mentions",
+                "reddit_positive_ratio",
+                "reddit_negative_ratio",
+                "reddit_positive_count",
+                "reddit_negative_count",
+                "reddit_neutral_count",
+            ]
+        )
+
+    entries: Sequence[dict[str, Any]] = payload.get("data", []) if isinstance(payload, dict) else []
+
+    if not entries:
+        return pd.DataFrame(
+            columns=[
+                "timestamp",
+                "reddit_score",
+                "mentions",
+                "reddit_positive_ratio",
+                "reddit_negative_ratio",
+                "reddit_positive_count",
+                "reddit_negative_count",
+                "reddit_neutral_count",
+            ]
+        )
+
+    analyser = analyzer or SentimentIntensityAnalyzer()
+
+    compounds: list[float] = []
+    pos = neg = neu = 0
+    for entry in entries:
+        text = _extract_text(entry, content_type=content_type).strip()
+        if not text or text in {"[deleted]", "[removed]"}:
+            continue
+        scores = analyser.polarity_scores(text)
+        compound = float(scores.get("compound", 0.0))
+        compounds.append(compound)
+        if compound > 0.05:
+            pos += 1
+        elif compound < -0.05:
+            neg += 1
+        else:
+            neu += 1
+
+    if not compounds:
+        return pd.DataFrame(
+            columns=[
+                "timestamp",
+                "reddit_score",
+                "mentions",
+                "reddit_positive_ratio",
+                "reddit_negative_ratio",
+                "reddit_positive_count",
+                "reddit_negative_count",
+                "reddit_neutral_count",
+            ]
+        )
+
+    mention_count = len(compounds)
+    avg_compound = sum(compounds) / mention_count
+    pos_ratio = pos / mention_count
+    neg_ratio = neg / mention_count
+
+    timestamp = pd.Timestamp.utcnow()
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.tz_localize("UTC")
+    else:
+        timestamp = timestamp.tz_convert("UTC")
+    frame = pd.DataFrame(
+        {
+            "timestamp": [timestamp],
+            "reddit_score": [avg_compound],
+            "mentions": [mention_count],
+            "reddit_positive_ratio": [pos_ratio],
+            "reddit_negative_ratio": [neg_ratio],
+            "reddit_positive_count": [pos],
+            "reddit_negative_count": [neg],
+            "reddit_neutral_count": [neu],
+        }
+    )
+    return frame
+
+
+__all__ = ["fetch_reddit_sentiment"]

--- a/tests/test_data_collector.py
+++ b/tests/test_data_collector.py
@@ -51,6 +51,73 @@ def test_fetch_glassnode_active_addresses_parses_payload():
     assert frame["timestamp"].iloc[0].tzinfo is not None
 
 
+def test_fetch_binance_order_book_extracts_top_of_book():
+    payload = {
+        "lastUpdateId": 1,
+        "bids": [["50000.0", "1.5"], ["49990.0", "0.25"]],
+        "asks": [["50010.0", "2.0"], ["50020.0", "1.0"]],
+    }
+    session = _DummySession(payload)
+
+    frame = data_collector.fetch_binance_order_book(
+        "BTCUSDT", depth=20, session=session
+    )
+
+    assert list(frame.columns) == [
+        "timestamp",
+        "bid_price",
+        "bid_volume",
+        "ask_price",
+        "ask_volume",
+        "spread",
+        "mid_price",
+        "bid_volume_total",
+        "ask_volume_total",
+        "bid_notional_total",
+        "ask_notional_total",
+        "depth_imbalance",
+    ]
+    assert frame.shape[0] == 1
+
+    row = frame.iloc[0]
+    assert row["bid_price"] == pytest.approx(50_000.0)
+    assert row["ask_price"] == pytest.approx(50_010.0)
+    assert row["spread"] == pytest.approx(10.0)
+    assert row["bid_volume_total"] == pytest.approx(1.75)
+    assert row["ask_volume_total"] == pytest.approx(3.0)
+    assert -1.0 <= row["depth_imbalance"] <= 1.0
+    assert session.calls[0]["params"]["limit"] == 20
+
+
+def test_fetch_binance_order_book_handles_missing_levels():
+    payload = {"bids": [], "asks": []}
+    session = _DummySession(payload)
+
+    frame = data_collector.fetch_binance_order_book("BTCUSDT", session=session)
+
+    assert frame.empty
+    assert list(frame.columns) == [
+        "timestamp",
+        "bid_price",
+        "bid_volume",
+        "ask_price",
+        "ask_volume",
+        "spread",
+        "mid_price",
+        "bid_volume_total",
+        "ask_volume_total",
+        "bid_notional_total",
+        "ask_notional_total",
+        "depth_imbalance",
+    ]
+
+
+def test_fetch_binance_order_book_rejects_invalid_depth():
+    session = _DummySession({"bids": [], "asks": []})
+    with pytest.raises(ValueError):
+        data_collector.fetch_binance_order_book("BTCUSDT", depth=0, session=session)
+
+
 def test_load_enriched_market_data_aligns_daily_series(monkeypatch):
     base = pd.DataFrame(
         {

--- a/tests/test_news_fetcher.py
+++ b/tests/test_news_fetcher.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import requests
+
+from crypto_analyzer.data.news_fetcher import fetch_cryptopanic_news
+
+
+class DummyResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+    def raise_for_status(self) -> None:  # pragma: no cover - mirrors requests
+        return None
+
+
+class DummySession:
+    def __init__(self, payloads: list[dict[str, Any]]) -> None:
+        self._payloads = list(payloads)
+        self.calls: list[dict[str, Any]] = []
+
+    def get(self, url: str, params: dict[str, Any] | None = None, timeout: int | None = None) -> DummyResponse:
+        if not self._payloads:
+            raise RuntimeError("No more responses queued")
+        self.calls.append({"url": url, "params": params, "timeout": timeout})
+        return DummyResponse(self._payloads.pop(0))
+
+
+def test_fetch_cryptopanic_news_parses_records() -> None:
+    payload = {
+        "results": [
+            {
+                "published_at": "2024-01-01T00:00:00Z",
+                "title": "Bitcoin hits new high",
+                "url": "https://example.com/1",
+                "votes": {"positive": 3, "negative": 1},
+                "tags": ["Bullish", "BTC"],
+                "currencies": [{"code": "BTC"}, {"code": "ETH"}],
+                "source": {"title": "CoinDesk"},
+            },
+            {
+                "published_at": "2024-01-01T12:00:00Z",
+                "title": "Market uncertainty",
+                "url": "https://example.com/2",
+                "votes": {"positive": 0, "negative": 2},
+                "tags": ["Bearish"],
+                "currencies": [{"code": "ETH"}],
+                "source": {"title": "CoinTelegraph"},
+            },
+        ]
+    }
+    session = DummySession([payload])
+
+    frame = fetch_cryptopanic_news("token", session=session, limit=5)
+
+    assert list(frame.columns) == [
+        "timestamp",
+        "title",
+        "url",
+        "source",
+        "sentiment",
+        "positive_votes",
+        "negative_votes",
+        "tags",
+        "currencies",
+    ]
+    assert frame.shape[0] == 2
+    assert frame.iloc[0]["source"] == "CoinDesk"
+    assert frame.iloc[0]["sentiment"] == pytest.approx(3 - 1)
+    assert "bullish" in frame.iloc[0]["tags"].lower()
+    assert "BTC" in frame.iloc[0]["currencies"]
+
+
+def test_fetch_cryptopanic_news_handles_pagination_limit() -> None:
+    payload_one = {
+        "results": [
+            {
+                "published_at": "2024-01-01T00:00:00Z",
+                "title": "First",
+                "url": "https://example.com/a",
+                "votes": {"positive": 1, "negative": 0},
+                "tags": [],
+                "currencies": [],
+                "source": {"title": "SourceA"},
+            }
+        ],
+        "next": "https://cryptopanic.com/api/v1/posts/?page=2",
+    }
+    payload_two = {
+        "results": [
+            {
+                "published_at": "2024-01-02T00:00:00Z",
+                "title": "Second",
+                "url": "https://example.com/b",
+                "votes": {"positive": 0, "negative": 1},
+                "tags": ["Bearish"],
+                "currencies": [],
+                "source": {"title": "SourceB"},
+            }
+        ]
+    }
+    session = DummySession([payload_one, payload_two])
+
+    frame = fetch_cryptopanic_news("token", session=session, limit=2, max_pages=2)
+
+    assert frame.shape[0] == 2
+    assert session.calls[0]["params"]["auth_token"] == "token"
+    assert session.calls[1]["params"] is None
+
+
+def test_fetch_cryptopanic_news_validates_arguments() -> None:
+    session = DummySession([])
+    with pytest.raises(ValueError):
+        fetch_cryptopanic_news("", session=session)
+    with pytest.raises(ValueError):
+        fetch_cryptopanic_news("token", session=session, limit=0)
+    with pytest.raises(ValueError):
+        fetch_cryptopanic_news("token", session=session, limit=1, max_pages=0)
+
+
+def test_fetch_cryptopanic_news_handles_errors() -> None:
+    class FailingSession:
+        def get(self, *_: Any, **__: Any) -> Any:
+            raise requests.RequestException("fail")
+
+    frame = fetch_cryptopanic_news("token", session=FailingSession())
+
+    assert frame.empty
+    assert list(frame.columns) == [
+        "timestamp",
+        "title",
+        "url",
+        "source",
+        "sentiment",
+        "positive_votes",
+        "negative_votes",
+        "tags",
+        "currencies",
+    ]

--- a/tests/test_onchain_fetcher.py
+++ b/tests/test_onchain_fetcher.py
@@ -10,9 +10,11 @@ import pytest
 import requests
 
 from crypto_analyzer.data.onchain_fetcher import (
+    COINMETRICS_ASSET_METRICS_ENDPOINT,
     GLASSNODE_EXCHANGE_INFLOW_ENDPOINT,
     GLASSNODE_EXCHANGE_OUTFLOW_ENDPOINT,
     fetch_exchange_flows,
+    fetch_coinmetrics_exchange_flows,
     fetch_mempool_stats,
 )
 
@@ -169,3 +171,58 @@ def test_fetch_exchange_flows_handles_request_errors() -> None:
     assert frame.index.name == "timestamp"
     assert frame.index.tz is not None
     assert list(frame.columns) == ["onch_exchange_inflow", "onch_exchange_outflow"]
+
+
+def test_fetch_coinmetrics_exchange_flows_paginates_and_parses() -> None:
+    page_one = {
+        "data": [
+            {
+                "time": "2024-01-01T00:00:00Z",
+                "ExchgNetFlow": "10.5",
+                "ExchgInflowVolume": "20.0",
+                "ExchgOutflowVolume": "9.5",
+            }
+        ],
+        "next_page_token": "token-1",
+    }
+    page_two = {
+        "data": [
+            {
+                "time": "2024-01-02T00:00:00Z",
+                "ExchgNetFlow": "-3.0",
+                "ExchgInflowVolume": "12.0",
+                "ExchgOutflowVolume": "15.0",
+            }
+        ]
+    }
+    session = QueueSession([DummyResponse(page_one), DummyResponse(page_two)])
+
+    frame = fetch_coinmetrics_exchange_flows(session=session)
+
+    assert list(frame.columns) == [
+        "onch_exchange_net_flow",
+        "onch_exchange_inflow",
+        "onch_exchange_outflow",
+    ]
+    assert frame.index.name == "timestamp"
+    assert frame.index.tz is not None
+    assert frame.iloc[0, 0] == pytest.approx(10.5)
+    assert frame.iloc[1, 1] == pytest.approx(12.0)
+    assert frame.iloc[1, 2] == pytest.approx(15.0)
+
+    first_call = session.calls[0]
+    assert first_call[0] == COINMETRICS_ASSET_METRICS_ENDPOINT
+    assert first_call[1]["params"]["frequency"] == "1d"
+    second_call = session.calls[1]
+    assert second_call[1]["params"]["page_token"] == "token-1"
+
+
+def test_fetch_coinmetrics_exchange_flows_handles_errors() -> None:
+    class FailingSession:
+        def get(self, *_: Any, **__: Any) -> Any:
+            raise requests.RequestException("bad")
+
+    frame = fetch_coinmetrics_exchange_flows(session=FailingSession())
+
+    assert frame.empty
+    assert frame.index.tz is not None

--- a/tests/test_sentiment_index_fetcher.py
+++ b/tests/test_sentiment_index_fetcher.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import requests
+
+from crypto_analyzer.data.sentiment_index_fetcher import fetch_fear_greed_index
+
+
+class DummyResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+    def raise_for_status(self) -> None:  # pragma: no cover - mirrors requests
+        return None
+
+
+class DummySession:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+        self.calls: list[dict[str, Any]] = []
+
+    def get(self, url: str, params: dict[str, Any], timeout: int | None = None) -> DummyResponse:
+        self.calls.append({"url": url, "params": params, "timeout": timeout})
+        return DummyResponse(self._payload)
+
+
+def test_fetch_fear_greed_index_parses_payload() -> None:
+    payload = {
+        "data": [
+            {
+                "value": "40",
+                "value_classification": "Fear",
+                "timestamp": "1",
+                "time_until_update": "3600",
+            },
+            {
+                "value": "60",
+                "value_classification": "Greed",
+                "timestamp": "2",
+            },
+        ]
+    }
+    session = DummySession(payload)
+
+    frame = fetch_fear_greed_index(limit=2, session=session)
+
+    assert list(frame.columns) == ["timestamp", "value", "classification", "time_until_update"]
+    assert frame.shape[0] == 2
+    assert frame.loc[0, "value"] == pytest.approx(40)
+    assert frame.loc[1, "classification"] == "Greed"
+    assert session.calls[0]["params"]["limit"] == 2
+
+
+def test_fetch_fear_greed_index_handles_errors() -> None:
+    class FailingSession:
+        def get(self, *_: Any, **__: Any) -> Any:
+            raise requests.RequestException("oops")
+
+    frame = fetch_fear_greed_index(session=FailingSession())
+
+    assert frame.empty
+    assert list(frame.columns) == ["timestamp", "value", "classification", "time_until_update"]
+
+
+@pytest.mark.parametrize("limit", [0, -1])
+def test_fetch_fear_greed_index_validates_limit(limit: int) -> None:
+    session = DummySession({"data": []})
+    with pytest.raises(ValueError):
+        fetch_fear_greed_index(limit=limit, session=session)

--- a/tests/test_social_sentiment_fetcher.py
+++ b/tests/test_social_sentiment_fetcher.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+import requests
+
+from crypto_analyzer.data.social_sentiment import fetch_reddit_sentiment
+
+
+class DummyAnalyzer:
+    def __init__(self, mapping: dict[str, float]) -> None:
+        self._mapping = mapping
+
+    def polarity_scores(self, text: str) -> dict[str, float]:  # pragma: no cover - simple mapping
+        return {"compound": self._mapping.get(text, 0.0)}
+
+
+class DummyResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+    def raise_for_status(self) -> None:  # pragma: no cover - mirrors requests
+        return None
+
+
+class DummySession:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+        self.calls: list[dict[str, Any]] = []
+
+    def get(self, url: str, params: dict[str, Any] | None = None, timeout: int | None = None) -> DummyResponse:
+        self.calls.append({"url": url, "params": params, "timeout": timeout})
+        return DummyResponse(self._payload)
+
+
+def test_fetch_reddit_sentiment_computes_expected_metrics() -> None:
+    payload = {
+        "data": [
+            {"body": "I love bitcoin"},
+            {"body": "This market looks awful"},
+            {"body": "[deleted]"},
+        ]
+    }
+    analyzer = DummyAnalyzer({"I love bitcoin": 0.8, "This market looks awful": -0.6})
+    session = DummySession(payload)
+
+    frame = fetch_reddit_sentiment(
+        subreddit="CryptoCurrency",
+        analyzer=analyzer,
+        session=session,
+    )
+
+    assert frame.shape == (1, 8)
+    row = frame.iloc[0]
+    assert row["reddit_score"] == pytest.approx(0.1)
+    assert row["mentions"] == 2
+    assert row["reddit_positive_count"] == 1
+    assert row["reddit_negative_count"] == 1
+    assert session.calls[0]["params"]["subreddit"] == "CryptoCurrency"
+
+
+def test_fetch_reddit_sentiment_normalises_time_parameters() -> None:
+    payload = {"data": [{"body": "neutral"}]}
+    analyzer = DummyAnalyzer({"neutral": 0.0})
+    session = DummySession(payload)
+    after = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    frame = fetch_reddit_sentiment(
+        after=after,
+        before=after + timedelta(hours=1),
+        analyzer=analyzer,
+        session=session,
+        size=123,
+    )
+
+    assert not frame.empty
+    params = session.calls[0]["params"]
+    assert params["after"] == int(after.timestamp())
+    assert params["before"] == int((after + timedelta(hours=1)).timestamp())
+    assert params["size"] == 123
+
+
+def test_fetch_reddit_sentiment_handles_request_errors() -> None:
+    class FailingSession:
+        def get(self, *_: Any, **__: Any) -> Any:
+            raise requests.RequestException("boom")
+
+    analyzer = DummyAnalyzer({})
+    frame = fetch_reddit_sentiment(
+        subreddit="Bitcoin",
+        analyzer=analyzer,
+        session=FailingSession(),
+    )
+
+    assert frame.empty
+    assert list(frame.columns) == [
+        "timestamp",
+        "reddit_score",
+        "mentions",
+        "reddit_positive_ratio",
+        "reddit_negative_ratio",
+        "reddit_positive_count",
+        "reddit_negative_count",
+        "reddit_neutral_count",
+    ]


### PR DESCRIPTION
## Summary
- add Binance futures order book snapshot fetching and extend derivatives data integration
- implement fetchers for Reddit sentiment, Fear & Greed index, CoinMetrics exchange flows, and CryptoPanic news
- register new dependencies and expand database schema plus unit tests covering the new fetchers

## Testing
- pytest tests/test_data_collector.py tests/test_onchain_fetcher.py tests/test_social_sentiment_fetcher.py tests/test_sentiment_index_fetcher.py tests/test_news_fetcher.py

------
https://chatgpt.com/codex/tasks/task_e_68f757fa2b9c8327befa1d3837b89266