### PR TITLE
Add APScheduler scheduler for automated data ingestion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "shap==0.46.0",
     "numba==0.60.0",
     "requests==2.32.3",
+    "APScheduler==3.10.4",
     "pydantic==2.8.2",
     "python-dateutil==2.9.0.post0",
     "tqdm==4.66.5",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ xgboost==2.1.1
 shap==0.46.0
 numba==0.60.0
 requests==2.32.3
+APScheduler==3.10.4
 pydantic==2.8.2
 python-dateutil==2.9.0.post0
 tqdm==4.66.5

--- a/scripts/run_scheduler.py
+++ b/scripts/run_scheduler.py
@@ -1,0 +1,95 @@
+"""Entry point for running the automated data ingestion scheduler."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from contextlib import suppress
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+
+from crypto_analyzer.scheduling import DataIngestionScheduler, SchedulerConfig
+from crypto_analyzer.utils.logging import configure_logging, resolve_run_id
+
+
+def _parse_args() -> SchedulerConfig:
+    parser = argparse.ArgumentParser(description="Start the Crypto Analyzer data scheduler")
+    parser.add_argument(
+        "--timezone",
+        help="Timezone override for scheduled jobs (defaults to config core.timezone)",
+    )
+    parser.add_argument(
+        "--binance-interval",
+        type=int,
+        help="Minutes between Binance market data refreshes",
+    )
+    parser.add_argument(
+        "--news-interval",
+        type=int,
+        help="Minutes between CryptoPanic news refreshes",
+    )
+    parser.add_argument(
+        "--reddit-interval",
+        type=int,
+        help="Minutes between Reddit sentiment refreshes",
+    )
+    parser.add_argument(
+        "--daily-time",
+        help="Cron-style HH:MM time for daily aggregations",
+    )
+    parser.add_argument(
+        "--retry-delay",
+        type=int,
+        help="Seconds to wait before retrying a failed job",
+    )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        help="Maximum retry attempts for a failed job",
+    )
+    args = parser.parse_args()
+
+    settings = SchedulerConfig()
+    if args.timezone:
+        settings.timezone = args.timezone
+    if args.binance_interval:
+        settings.binance_interval_minutes = max(1, args.binance_interval)
+    if args.news_interval:
+        settings.news_interval_minutes = max(1, args.news_interval)
+    if args.reddit_interval:
+        settings.reddit_interval_minutes = max(1, args.reddit_interval)
+    if args.retry_delay:
+        settings.retry_delay_seconds = max(1, args.retry_delay)
+    if args.max_retries is not None:
+        settings.max_retries = max(0, args.max_retries)
+    if args.daily_time:
+        try:
+            hour_str, minute_str = args.daily_time.split(":", 1)
+            settings.daily_run_time = settings.daily_run_time.replace(
+                hour=int(hour_str), minute=int(minute_str)
+            )
+        except (ValueError, AttributeError):
+            raise SystemExit("--daily-time must be in HH:MM format")
+    return settings
+
+
+def main() -> None:
+    configure_logging(resolve_run_id())
+    settings = _parse_args()
+    scheduler = BlockingScheduler()
+    ingestion = DataIngestionScheduler(scheduler=scheduler, settings=settings)
+    ingestion.configure_jobs()
+    try:
+        ingestion.start()
+    except (KeyboardInterrupt, SystemExit):
+        with suppress(Exception):
+            ingestion.shutdown()
+        sys.exit(0)
+    except Exception:  # pragma: no cover - unexpected runtime failure
+        with suppress(Exception):
+            ingestion.shutdown(wait=False)
+        raise
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/src/crypto_analyzer/data/ingestion_store.py
+++ b/src/crypto_analyzer/data/ingestion_store.py
@@ -179,23 +179,23 @@ def _upsert(table: Table, records: Iterable[dict[str, object]], engine: Engine, 
         return 0
 
     dialect = engine.dialect.name
-    if dialect == "postgresql":
-        insert_stmt = pg_insert(table)
-        update_cols = {
+
+    def _build_update_cols(insert_stmt):
+        return {
             col.name: getattr(insert_stmt.excluded, col.name)
             for col in table.c
-            if col.name not in conflict_cols
+            if col.name not in conflict_cols and not col.primary_key
         }
+
+    if dialect == "postgresql":
+        insert_stmt = pg_insert(table)
+        update_cols = _build_update_cols(insert_stmt)
         insert_stmt = insert_stmt.on_conflict_do_update(
             index_elements=[table.c[name] for name in conflict_cols], set_=update_cols
         )
     elif dialect == "sqlite":
         insert_stmt = sqlite_insert(table)
-        update_cols = {
-            col.name: getattr(insert_stmt.excluded, col.name)
-            for col in table.c
-            if col.name not in conflict_cols
-        }
+        update_cols = _build_update_cols(insert_stmt)
         insert_stmt = insert_stmt.on_conflict_do_update(index_elements=list(conflict_cols), set_=update_cols)
     else:
         insert_stmt = table.insert().prefix_with("OR REPLACE")

--- a/src/crypto_analyzer/data/ingestion_store.py
+++ b/src/crypto_analyzer/data/ingestion_store.py
@@ -1,0 +1,383 @@
+"""Persistence helpers for scheduler-managed data feeds."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Float,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    UniqueConstraint,
+    func,
+    select,
+    text,
+)
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.engine import Engine
+
+from crypto_analyzer.data.db_connector import get_engine
+
+_METADATA = MetaData()
+
+DERIVATIVES_TABLE = Table(
+    "derivatives_intraday",
+    _METADATA,
+    Column("timestamp", DateTime(timezone=True), nullable=False),
+    Column("symbol", String(20), nullable=False),
+    Column("funding_rate", Float),
+    Column("open_interest", Float),
+    Column("fetched_at", DateTime(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+    UniqueConstraint("timestamp", "symbol", name="ux_derivatives_intraday"),
+)
+
+ORDERBOOK_TABLE = Table(
+    "orderbook_snapshots",
+    _METADATA,
+    Column("timestamp", DateTime(timezone=True), nullable=False),
+    Column("symbol", String(20), nullable=False),
+    Column("bid_price", Float),
+    Column("bid_volume", Float),
+    Column("ask_price", Float),
+    Column("ask_volume", Float),
+    Column("spread", Float),
+    Column("mid_price", Float),
+    Column("bid_volume_total", Float),
+    Column("ask_volume_total", Float),
+    Column("bid_notional_total", Float),
+    Column("ask_notional_total", Float),
+    Column("depth_imbalance", Float),
+    Column("fetched_at", DateTime(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+    UniqueConstraint("timestamp", "symbol", name="ux_orderbook_snapshots"),
+)
+
+NEWS_TABLE = Table(
+    "news_items",
+    _METADATA,
+    Column("id", Integer, primary_key=True, autoincrement=True),
+    Column("timestamp", DateTime(timezone=True), nullable=False),
+    Column("title", String(512), nullable=False, default=""),
+    Column("url", String(512), nullable=False, unique=True),
+    Column("source", String(128)),
+    Column("sentiment", Float),
+    Column("positive_votes", Float),
+    Column("negative_votes", Float),
+    Column("tags", String(256)),
+    Column("currencies", String(128)),
+    Column("fetched_at", DateTime(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+)
+
+REDDIT_SENTIMENT_TABLE = Table(
+    "reddit_sentiment",
+    _METADATA,
+    Column("timestamp", DateTime(timezone=True), nullable=False),
+    Column("subreddit", String(128), nullable=False, default=""),
+    Column("query", String(128), nullable=False, default=""),
+    Column("reddit_score", Float),
+    Column("mentions", Float),
+    Column("reddit_positive_ratio", Float),
+    Column("reddit_negative_ratio", Float),
+    Column("reddit_positive_count", Float),
+    Column("reddit_negative_count", Float),
+    Column("reddit_neutral_count", Float),
+    Column("fetched_at", DateTime(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+    UniqueConstraint("timestamp", "subreddit", "query", name="ux_reddit_sentiment"),
+)
+
+GLASSNODE_ACTIVE_TABLE = Table(
+    "glassnode_active_addresses",
+    _METADATA,
+    Column("timestamp", DateTime(timezone=True), nullable=False),
+    Column("asset", String(16), nullable=False),
+    Column("onch_active_addresses", Float),
+    Column("fetched_at", DateTime(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+    UniqueConstraint("timestamp", "asset", name="ux_glassnode_active_addresses"),
+)
+
+COINMETRICS_FLOWS_TABLE = Table(
+    "coinmetrics_exchange_flows",
+    _METADATA,
+    Column("timestamp", DateTime(timezone=True), nullable=False),
+    Column("asset", String(16), nullable=False),
+    Column("onch_exchange_net_flow", Float),
+    Column("onch_exchange_inflow", Float),
+    Column("onch_exchange_outflow", Float),
+    Column("fetched_at", DateTime(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+    UniqueConstraint("timestamp", "asset", name="ux_coinmetrics_exchange_flows"),
+)
+
+FEAR_GREED_TABLE = Table(
+    "fear_greed_index",
+    _METADATA,
+    Column("timestamp", DateTime(timezone=True), nullable=False, unique=True),
+    Column("value", Float),
+    Column("classification", String(64)),
+    Column("time_until_update", Float),
+    Column("fetched_at", DateTime(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class StoreResult:
+    """Summarise how many rows have been written by a persistence call."""
+
+    inserted: int = 0
+
+
+def ensure_schema(engine: Engine | None = None, *, db_path: str | Path | None = None) -> Engine:
+    """Initialise all scheduler-managed tables and return the active engine."""
+
+    if engine is None:
+        engine = get_engine(db_path)
+    with engine.begin() as conn:
+        _METADATA.create_all(conn)
+    return engine
+
+
+def _ensure_utc(value: object) -> datetime:
+    ts = pd.Timestamp(value)
+    if ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    else:
+        ts = ts.tz_convert("UTC")
+    return ts.to_pydatetime()
+
+
+def _prepare_records(frame: pd.DataFrame, *, extra: dict[str, object] | None = None) -> list[dict[str, object]]:
+    if frame.empty:
+        return []
+    records: list[dict[str, object]] = []
+    for raw in frame.to_dict(orient="records"):
+        record = dict(extra or {})
+        for key, value in raw.items():
+            if key == "timestamp":
+                if value is None or pd.isna(value):
+                    break
+                record[key] = _ensure_utc(value)
+            else:
+                if value is None or (isinstance(value, float) and pd.isna(value)):
+                    record[key] = None
+                else:
+                    record[key] = value
+        else:
+            records.append(record)
+    return records
+
+
+def _upsert(table: Table, records: Iterable[dict[str, object]], engine: Engine, conflict_cols: tuple[str, ...]) -> int:
+    payload = list(records)
+    if not payload:
+        return 0
+
+    dialect = engine.dialect.name
+    if dialect == "postgresql":
+        insert_stmt = pg_insert(table)
+        update_cols = {
+            col.name: getattr(insert_stmt.excluded, col.name)
+            for col in table.c
+            if col.name not in conflict_cols
+        }
+        insert_stmt = insert_stmt.on_conflict_do_update(
+            index_elements=[table.c[name] for name in conflict_cols], set_=update_cols
+        )
+    elif dialect == "sqlite":
+        insert_stmt = sqlite_insert(table)
+        update_cols = {
+            col.name: getattr(insert_stmt.excluded, col.name)
+            for col in table.c
+            if col.name not in conflict_cols
+        }
+        insert_stmt = insert_stmt.on_conflict_do_update(index_elements=list(conflict_cols), set_=update_cols)
+    else:
+        insert_stmt = table.insert().prefix_with("OR REPLACE")
+
+    with engine.begin() as conn:
+        conn.execute(insert_stmt, payload)
+    return len(payload)
+
+
+def _latest_timestamp(table: Table, engine: Engine, *, filters: dict[str, object] | None = None) -> pd.Timestamp | None:
+    stmt = select(func.max(table.c.timestamp))
+    if filters:
+        for key, value in filters.items():
+            if value is None or key not in table.c:
+                continue
+            stmt = stmt.where(table.c[key] == value)
+    with engine.connect() as conn:
+        result = conn.execute(stmt).scalar_one_or_none()
+    if result is None:
+        return None
+    ts = pd.Timestamp(result)
+    if ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    else:
+        ts = ts.tz_convert("UTC")
+    return ts
+
+
+def latest_derivatives_timestamp(engine: Engine, *, symbol: str) -> pd.Timestamp | None:
+    return _latest_timestamp(DERIVATIVES_TABLE, engine, filters={"symbol": symbol})
+
+
+def latest_glassnode_timestamp(engine: Engine, *, asset: str) -> pd.Timestamp | None:
+    return _latest_timestamp(GLASSNODE_ACTIVE_TABLE, engine, filters={"asset": asset})
+
+
+def latest_coinmetrics_timestamp(engine: Engine, *, asset: str) -> pd.Timestamp | None:
+    return _latest_timestamp(COINMETRICS_FLOWS_TABLE, engine, filters={"asset": asset})
+
+
+def latest_fear_greed_timestamp(engine: Engine) -> pd.Timestamp | None:
+    return _latest_timestamp(FEAR_GREED_TABLE, engine)
+
+
+def store_derivatives(
+    funding: pd.DataFrame,
+    open_interest: pd.DataFrame,
+    *,
+    engine: Engine,
+    symbol: str,
+) -> StoreResult:
+    frames: list[pd.DataFrame] = []
+    if not funding.empty:
+        frame = funding.loc[:, ["timestamp", "funding_rate"]].copy()
+        frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True, errors="coerce")
+        frames.append(frame)
+    if not open_interest.empty:
+        frame = open_interest.loc[:, ["timestamp", "open_interest"]].copy()
+        frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True, errors="coerce")
+        frames.append(frame)
+
+    if not frames:
+        return StoreResult(0)
+
+    merged = frames[0]
+    for frame in frames[1:]:
+        merged = merged.merge(frame, on="timestamp", how="outer")
+
+    merged = merged.dropna(subset=["timestamp"]).drop_duplicates(subset=["timestamp"])
+    value_cols = [col for col in merged.columns if col not in {"timestamp"}]
+    merged = merged.dropna(subset=value_cols, how="all")
+    merged["symbol"] = symbol
+    merged = merged.sort_values("timestamp").reset_index(drop=True)
+
+    records = _prepare_records(merged)
+    inserted = _upsert(DERIVATIVES_TABLE, records, engine, ("timestamp", "symbol"))
+    return StoreResult(inserted)
+
+
+def store_orderbook(snapshot: pd.DataFrame, *, engine: Engine, symbol: str) -> StoreResult:
+    if snapshot.empty:
+        return StoreResult(0)
+    frame = snapshot.copy()
+    frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True, errors="coerce")
+    frame = frame.dropna(subset=["timestamp"]).reset_index(drop=True)
+    frame["symbol"] = symbol
+    records = _prepare_records(frame)
+    inserted = _upsert(ORDERBOOK_TABLE, records, engine, ("timestamp", "symbol"))
+    return StoreResult(inserted)
+
+
+def store_news(news: pd.DataFrame, *, engine: Engine) -> StoreResult:
+    if news.empty:
+        return StoreResult(0)
+    frame = news.copy()
+    frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True, errors="coerce")
+    frame = frame.dropna(subset=["timestamp", "url"]).reset_index(drop=True)
+    frame["url"] = frame["url"].astype(str).str.strip()
+    frame = frame.loc[frame["url"] != ""]
+    records = _prepare_records(frame)
+    inserted = _upsert(NEWS_TABLE, records, engine, ("url",))
+    return StoreResult(inserted)
+
+
+def store_reddit_sentiment(
+    sentiment: pd.DataFrame,
+    *,
+    engine: Engine,
+    subreddit: str | None = None,
+    query: str | None = None,
+) -> StoreResult:
+    if sentiment.empty:
+        return StoreResult(0)
+    frame = sentiment.copy()
+    frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True, errors="coerce")
+    frame = frame.dropna(subset=["timestamp"]).reset_index(drop=True)
+    frame["subreddit"] = (subreddit or "").strip()
+    frame["query"] = (query or "").strip()
+    records = _prepare_records(frame)
+    inserted = _upsert(REDDIT_SENTIMENT_TABLE, records, engine, ("timestamp", "subreddit", "query"))
+    return StoreResult(inserted)
+
+
+def store_glassnode_active_addresses(
+    addresses: pd.DataFrame,
+    *,
+    engine: Engine,
+    asset: str,
+) -> StoreResult:
+    if addresses.empty:
+        return StoreResult(0)
+    frame = addresses.copy()
+    frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True, errors="coerce")
+    frame = frame.dropna(subset=["timestamp"]).reset_index(drop=True)
+    frame["asset"] = asset
+    records = _prepare_records(frame)
+    inserted = _upsert(GLASSNODE_ACTIVE_TABLE, records, engine, ("timestamp", "asset"))
+    return StoreResult(inserted)
+
+
+def store_coinmetrics_flows(
+    flows: pd.DataFrame,
+    *,
+    engine: Engine,
+    asset: str,
+) -> StoreResult:
+    if flows.empty:
+        return StoreResult(0)
+    frame = flows.copy()
+    if "timestamp" not in frame.columns:
+        frame = frame.reset_index()
+    frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True, errors="coerce")
+    frame = frame.dropna(subset=["timestamp"]).reset_index(drop=True)
+    frame["asset"] = asset
+    records = _prepare_records(frame)
+    inserted = _upsert(COINMETRICS_FLOWS_TABLE, records, engine, ("timestamp", "asset"))
+    return StoreResult(inserted)
+
+
+def store_fear_greed_index(index_frame: pd.DataFrame, *, engine: Engine) -> StoreResult:
+    if index_frame.empty:
+        return StoreResult(0)
+    frame = index_frame.copy()
+    frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True, errors="coerce")
+    frame = frame.dropna(subset=["timestamp"]).reset_index(drop=True)
+    records = _prepare_records(frame)
+    inserted = _upsert(FEAR_GREED_TABLE, records, engine, ("timestamp",))
+    return StoreResult(inserted)
+
+
+__all__ = [
+    "StoreResult",
+    "ensure_schema",
+    "latest_coinmetrics_timestamp",
+    "latest_derivatives_timestamp",
+    "latest_fear_greed_timestamp",
+    "latest_glassnode_timestamp",
+    "store_coinmetrics_flows",
+    "store_derivatives",
+    "store_fear_greed_index",
+    "store_glassnode_active_addresses",
+    "store_news",
+    "store_orderbook",
+    "store_reddit_sentiment",
+]

--- a/src/crypto_analyzer/scheduling/__init__.py
+++ b/src/crypto_analyzer/scheduling/__init__.py
@@ -1,0 +1,5 @@
+"""Scheduler utilities for automated data collection."""
+
+from .data_ingestion import DataIngestionScheduler, SchedulerConfig
+
+__all__ = ["DataIngestionScheduler", "SchedulerConfig"]

--- a/src/crypto_analyzer/scheduling/data_ingestion.py
+++ b/src/crypto_analyzer/scheduling/data_ingestion.py
@@ -1,0 +1,382 @@
+"""APScheduler integration for recurring data collection jobs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, time, timedelta
+from typing import Any, Callable
+
+import pandas as pd
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.schedulers.base import BaseScheduler
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
+
+from crypto_analyzer.data.data_collector import (
+    fetch_binance_funding_rates,
+    fetch_binance_open_interest,
+    fetch_binance_order_book,
+    fetch_glassnode_active_addresses,
+)
+from crypto_analyzer.data.ingestion_store import (
+    StoreResult,
+    ensure_schema,
+    latest_coinmetrics_timestamp,
+    latest_derivatives_timestamp,
+    latest_fear_greed_timestamp,
+    latest_glassnode_timestamp,
+    store_coinmetrics_flows,
+    store_derivatives,
+    store_fear_greed_index,
+    store_glassnode_active_addresses,
+    store_news,
+    store_orderbook,
+    store_reddit_sentiment,
+)
+from crypto_analyzer.data.news_fetcher import fetch_cryptopanic_news
+from crypto_analyzer.data.onchain_fetcher import fetch_coinmetrics_exchange_flows
+from crypto_analyzer.data.sentiment_index_fetcher import fetch_fear_greed_index
+from crypto_analyzer.data.social_sentiment import fetch_reddit_sentiment
+from crypto_analyzer.utils.logging import get_logger
+from crypto_analyzer.utils.secrets import get_secret
+
+try:  # pragma: no cover - optional during tests
+    from crypto_analyzer.utils.config import CONFIG, AppConfig
+except ModuleNotFoundError:  # pragma: no cover - fallback when config is optional
+    CONFIG = None  # type: ignore[assignment]
+    AppConfig = Any  # type: ignore[misc, assignment]
+
+try:  # pragma: no cover - optional dependency on Python < 3.9
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover - fallback when zoneinfo missing
+    from backports.zoneinfo import ZoneInfo  # type: ignore[no-redef]
+
+
+LOGGER = get_logger(__name__)
+
+
+@dataclass(slots=True)
+class SchedulerConfig:
+    """Settings controlling job cadence and API parameters."""
+
+    binance_interval_minutes: int = 15
+    news_interval_minutes: int = 15
+    reddit_interval_minutes: int = 60
+    daily_run_time: time = time(hour=0, minute=33)
+    timezone: str | None = None
+    retry_delay_seconds: int = 60
+    max_retries: int = 1
+    reddit_subreddit: str | None = "bitcoin"
+    reddit_query: str | None = "BTC"
+    reddit_size: int = 200
+    cryptopanic_filter: str | None = None
+    cryptopanic_currencies: tuple[str, ...] = field(default_factory=lambda: ("BTC",))
+    cryptopanic_kind: str | None = None
+    cryptopanic_limit: int = 50
+    coinmetrics_asset: str = "btc"
+    glassnode_asset: str = "BTC"
+    binance_depth: int = 50
+    daily_lookback_days: int = 30
+    derivatives_initial_lookback_days: int = 3
+    derivatives_overlap_hours: int = 6
+    fear_greed_limit: int = 30
+
+
+class DataIngestionScheduler:
+    """Manage recurring data collection jobs using APScheduler."""
+
+    def __init__(
+        self,
+        scheduler: BaseScheduler | None = None,
+        *,
+        settings: SchedulerConfig | None = None,
+        app_config: AppConfig | None = None,
+    ) -> None:
+        self.settings = settings or SchedulerConfig()
+        cfg = app_config
+        if cfg is None:
+            if CONFIG is None:  # pragma: no cover - defensive
+                raise RuntimeError("Application configuration is unavailable")
+            cfg = CONFIG
+        self._config: AppConfig = cfg
+
+        tz_name = self.settings.timezone or getattr(self._config.core, "timezone", "UTC")
+        try:
+            timezone = ZoneInfo(tz_name)
+        except Exception:  # pragma: no cover - fallback to UTC when zone not found
+            timezone = ZoneInfo("UTC")
+        self.timezone = timezone
+
+        if scheduler is None:
+            scheduler = BackgroundScheduler(timezone=timezone)
+        else:
+            scheduler.configure(timezone=timezone)
+        self.scheduler: BaseScheduler = scheduler
+
+        self.logger = LOGGER
+        self.engine = ensure_schema(db_path=str(self._config.db_path))
+
+        sentiment_cfg = getattr(self._config, "sentiment", None)
+        token = get_secret("CRYPTOPANIC_TOKEN")
+        if not token and sentiment_cfg is not None:
+            token = getattr(sentiment_cfg, "sentiment_api_key", None)
+        self._cryptopanic_token: str | None = token if token else None
+
+        onchain_cfg = getattr(self._config, "onchain", None)
+        api_key = getattr(onchain_cfg, "glassnode_api_key", None) if onchain_cfg else None
+        if not api_key:
+            api_key = get_secret("GLASSNODE_API_KEY")
+        self._glassnode_api_key = api_key
+
+    # ------------------------------------------------------------------
+    # Job scheduling helpers
+    # ------------------------------------------------------------------
+
+    def configure_jobs(self) -> None:
+        """Register recurring jobs according to :class:`SchedulerConfig`."""
+
+        if self.settings.binance_interval_minutes > 0:
+            trigger = IntervalTrigger(minutes=self.settings.binance_interval_minutes, timezone=self.timezone)
+            self.scheduler.add_job(
+                self._wrap_job(self._run_binance_job, job_id="binance"),
+                trigger,
+                id="binance_job",
+                replace_existing=True,
+                max_instances=1,
+                kwargs={"attempt": 1},
+            )
+        else:
+            self.logger.info("Binance job disabled via configuration", extra={"job_id": "binance"})
+
+        if self.settings.news_interval_minutes > 0:
+            trigger = IntervalTrigger(minutes=self.settings.news_interval_minutes, timezone=self.timezone)
+            self.scheduler.add_job(
+                self._wrap_job(self._run_news_job, job_id="news"),
+                trigger,
+                id="news_job",
+                replace_existing=True,
+                max_instances=1,
+                kwargs={"attempt": 1},
+            )
+
+        if self.settings.reddit_interval_minutes > 0 and (
+            self.settings.reddit_subreddit or self.settings.reddit_query
+        ):
+            trigger = IntervalTrigger(minutes=self.settings.reddit_interval_minutes, timezone=self.timezone)
+            self.scheduler.add_job(
+                self._wrap_job(self._run_reddit_job, job_id="reddit"),
+                trigger,
+                id="reddit_job",
+                replace_existing=True,
+                max_instances=1,
+                kwargs={"attempt": 1},
+            )
+        else:
+            self.logger.info(
+                "Reddit job disabled or lacking parameters",
+                extra={"job_id": "reddit"},
+            )
+
+        daily_time = self.settings.daily_run_time
+        cron = CronTrigger(hour=daily_time.hour, minute=daily_time.minute, timezone=self.timezone)
+        self.scheduler.add_job(
+            self._wrap_job(self._run_daily_job, job_id="daily"),
+            cron,
+            id="daily_job",
+            replace_existing=True,
+            max_instances=1,
+            kwargs={"attempt": 1},
+        )
+
+    def start(self) -> None:
+        """Start the underlying APScheduler instance."""
+
+        self.logger.info("Starting data ingestion scheduler", extra={"timezone": str(self.timezone)})
+        self.scheduler.start()
+
+    def shutdown(self, *, wait: bool = True) -> None:
+        """Stop the scheduler and cancel scheduled retries."""
+
+        self.logger.info("Shutting down data ingestion scheduler")
+        self.scheduler.shutdown(wait=wait)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _wrap_job(self, func: Callable[[], None], *, job_id: str) -> Callable[[int], None]:
+        def runner(attempt: int = 1) -> None:
+            extra = {"job_id": job_id, "attempt": attempt}
+            self.logger.info("Starting job", extra=extra)
+            try:
+                func()
+            except Exception as exc:  # pragma: no cover - network failures
+                self.logger.error("Job execution failed", exc_info=exc, extra=extra)
+                if attempt > self.settings.max_retries:
+                    self.logger.error("Maximum retry attempts reached", extra=extra)
+                    return
+                run_time = datetime.now(tz=self.timezone) + timedelta(seconds=self.settings.retry_delay_seconds)
+                retry_id = f"{job_id}_retry_{attempt}"
+                retry_extra = {"job_id": job_id, "attempt": attempt + 1, "run_time": run_time.isoformat()}
+                self.logger.info("Scheduling retry", extra=retry_extra)
+                self.scheduler.add_job(
+                    runner,
+                    trigger="date",
+                    run_date=run_time,
+                    id=retry_id,
+                    replace_existing=True,
+                    kwargs={"attempt": attempt + 1},
+                )
+            else:
+                self.logger.info("Job completed", extra=extra)
+
+        return runner
+
+    # ------------------------------------------------------------------
+    # Job implementations
+    # ------------------------------------------------------------------
+
+    def _run_binance_job(self) -> None:
+        symbol = self._config.symbol
+        now = datetime.now(tz=UTC)
+        latest = latest_derivatives_timestamp(self.engine, symbol=symbol)
+        if latest is not None:
+            start = latest.tz_convert("UTC") - timedelta(hours=max(1, self.settings.derivatives_overlap_hours))
+        else:
+            start = pd.Timestamp(now - timedelta(days=max(1, self.settings.derivatives_initial_lookback_days)), tz="UTC")
+        if start > pd.Timestamp(now):
+            start = pd.Timestamp(now - timedelta(minutes=5), tz="UTC")
+        start_dt = start.to_pydatetime()
+
+        self.logger.info(
+            "Fetching Binance metrics",
+            extra={"job_id": "binance", "symbol": symbol, "start": start_dt.isoformat(), "end": now.isoformat()},
+        )
+
+        funding = fetch_binance_funding_rates(symbol, start=start_dt, end=now)
+        open_interest = fetch_binance_open_interest(symbol, start=start_dt, end=now)
+        derivatives_result = store_derivatives(funding, open_interest, engine=self.engine, symbol=symbol)
+
+        orderbook = fetch_binance_order_book(symbol, depth=self.settings.binance_depth)
+        orderbook_result = store_orderbook(orderbook, engine=self.engine, symbol=symbol)
+
+        self._log_store_result(
+            "binance",
+            {
+                "derivative_rows": derivatives_result.inserted,
+                "orderbook_rows": orderbook_result.inserted,
+            },
+        )
+
+    def _run_news_job(self) -> None:
+        if not self._cryptopanic_token:
+            self.logger.warning("CryptoPanic token missing; skipping news job", extra={"job_id": "news"})
+            return
+
+        currencies = [code for code in self.settings.cryptopanic_currencies if code]
+        limit = max(1, min(100, self.settings.cryptopanic_limit))
+        kwargs: dict[str, Any] = {
+            "limit": limit,
+            "currencies": currencies if currencies else None,
+            "filter": self.settings.cryptopanic_filter,
+            "kind": self.settings.cryptopanic_kind,
+        }
+        self.logger.info("Fetching CryptoPanic news", extra={"job_id": "news", "limit": kwargs["limit"]})
+        news_frame = fetch_cryptopanic_news(self._cryptopanic_token, **kwargs)
+        result = store_news(news_frame, engine=self.engine)
+        self._log_store_result("news", {"records": result.inserted})
+
+    def _run_reddit_job(self) -> None:
+        subreddit = self.settings.reddit_subreddit or ""
+        query = self.settings.reddit_query or ""
+        self.logger.info(
+            "Fetching Reddit sentiment",
+            extra={"job_id": "reddit", "subreddit": subreddit, "query": query},
+        )
+        size = max(20, min(500, self.settings.reddit_size))
+        sentiment = fetch_reddit_sentiment(
+            subreddit=subreddit or None,
+            query=query or None,
+            size=size,
+        )
+        result = store_reddit_sentiment(sentiment, engine=self.engine, subreddit=subreddit, query=query)
+        self._log_store_result("reddit", {"records": result.inserted})
+
+    def _run_daily_job(self) -> None:
+        now = datetime.now(tz=UTC)
+        asset_glassnode = self.settings.glassnode_asset
+        asset_coinmetrics = self.settings.coinmetrics_asset
+
+        if self._glassnode_api_key:
+            latest_glassnode = latest_glassnode_timestamp(self.engine, asset=asset_glassnode)
+            if latest_glassnode is not None:
+                start_glassnode = latest_glassnode.tz_convert("UTC") - timedelta(days=7)
+            else:
+                start_glassnode = pd.Timestamp(now - timedelta(days=self.settings.daily_lookback_days), tz="UTC")
+            start_glassnode = min(start_glassnode, pd.Timestamp(now))
+            self.logger.info(
+                "Fetching Glassnode active addresses",
+                extra={"job_id": "daily", "asset": asset_glassnode, "start": start_glassnode.isoformat(), "end": now.isoformat()},
+            )
+            glassnode = fetch_glassnode_active_addresses(
+                start=start_glassnode.to_pydatetime(),
+                end=now,
+                api_key=self._glassnode_api_key,
+                asset=asset_glassnode,
+            )
+            glassnode_result = store_glassnode_active_addresses(
+                glassnode, engine=self.engine, asset=asset_glassnode
+            )
+        else:
+            self.logger.warning(
+                "Glassnode API key missing; skipping active address download",
+                extra={"job_id": "daily"},
+            )
+            glassnode_result = StoreResult(0)
+
+        latest_coinmetrics = latest_coinmetrics_timestamp(self.engine, asset=asset_coinmetrics)
+        if latest_coinmetrics is not None:
+            start_coinmetrics = latest_coinmetrics.tz_convert("UTC") - timedelta(days=7)
+        else:
+            start_coinmetrics = pd.Timestamp(now - timedelta(days=self.settings.daily_lookback_days), tz="UTC")
+        start_coinmetrics = min(start_coinmetrics, pd.Timestamp(now))
+        self.logger.info(
+            "Fetching CoinMetrics flows",
+            extra={"job_id": "daily", "asset": asset_coinmetrics, "start": start_coinmetrics.isoformat(), "end": now.isoformat()},
+        )
+        coinmetrics = fetch_coinmetrics_exchange_flows(
+            asset=asset_coinmetrics,
+            start=start_coinmetrics,
+            end=pd.Timestamp(now, tz="UTC"),
+        )
+        coinmetrics_result = store_coinmetrics_flows(
+            coinmetrics, engine=self.engine, asset=asset_coinmetrics
+        )
+
+        self.logger.info(
+            "Fetching Fear & Greed index",
+            extra={"job_id": "daily", "limit": self.settings.fear_greed_limit},
+        )
+        fear_greed = fetch_fear_greed_index(limit=self.settings.fear_greed_limit)
+        latest_seen = latest_fear_greed_timestamp(self.engine)
+        if latest_seen is not None and not fear_greed.empty:
+            fear_greed = fear_greed.loc[fear_greed["timestamp"] > latest_seen]
+        fear_greed_result = store_fear_greed_index(fear_greed, engine=self.engine)
+
+        self._log_store_result(
+            "daily",
+            {
+                "glassnode_rows": glassnode_result.inserted,
+                "coinmetrics_rows": coinmetrics_result.inserted,
+                "fear_greed_rows": fear_greed_result.inserted,
+            },
+        )
+
+    def _log_store_result(self, job_id: str, metrics: dict[str, Any]) -> None:
+        payload = {"job_id": job_id}
+        payload.update(metrics)
+        self.logger.info("Persisted fetched data", extra=payload)
+
+
+__all__ = ["DataIngestionScheduler", "SchedulerConfig"]

--- a/tests/test_ingestion_store.py
+++ b/tests/test_ingestion_store.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pandas as pd
+from sqlalchemy import create_engine, select
+
+from crypto_analyzer.data import ingestion_store
+
+
+def _setup_engine():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    ingestion_store.ensure_schema(engine=engine)
+    return engine
+
+
+def test_store_derivatives_upserts_and_tracks_latest_timestamp() -> None:
+    engine = _setup_engine()
+    funding = pd.DataFrame(
+        {
+            "timestamp": [
+                pd.Timestamp("2024-01-01T00:00:00Z"),
+                pd.Timestamp("2024-01-01T08:00:00Z"),
+            ],
+            "funding_rate": [0.01, 0.02],
+        }
+    )
+    open_interest = pd.DataFrame(
+        {
+            "timestamp": [
+                pd.Timestamp("2024-01-01T08:00:00Z"),
+                pd.Timestamp("2024-01-01T16:00:00Z"),
+            ],
+            "open_interest": [1_000.0, 1_100.0],
+        }
+    )
+
+    result = ingestion_store.store_derivatives(funding, open_interest, engine=engine, symbol="BTCUSDT")
+    assert result.inserted == 3
+
+    latest = ingestion_store.latest_derivatives_timestamp(engine, symbol="BTCUSDT")
+    assert latest is not None
+    assert latest.tz_convert("UTC").to_pydatetime() == datetime(2024, 1, 1, 16, tzinfo=timezone.utc)
+
+    updated_funding = pd.DataFrame(
+        {
+            "timestamp": [pd.Timestamp("2024-01-01T08:00:00Z")],
+            "funding_rate": [0.05],
+        }
+    )
+    ingestion_store.store_derivatives(updated_funding, pd.DataFrame(), engine=engine, symbol="BTCUSDT")
+
+    query = select(ingestion_store.DERIVATIVES_TABLE.c.funding_rate).where(
+        ingestion_store.DERIVATIVES_TABLE.c.timestamp == pd.Timestamp("2024-01-01T08:00:00Z"),
+        ingestion_store.DERIVATIVES_TABLE.c.symbol == "BTCUSDT",
+    )
+    with engine.connect() as conn:
+        stored_value = conn.execute(query).scalar_one()
+    assert stored_value == 0.05
+
+
+def test_store_news_deduplicates_by_url() -> None:
+    engine = _setup_engine()
+    news = pd.DataFrame(
+        {
+            "timestamp": [pd.Timestamp("2024-01-01T12:00:00Z")],
+            "title": ["Headline"],
+            "url": ["https://example.com/news"],
+            "source": ["Example"],
+            "sentiment": [1.0],
+            "positive_votes": [5],
+            "negative_votes": [0],
+            "tags": ["bullish"],
+            "currencies": ["BTC"],
+        }
+    )
+    first = ingestion_store.store_news(news, engine=engine)
+    assert first.inserted == 1
+
+    updated_news = news.assign(sentiment=[0.5])
+    second = ingestion_store.store_news(updated_news, engine=engine)
+    assert second.inserted == 1
+
+    query = select(ingestion_store.NEWS_TABLE.c.sentiment).where(
+        ingestion_store.NEWS_TABLE.c.url == "https://example.com/news"
+    )
+    with engine.connect() as conn:
+        sentiment_value = conn.execute(query).scalar_one()
+    assert sentiment_value == 0.5


### PR DESCRIPTION
## Summary
- add an APScheduler-powered data ingestion scheduler with retry handling
- introduce a persistence module and CLI entry point for running scheduled jobs
- extend dependencies and add tests for the new ingestion storage logic

## Testing
- pytest tests/test_ingestion_store.py

------
https://chatgpt.com/codex/tasks/task_e_68f767ef806083278a38429cae550971