### PR TITLE
Add Whale Alert transaction fetcher and persistence

### DIFF
--- a/api/onchain.py
+++ b/api/onchain.py
@@ -8,6 +8,7 @@ import pandas as pd
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
+from crypto_analyzer.data.onchain_fetcher import fetch_whale_alert_transactions
 from crypto_analyzer.utils.config import CONFIG, OnChainSettings
 from crypto_analyzer.utils.timeframes import interval_to_pandas_freq
 
@@ -163,31 +164,23 @@ def fetch_usdt_events(start: datetime, end: datetime, api_key: str | None = None
     key = api_key or SETTINGS.whale_api_key
     if not key:
         raise ValueError("api_key required for Whale Alert")
+
     sess = _session()
-    params = {
-        "start": int(start.timestamp()),
-        "end": int(end.timestamp()),
-        "currency": "usdt",
-        "api_key": key,
-    }
-    resp = _get_with_retry(
-        sess,
-        "https://api.whale-alert.io/v1/transactions",
-        params=params,
+    tx_frame = fetch_whale_alert_transactions(
+        api_key=key,
+        start=start,
+        end=end,
+        currency="USDT",
+        session=sess,
         timeout=SETTINGS.request_timeout,
         retries=SETTINGS.request_retries,
+        backoff=1.0,
     )
-    data = resp.json().get("transactions", [])
-    records: list[dict[str, float]] = []
-    for tx in data:
-        ts = pd.to_datetime(tx.get("timestamp"), unit="s", utc=True)
-        usd = float(tx.get("amount_usd", 0.0))
-        records.append({"timestamp": ts, "usd": usd})
-    df = pd.DataFrame(records)
-    if not df.empty:
-        df = df.set_index("timestamp").sort_index()
+
+    if not tx_frame.empty:
+        df = tx_frame.copy()
         df["onch_usdt_count"] = 1
-        df.rename(columns={"usd": "onch_usd"}, inplace=True)
+        df["onch_usd"] = df["amount_usd"].fillna(0.0)
         df = df.resample(CANDLE_FREQ, label="right", closed="right").agg(
             {"onch_usdt_count": "sum", "onch_usd": "sum"}
         )

--- a/src/crypto_analyzer/data/db.py
+++ b/src/crypto_analyzer/data/db.py
@@ -59,6 +59,21 @@ TABLE_DEFINITIONS: dict[str, str] = {
             PRIMARY KEY (timestamp)
         )
     """,
+    "whale_transactions": """
+        CREATE TABLE IF NOT EXISTS whale_transactions (
+            timestamp TIMESTAMPTZ NOT NULL,
+            transaction_hash TEXT NOT NULL,
+            currency TEXT NOT NULL,
+            amount NUMERIC(30, 10),
+            amount_usd NUMERIC(30, 10),
+            from_address TEXT,
+            from_owner TEXT,
+            to_address TEXT,
+            to_owner TEXT,
+            blockchain TEXT,
+            PRIMARY KEY (timestamp, transaction_hash)
+        )
+    """,
     "sentiment_index": """
         CREATE TABLE IF NOT EXISTS sentiment_index (
             timestamp TIMESTAMPTZ NOT NULL,
@@ -101,6 +116,7 @@ TABLE_DEFINITIONS: dict[str, str] = {
 HYPERTABLE_STATEMENTS: tuple[str, ...] = (
     "SELECT create_hypertable('market_data', 'timestamp', if_not_exists => TRUE)",
     "SELECT create_hypertable('onchain_metrics', 'timestamp', if_not_exists => TRUE)",
+    "SELECT create_hypertable('whale_transactions', 'timestamp', if_not_exists => TRUE)",
     "SELECT create_hypertable('sentiment_index', 'timestamp', if_not_exists => TRUE)",
     "SELECT create_hypertable('social_sentiment', 'timestamp', if_not_exists => TRUE)",
     "SELECT create_hypertable('derivatives_signals', 'timestamp', if_not_exists => TRUE)",

--- a/src/crypto_analyzer/data/onchain_fetcher.py
+++ b/src/crypto_analyzer/data/onchain_fetcher.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
+import threading
+import time
 from typing import Any
 
 import pandas as pd
@@ -19,6 +21,15 @@ GLASSNODE_EXCHANGE_OUTFLOW_ENDPOINT = "https://api.glassnode.com/v1/metrics/exch
 COINMETRICS_ASSET_METRICS_ENDPOINT = (
     "https://community-api.coinmetrics.io/v4/timeseries/asset-metrics"
 )
+WHALE_ALERT_TRANSACTIONS_ENDPOINT = "https://api.whale-alert.io/v1/transactions"
+
+_DEFAULT_WHALE_TIMEOUT = 15.0
+_DEFAULT_WHALE_RETRIES = 5
+_DEFAULT_WHALE_BACKOFF = 1.0
+_DEFAULT_WHALE_RATE_LIMIT_SECONDS = 1.0
+
+_WHALE_RATE_LOCK = threading.Lock()
+_WHALE_LAST_CALL: float | None = None
 
 _COINMETRICS_COLUMN_MAP = {
     "ExchgNetFlow": "onch_exchange_net_flow",
@@ -41,6 +52,25 @@ def _ensure_utc_timestamp(value: Any) -> pd.Timestamp:
     if ts.tzinfo is None:
         ts = ts.tz_localize("UTC")
     return ts.tz_convert("UTC")
+
+
+def _respect_whale_rate_limit(
+    min_interval: float, sleep: Callable[[float], None]
+) -> None:
+    """Ensure at least ``min_interval`` seconds elapsed since the previous call."""
+
+    if min_interval <= 0:
+        return
+
+    global _WHALE_LAST_CALL
+    with _WHALE_RATE_LOCK:
+        now = time.monotonic()
+        if _WHALE_LAST_CALL is not None:
+            wait = (_WHALE_LAST_CALL + min_interval) - now
+            if wait > 0:
+                sleep(wait)
+                now = time.monotonic()
+        _WHALE_LAST_CALL = now
 
 
 def fetch_mempool_stats(*, session: requests.Session | None = None) -> pd.DataFrame:
@@ -275,4 +305,213 @@ __all__ = [
     "fetch_mempool_stats",
     "fetch_exchange_flows",
     "fetch_coinmetrics_exchange_flows",
+    "fetch_whale_alert_transactions",
+    "WHALE_ALERT_TRANSACTIONS_ENDPOINT",
 ]
+
+
+def fetch_whale_alert_transactions(
+    *,
+    api_key: str | None,
+    start: pd.Timestamp | str | None = None,
+    end: pd.Timestamp | str | None = None,
+    lookback_hours: float | None = None,
+    currency: str | None = None,
+    min_value_usd: float | None = None,
+    limit: int | None = None,
+    session: requests.Session | None = None,
+    timeout: float = _DEFAULT_WHALE_TIMEOUT,
+    retries: int = _DEFAULT_WHALE_RETRIES,
+    backoff: float = _DEFAULT_WHALE_BACKOFF,
+    rate_limit_seconds: float = _DEFAULT_WHALE_RATE_LIMIT_SECONDS,
+    _sleep: Callable[[float], None] = time.sleep,
+) -> pd.DataFrame:
+    """Retrieve large transfers from the Whale Alert REST API.
+
+    Parameters
+    ----------
+    api_key:
+        Whale Alert API key.  The function raises :class:`ValueError` when the
+        key is missing or an empty string.
+    start, end:
+        Optional timestamps bounding the requested interval.  When omitted,
+        ``lookback_hours`` must be provided.
+    lookback_hours:
+        Convenience shorthand for fetching the most recent *N* hours of data.
+    currency:
+        Optional asset ticker filter understood by Whale Alert, e.g. ``"USDT"``.
+    min_value_usd:
+        Optional minimum USD value filter.
+    limit:
+        Optional pagination limit (defaults to the API default when omitted).
+    session:
+        Optional :class:`requests.Session` reused across calls.
+    timeout:
+        HTTP timeout per request in seconds.
+    retries, backoff:
+        Retry configuration for transient errors using exponential backoff.
+    rate_limit_seconds:
+        Minimum number of seconds to wait between consecutive API calls.
+    _sleep:
+        Internal testing hook to override :func:`time.sleep`.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Data frame indexed by the transaction timestamp with Whale Alert
+        metadata.  Empty results produce an empty frame with the expected
+        columns.
+    """
+
+    key = (api_key or "").strip()
+    if not key:
+        raise ValueError("Whale Alert API key required")
+
+    if lookback_hours is not None:
+        if lookback_hours <= 0:
+            raise ValueError("lookback_hours must be positive when provided")
+        end_ts = _ensure_utc_timestamp(end) if end is not None else pd.Timestamp.utcnow()
+        start_ts = end_ts - pd.Timedelta(hours=lookback_hours)
+    else:
+        if start is None or end is None:
+            raise ValueError("Both start and end must be provided when lookback_hours is omitted")
+        start_ts = _ensure_utc_timestamp(start)
+        end_ts = _ensure_utc_timestamp(end)
+
+    if start_ts >= end_ts:
+        raise ValueError("start must be earlier than end for Whale Alert queries")
+
+    sess = session or requests.Session()
+
+    params: dict[str, Any] = {
+        "start": int(start_ts.timestamp()),
+        "end": int(end_ts.timestamp()),
+        "api_key": key,
+    }
+    if currency:
+        params["currency"] = currency.lower()
+    if min_value_usd is not None:
+        params["min_value"] = float(min_value_usd)
+    if limit is not None:
+        params["limit"] = int(limit)
+
+    delay = max(backoff, 0.0) or 1.0
+    last_error: Exception | None = None
+
+    for attempt in range(max(1, retries)):
+        try:
+            _respect_whale_rate_limit(rate_limit_seconds, _sleep)
+            response = sess.get(
+                WHALE_ALERT_TRANSACTIONS_ENDPOINT,
+                params=params,
+                timeout=timeout,
+            )
+        except requests.RequestException as exc:
+            last_error = exc
+        else:
+            if response.status_code == 429:
+                retry_after = response.headers.get("Retry-After")
+                try:
+                    wait_seconds = float(retry_after) if retry_after is not None else delay
+                except ValueError:
+                    wait_seconds = delay
+                logger.warning(
+                    "Whale Alert rate limit hit; retrying", extra={"wait_seconds": wait_seconds}
+                )
+                _sleep(max(wait_seconds, delay))
+                delay *= 2
+                last_error = requests.HTTPError("HTTP 429: Too Many Requests")
+                continue
+
+            if response.status_code in (401, 403):
+                raise ValueError("Whale Alert API key required")
+
+            try:
+                response.raise_for_status()
+            except requests.HTTPError as exc:
+                if 500 <= response.status_code < 600:
+                    last_error = exc
+                else:
+                    raise
+            else:
+                try:
+                    payload = response.json() or {}
+                except ValueError as exc:  # pragma: no cover - defensive guard
+                    raise ValueError("Invalid JSON payload from Whale Alert") from exc
+
+                transactions = payload.get("transactions", [])
+                records: list[dict[str, Any]] = []
+                for tx in transactions:
+                    timestamp_value = tx.get("timestamp")
+                    if timestamp_value is None:
+                        continue
+                    ts = pd.to_datetime(timestamp_value, unit="s", utc=True, errors="coerce")
+                    if pd.isna(ts):
+                        continue
+
+                    from_info = tx.get("from") if isinstance(tx.get("from"), Mapping) else {}
+                    to_info = tx.get("to") if isinstance(tx.get("to"), Mapping) else {}
+
+                    amount_native = tx.get("amount")
+                    amount_usd = tx.get("amount_usd")
+                    try:
+                        amount_native_f = float(amount_native) if amount_native is not None else None
+                    except (TypeError, ValueError):
+                        amount_native_f = None
+                    try:
+                        amount_usd_f = float(amount_usd) if amount_usd is not None else None
+                    except (TypeError, ValueError):
+                        amount_usd_f = None
+
+                    currency_value = tx.get("symbol") or tx.get("currency")
+                    currency_text = str(currency_value).upper() if currency_value else None
+
+                    record = {
+                        "timestamp": ts,
+                        "transaction_hash": tx.get("hash") or tx.get("transaction_hash"),
+                        "blockchain": tx.get("blockchain"),
+                        "currency": currency_text,
+                        "amount": amount_native_f,
+                        "amount_usd": amount_usd_f,
+                        "from_address": from_info.get("address") if isinstance(from_info, Mapping) else None,
+                        "from_owner": from_info.get("owner") if isinstance(from_info, Mapping) else None,
+                        "to_address": to_info.get("address") if isinstance(to_info, Mapping) else None,
+                        "to_owner": to_info.get("owner") if isinstance(to_info, Mapping) else None,
+                    }
+                    records.append(record)
+
+                if not records:
+                    columns = [
+                        "transaction_hash",
+                        "blockchain",
+                        "currency",
+                        "amount",
+                        "amount_usd",
+                        "from_address",
+                        "from_owner",
+                        "to_address",
+                        "to_owner",
+                    ]
+                    index = pd.DatetimeIndex([], name="timestamp", tz="UTC")
+                    return pd.DataFrame(columns=columns, index=index)
+
+                frame = pd.DataFrame.from_records(records)
+                frame = frame.dropna(subset=["timestamp"]).copy()
+                frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True)
+                frame = frame.set_index("timestamp").sort_index()
+
+                logger.info(
+                    "Fetched Whale Alert transactions",
+                    extra={"rows": len(frame), "currency": currency},
+                )
+                return frame
+
+        if attempt == retries - 1:
+            if last_error is not None:
+                raise last_error
+            raise RuntimeError("Failed to fetch Whale Alert transactions")
+
+        _sleep(delay)
+        delay *= 2
+
+    raise RuntimeError("Exhausted retries fetching Whale Alert transactions")

--- a/src/crypto_analyzer/data/timescale_writer.py
+++ b/src/crypto_analyzer/data/timescale_writer.py
@@ -437,6 +437,85 @@ def save_onchain_metrics(
         return written
 
 
+def save_whale_transactions(
+    data: Any,
+    *,
+    connection: PGConnection | None = None,
+    batch_size: int = 200,
+    **connect_kwargs: Any,
+) -> int:
+    """Persist Whale Alert transactions into the ``whale_transactions`` table."""
+
+    records = _ensure_records(data)
+    if not records:
+        LOGGER.debug("No whale transactions supplied – skipping insert")
+        return 0
+
+    payload: list[tuple[Any, ...]] = []
+    for record in records:
+        tx_hash_value = record.get("transaction_hash") or record.get("hash")
+        currency_value = record.get("currency") or record.get("symbol")
+        blockchain = record.get("blockchain")
+
+        from_info = record.get("from") if isinstance(record.get("from"), Mapping) else None
+        to_info = record.get("to") if isinstance(record.get("to"), Mapping) else None
+
+        from_address = record.get("from_address")
+        if from_address is None and isinstance(from_info, Mapping):
+            from_address = from_info.get("address")
+        to_address = record.get("to_address")
+        if to_address is None and isinstance(to_info, Mapping):
+            to_address = to_info.get("address")
+
+        from_owner = record.get("from_owner")
+        if from_owner is None and isinstance(from_info, Mapping):
+            from_owner = from_info.get("owner")
+        to_owner = record.get("to_owner")
+        if to_owner is None and isinstance(to_info, Mapping):
+            to_owner = to_info.get("owner")
+
+        ts = _ensure_timestamp(record.get("timestamp"))
+        tx_hash = _require_string(tx_hash_value, field="transaction_hash")
+        currency = _require_string(currency_value, field="currency").upper()
+        amount = _coerce_float(record.get("amount"), field="amount")
+        amount_usd = _coerce_float(record.get("amount_usd"), field="amount_usd", required=True)
+        payload.append(
+            (
+                ts,
+                tx_hash,
+                currency,
+                amount,
+                amount_usd,
+                _optional_string(from_address),
+                _optional_string(from_owner),
+                _optional_string(to_address),
+                _optional_string(to_owner),
+                _optional_string(blockchain),
+            )
+        )
+
+    sql = (
+        "INSERT INTO whale_transactions "
+        "(timestamp, transaction_hash, currency, amount, amount_usd, from_address, "
+        "from_owner, to_address, to_owner, blockchain) "
+        "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
+        "ON CONFLICT (timestamp, transaction_hash) DO UPDATE SET "
+        "currency = EXCLUDED.currency, "
+        "amount = EXCLUDED.amount, "
+        "amount_usd = EXCLUDED.amount_usd, "
+        "from_address = EXCLUDED.from_address, "
+        "from_owner = EXCLUDED.from_owner, "
+        "to_address = EXCLUDED.to_address, "
+        "to_owner = EXCLUDED.to_owner, "
+        "blockchain = EXCLUDED.blockchain"
+    )
+
+    with _managed_connection(connection, connect_kwargs) as conn:
+        written = _execute_upsert(conn, sql, payload, page_size=batch_size)
+        LOGGER.info("Stored whale transaction rows", extra={"rows": written})
+        return written
+
+
 def save_news(
     data: Any,
     *,
@@ -482,5 +561,6 @@ __all__ = [
     "save_sentiment_index",
     "save_onchain_metrics",
     "save_news",
+    "save_whale_transactions",
 ]
 

--- a/tests/test_onchain_fetcher.py
+++ b/tests/test_onchain_fetcher.py
@@ -16,6 +16,8 @@ from crypto_analyzer.data.onchain_fetcher import (
     fetch_exchange_flows,
     fetch_coinmetrics_exchange_flows,
     fetch_mempool_stats,
+    fetch_whale_alert_transactions,
+    WHALE_ALERT_TRANSACTIONS_ENDPOINT,
 )
 
 
@@ -36,15 +38,23 @@ def freeze_timestamp(monkeypatch: pytest.MonkeyPatch) -> None:
 class DummyResponse:
     """Simple stand-in for ``requests.Response``."""
 
-    def __init__(self, payload: Any) -> None:
+    def __init__(
+        self,
+        payload: Any,
+        *,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+    ) -> None:
         self._payload = payload
-        self.status_code = 200
+        self.status_code = status_code
+        self.headers = headers or {}
 
     def json(self) -> Any:
         return self._payload
 
-    def raise_for_status(self) -> None:  # pragma: no cover - nothing to do on success
-        return None
+    def raise_for_status(self) -> None:  # pragma: no cover - exercised in tests
+        if 400 <= self.status_code < 600:
+            raise requests.HTTPError(f"HTTP {self.status_code}", response=self)
 
 
 class QueueSession:
@@ -59,6 +69,12 @@ class QueueSession:
         if not self._responses:
             raise RuntimeError("No more responses queued")
         return self._responses.pop(0)
+
+
+def _reset_whale_limiter() -> None:
+    from crypto_analyzer.data import onchain_fetcher as module
+
+    module._WHALE_LAST_CALL = None
 
 
 def test_fetch_mempool_stats_returns_expected_frame() -> None:
@@ -226,3 +242,110 @@ def test_fetch_coinmetrics_exchange_flows_handles_errors() -> None:
 
     assert frame.empty
     assert frame.index.tz is not None
+
+
+def test_fetch_whale_alert_transactions_parses_payload() -> None:
+    _reset_whale_limiter()
+
+    payload = {
+        "transactions": [
+            {
+                "timestamp": 1_700_000_000,
+                "hash": "abc123",
+                "symbol": "usdt",
+                "blockchain": "tron",
+                "amount": "123.45",
+                "amount_usd": "6789.01",
+                "from": {"address": "addr1", "owner": "Exchange A"},
+                "to": {"address": "addr2", "owner": "Wallet B"},
+            }
+        ]
+    }
+    session = QueueSession([DummyResponse(payload)])
+
+    frame = fetch_whale_alert_transactions(
+        api_key="secret",
+        start="2024-01-01T00:00:00Z",
+        end="2024-01-01T06:00:00Z",
+        currency="USDT",
+        session=session,
+        _sleep=lambda *_: None,
+    )
+
+    assert not frame.empty
+    assert frame.index.name == "timestamp"
+    assert frame.index.tz is not None
+    row = frame.iloc[0]
+    assert row["amount_usd"] == pytest.approx(6789.01)
+    assert row["currency"] == "USDT"
+    assert row["from_owner"] == "Exchange A"
+    assert row["to_owner"] == "Wallet B"
+
+    assert session.calls[0][0] == WHALE_ALERT_TRANSACTIONS_ENDPOINT
+    params = session.calls[0][1]["params"]
+    assert params["currency"] == "usdt"
+    assert params["api_key"] == "secret"
+
+
+def test_fetch_whale_alert_transactions_handles_empty() -> None:
+    _reset_whale_limiter()
+    session = QueueSession([DummyResponse({"transactions": []})])
+
+    frame = fetch_whale_alert_transactions(
+        api_key="secret",
+        start="2024-01-01T00:00:00Z",
+        end="2024-01-01T01:00:00Z",
+        session=session,
+        _sleep=lambda *_: None,
+    )
+
+    assert frame.empty
+    assert frame.index.name == "timestamp"
+    assert frame.index.tz is not None
+    assert set(frame.columns) == {
+        "transaction_hash",
+        "blockchain",
+        "currency",
+        "amount",
+        "amount_usd",
+        "from_address",
+        "from_owner",
+        "to_address",
+        "to_owner",
+    }
+
+
+def test_fetch_whale_alert_transactions_requires_api_key() -> None:
+    _reset_whale_limiter()
+    with pytest.raises(ValueError, match="Whale Alert API key required"):
+        fetch_whale_alert_transactions(
+            api_key=" ",
+            start="2024-01-01T00:00:00Z",
+            end="2024-01-01T02:00:00Z",
+            session=QueueSession([]),
+        )
+
+
+def test_fetch_whale_alert_transactions_validates_range() -> None:
+    _reset_whale_limiter()
+    with pytest.raises(ValueError, match="start must be earlier than end"):
+        fetch_whale_alert_transactions(
+            api_key="secret",
+            start="2024-01-02T00:00:00Z",
+            end="2024-01-01T00:00:00Z",
+            session=QueueSession([]),
+        )
+
+
+def test_fetch_whale_alert_transactions_raises_on_invalid_key() -> None:
+    _reset_whale_limiter()
+    session = QueueSession([DummyResponse({"error": "Invalid API key"}, status_code=401)])
+
+    with pytest.raises(ValueError, match="Whale Alert API key required"):
+        fetch_whale_alert_transactions(
+            api_key="bad",
+            start="2024-01-01T00:00:00Z",
+            end="2024-01-01T01:00:00Z",
+            session=session,
+            _sleep=lambda *_: None,
+        )

--- a/tests/test_timescale_writer.py
+++ b/tests/test_timescale_writer.py
@@ -129,3 +129,65 @@ def test_save_news_strips_optional_fields(mock_connection: MagicMock, monkeypatc
     assert row[2] is None  # URL stripped to None
     assert row[3] == "Coindesk"
 
+
+def test_save_whale_transactions_upserts(mock_connection: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_execute_batch(cursor, sql, params, page_size=None):  # type: ignore[no-untyped-def]
+        captured["sql"] = sql
+        captured["params"] = params
+        captured["page_size"] = page_size
+
+    monkeypatch.setattr(writer, "execute_batch", fake_execute_batch)
+
+    payload = [
+        {
+            "timestamp": "2024-01-01T00:00:00Z",
+            "transaction_hash": "abc123",
+            "currency": "usdt",
+            "amount": "123.45",
+            "amount_usd": "6789.01",
+            "from_owner": "Exchange A",
+            "to_owner": "Wallet B",
+            "blockchain": "tron",
+        }
+    ]
+
+    rows = writer.save_whale_transactions(payload, connection=mock_connection)
+
+    assert rows == 1
+    assert "INSERT INTO whale_transactions" in captured["sql"]
+    params = captured["params"]
+    assert isinstance(params, list)
+    row = params[0]
+    assert row[1] == "abc123"
+    assert row[2] == "USDT"
+    assert row[3] == pytest.approx(123.45)
+    assert row[4] == pytest.approx(6789.01)
+    assert row[6] == "Exchange A"
+    assert row[8] == "Wallet B"
+    assert captured["page_size"] == 200
+
+    mock_connection.cursor.assert_called_once()
+    mock_connection.commit.assert_called_once()
+    mock_connection.rollback.assert_not_called()
+
+
+def test_save_whale_transactions_validates_required_fields(
+    mock_connection: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(writer, "execute_batch", MagicMock())
+
+    payload = [
+        {
+            "timestamp": "2024-01-01T00:00:00Z",
+            "currency": "usdt",
+            "amount_usd": "6789.01",
+        }
+    ]
+
+    with pytest.raises(ValueError):
+        writer.save_whale_transactions(payload, connection=mock_connection)
+
+    writer.execute_batch.assert_not_called()  # type: ignore[attr-defined]
+


### PR DESCRIPTION
## Summary
- add a Whale Alert transaction fetcher with rate limiting, retry logic, and input validation
- persist Whale Alert data via a new `whale_transactions` TimescaleDB hypertable and writer helper
- refactor the cached USDT event loader to reuse the new fetcher and cover the behaviour with unit tests

## Testing
- pytest tests/test_onchain_fetcher.py tests/test_timescale_writer.py

------
https://chatgpt.com/codex/tasks/task_e_68f793b22f10832781453ec5b4cca680