### PR TITLE
Add Binance basis retrieval and storage

### DIFF
--- a/src/crypto_analyzer/data/data_collector.py
+++ b/src/crypto_analyzer/data/data_collector.py
@@ -37,6 +37,8 @@ GLASSNODE_ENDPOINT = "https://api.glassnode.com/v1/metrics/addresses/active_coun
 BINANCE_FUNDING_ENDPOINT = "https://fapi.binance.com/fapi/v1/fundingRate"
 BINANCE_ORDERBOOK_ENDPOINT = "https://fapi.binance.com/fapi/v1/depth"
 BINANCE_OPEN_INTEREST_ENDPOINT = "https://fapi.binance.com/futures/data/openInterestHist"
+BINANCE_PREMIUM_INDEX_ENDPOINT = "https://fapi.binance.com/fapi/v1/premiumIndex"
+BINANCE_SPOT_TICKER_ENDPOINT = "https://api.binance.com/api/v3/ticker/price"
 
 
 @dataclass(frozen=True)
@@ -353,6 +355,93 @@ def fetch_binance_open_interest(
     return frame.loc[:, ["timestamp", "open_interest"]].reset_index(drop=True)
 
 
+def fetch_binance_basis(
+    symbol: str,
+    *,
+    session: requests.Session | None = None,
+    settings: _HTTPSettings | None = None,
+) -> pd.DataFrame:
+    """Compute the futures basis in basis points for ``symbol``.
+
+    The function requests the perpetual futures mark price from Binance's
+    ``/premiumIndex`` endpoint and compares it with the spot ticker price from
+    the main exchange REST API.  The resulting basis is expressed in basis
+    points and aligned to the timestamp reported by the futures endpoint.
+
+    Parameters
+    ----------
+    symbol:
+        Trading pair identifier understood by Binance, e.g. ``"BTCUSDT"``.
+    session:
+        Optional :class:`requests.Session` reused across invocations.
+    settings:
+        Optional :class:`_HTTPSettings` overriding timeout defaults.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Frame with columns ``timestamp``, ``basis`` (basis points),
+        ``basis_bp``, ``futures_price`` and ``spot_price``.  When the exchange
+        returns incomplete data an empty frame is produced.
+    """
+
+    if not symbol or not isinstance(symbol, str):
+        raise ValueError("Symbol must be provided when fetching Binance basis")
+
+    cfg = settings or _HTTPSettings()
+    sess = session or requests.Session()
+
+    params = {"symbol": symbol}
+    response = sess.get(BINANCE_PREMIUM_INDEX_ENDPOINT, params=params, timeout=cfg.timeout)
+    response.raise_for_status()
+    payload = response.json() or {}
+
+    mark_raw = payload.get("markPrice")
+    try:
+        mark_price = float(mark_raw)
+    except (TypeError, ValueError):
+        mark_price = float("nan")
+
+    time_raw = payload.get("time") or payload.get("closeTime") or payload.get("updateTime")
+    if time_raw is not None:
+        try:
+            timestamp = pd.to_datetime(int(time_raw), unit="ms", utc=True)
+        except (TypeError, ValueError):
+            timestamp = pd.Timestamp.now(tz="UTC")
+    else:
+        timestamp = pd.Timestamp.now(tz="UTC")
+
+    spot_response = sess.get(BINANCE_SPOT_TICKER_ENDPOINT, params=params, timeout=cfg.timeout)
+    spot_response.raise_for_status()
+    spot_payload = spot_response.json() or {}
+
+    spot_raw = spot_payload.get("price")
+    try:
+        spot_price = float(spot_raw)
+    except (TypeError, ValueError):
+        spot_price = float("nan")
+
+    if not pd.notna(mark_price) or not pd.notna(spot_price) or spot_price == 0:
+        logger.warning(
+            "Unable to compute Binance basis due to missing price data",
+            extra={"symbol": symbol, "mark_price": mark_raw, "spot_price": spot_raw},
+        )
+        return pd.DataFrame(columns=["timestamp", "basis", "basis_bp", "futures_price", "spot_price"])
+
+    basis_bp = (mark_price - spot_price) / spot_price * 10_000.0
+
+    frame = pd.DataFrame(
+        {
+            "timestamp": [timestamp],
+            "basis": [basis_bp],
+            "basis_bp": [basis_bp],
+            "futures_price": [mark_price],
+            "spot_price": [spot_price],
+        }
+    )
+    return frame
+
+
 def _merge_daily_features(base: pd.DataFrame, daily_frames: Iterable[pd.DataFrame]) -> pd.DataFrame:
     """Merge daily features into the base OHLCV frame."""
 
@@ -495,6 +584,7 @@ __all__ = [
     "fetch_binance_funding_rates",
     "fetch_binance_order_book",
     "fetch_binance_open_interest",
+    "fetch_binance_basis",
     "fetch_exchange_flows",
     "fetch_mempool_stats",
     "load_enriched_market_data",

--- a/src/crypto_analyzer/data/ingestion_store.py
+++ b/src/crypto_analyzer/data/ingestion_store.py
@@ -174,7 +174,14 @@ def _prepare_records(frame: pd.DataFrame, *, extra: dict[str, object] | None = N
     return records
 
 
-def _upsert(table: Table, records: Iterable[dict[str, object]], engine: Engine, conflict_cols: tuple[str, ...]) -> int:
+def _upsert(
+    table: Table,
+    records: Iterable[dict[str, object]],
+    engine: Engine,
+    conflict_cols: tuple[str, ...],
+    *,
+    update_columns: Iterable[str] | None = None,
+) -> int:
     payload = list(records)
     if not payload:
         return 0
@@ -182,10 +189,12 @@ def _upsert(table: Table, records: Iterable[dict[str, object]], engine: Engine, 
     dialect = engine.dialect.name
 
     def _build_update_cols(insert_stmt):
+        allowed = set(update_columns) if update_columns is not None else None
         return {
             col.name: getattr(insert_stmt.excluded, col.name)
             for col in table.c
             if col.name not in conflict_cols and not col.primary_key
+            and (allowed is None or col.name in allowed)
         }
 
     if dialect == "postgresql":
@@ -283,7 +292,39 @@ def store_derivatives(
     merged = merged.sort_values("timestamp").reset_index(drop=True)
 
     records = _prepare_records(merged)
-    inserted = _upsert(DERIVATIVES_TABLE, records, engine, ("timestamp", "symbol"))
+    if not records:
+        return StoreResult(0)
+
+    records_with_basis: list[dict[str, object]] = []
+    records_without_basis: list[dict[str, object]] = []
+
+    for record in records:
+        if "basis" in record:
+            if record["basis"] is None:
+                trimmed = {key: value for key, value in record.items() if key != "basis"}
+                records_without_basis.append(trimmed)
+            else:
+                records_with_basis.append(record)
+        else:
+            records_without_basis.append(record)
+
+    inserted = 0
+    if records_without_basis:
+        update_columns = sorted({key for record in records_without_basis for key in record})
+        inserted += _upsert(
+            DERIVATIVES_TABLE,
+            records_without_basis,
+            engine,
+            ("timestamp", "symbol"),
+            update_columns=update_columns,
+        )
+    if records_with_basis:
+        inserted += _upsert(
+            DERIVATIVES_TABLE,
+            records_with_basis,
+            engine,
+            ("timestamp", "symbol"),
+        )
     return StoreResult(inserted)
 
 

--- a/src/crypto_analyzer/data/ingestion_store.py
+++ b/src/crypto_analyzer/data/ingestion_store.py
@@ -36,6 +36,7 @@ DERIVATIVES_TABLE = Table(
     Column("symbol", String(20), nullable=False),
     Column("funding_rate", Float),
     Column("open_interest", Float),
+    Column("basis", Float),
     Column("fetched_at", DateTime(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
     UniqueConstraint("timestamp", "symbol", name="ux_derivatives_intraday"),
 )
@@ -243,6 +244,7 @@ def latest_fear_greed_timestamp(engine: Engine) -> pd.Timestamp | None:
 def store_derivatives(
     funding: pd.DataFrame,
     open_interest: pd.DataFrame,
+    basis: pd.DataFrame | None = None,
     *,
     engine: Engine,
     symbol: str,
@@ -254,6 +256,16 @@ def store_derivatives(
         frames.append(frame)
     if not open_interest.empty:
         frame = open_interest.loc[:, ["timestamp", "open_interest"]].copy()
+        frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True, errors="coerce")
+        frames.append(frame)
+    if basis is not None and not basis.empty:
+        frame = basis.copy()
+        if "basis" not in frame.columns and "basis_bp" in frame.columns:
+            frame = frame.rename(columns={"basis_bp": "basis"})
+        missing = {"timestamp", "basis"} - set(frame.columns)
+        if missing:
+            raise KeyError(f"Basis frame missing required columns: {sorted(missing)}")
+        frame = frame.loc[:, ["timestamp", "basis"]]
         frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True, errors="coerce")
         frames.append(frame)
 

--- a/src/crypto_analyzer/data/timescale_writer.py
+++ b/src/crypto_analyzer/data/timescale_writer.py
@@ -297,7 +297,10 @@ def save_derivatives_data(
         sym = _require_string(record.get("symbol"), field="symbol")
         funding = _coerce_float(record.get("funding_rate"), field="funding_rate")
         open_interest = _coerce_float(record.get("open_interest"), field="open_interest")
-        basis = _coerce_float(record.get("basis"), field="basis")
+        basis_value = record.get("basis")
+        if basis_value is None:
+            basis_value = record.get("basis_bp")
+        basis = _coerce_float(basis_value, field="basis")
         payload.append((ts, sym, funding, open_interest, basis))
 
     sql = (

--- a/src/crypto_analyzer/scheduling/data_ingestion.py
+++ b/src/crypto_analyzer/scheduling/data_ingestion.py
@@ -14,6 +14,7 @@ from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 
 from crypto_analyzer.data.data_collector import (
+    fetch_binance_basis,
     fetch_binance_funding_rates,
     fetch_binance_open_interest,
     fetch_binance_order_book,
@@ -237,6 +238,44 @@ class DataIngestionScheduler:
     # Job implementations
     # ------------------------------------------------------------------
 
+    def _fetch_with_retries(
+        self,
+        fetcher: Callable[..., pd.DataFrame],
+        *,
+        description: str,
+        job_id: str,
+        max_attempts: int | None = None,
+        **kwargs: Any,
+    ) -> pd.DataFrame:
+        attempts = max(1, (max_attempts or (self.settings.max_retries + 1)))
+        for attempt in range(1, attempts + 1):
+            try:
+                return fetcher(**kwargs)
+            except Exception as exc:  # pragma: no cover - network failures
+                extra = {
+                    "job_id": job_id,
+                    "attempt": attempt,
+                    "max_attempts": attempts,
+                    "stage": description,
+                }
+                if attempt >= attempts:
+                    self.logger.error(
+                        "Failed to fetch %s after %s attempts",
+                        description,
+                        attempts,
+                        exc_info=exc,
+                        extra=extra,
+                    )
+                    break
+                self.logger.warning(
+                    "Fetch attempt %s/%s for %s failed; retrying",
+                    attempt,
+                    attempts,
+                    description,
+                    extra=extra,
+                )
+        return pd.DataFrame()
+
     def _run_binance_job(self) -> None:
         symbol = self._config.symbol
         now = datetime.now(tz=UTC)
@@ -254,9 +293,35 @@ class DataIngestionScheduler:
             extra={"job_id": "binance", "symbol": symbol, "start": start_dt.isoformat(), "end": now.isoformat()},
         )
 
-        funding = fetch_binance_funding_rates(symbol, start=start_dt, end=now)
-        open_interest = fetch_binance_open_interest(symbol, start=start_dt, end=now)
-        derivatives_result = store_derivatives(funding, open_interest, engine=self.engine, symbol=symbol)
+        funding = self._fetch_with_retries(
+            fetch_binance_funding_rates,
+            description="funding rates",
+            job_id="binance",
+            symbol=symbol,
+            start=start_dt,
+            end=now,
+        )
+        open_interest = self._fetch_with_retries(
+            fetch_binance_open_interest,
+            description="open interest",
+            job_id="binance",
+            symbol=symbol,
+            start=start_dt,
+            end=now,
+        )
+        basis = self._fetch_with_retries(
+            fetch_binance_basis,
+            description="basis",
+            job_id="binance",
+            symbol=symbol,
+        )
+        derivatives_result = store_derivatives(
+            funding,
+            open_interest,
+            basis,
+            engine=self.engine,
+            symbol=symbol,
+        )
 
         orderbook = fetch_binance_order_book(symbol, depth=self.settings.binance_depth)
         orderbook_result = store_orderbook(orderbook, engine=self.engine, symbol=symbol)
@@ -265,6 +330,7 @@ class DataIngestionScheduler:
             "binance",
             {
                 "derivative_rows": derivatives_result.inserted,
+                "basis_rows": 0 if basis.empty else len(basis),
                 "orderbook_rows": orderbook_result.inserted,
             },
         )

--- a/tests/test_data_collector.py
+++ b/tests/test_data_collector.py
@@ -29,6 +29,18 @@ class _DummySession:
         return _DummyResponse(self._payload)
 
 
+class _SequentialSession:
+    def __init__(self, payloads: list[dict[str, object]]):
+        self._payloads = payloads
+        self.calls: list[dict[str, object]] = []
+
+    def get(self, url, params=None, timeout=None):  # noqa: D401 - signature matches requests
+        index = len(self.calls)
+        payload = self._payloads[min(index, len(self._payloads) - 1)]
+        self.calls.append({"url": url, "params": params, "timeout": timeout})
+        return _DummyResponse(payload)
+
+
 def test_fetch_glassnode_active_addresses_parses_payload():
     payload = [
         {"t": 1_609_459_200, "v": 123},
@@ -116,6 +128,32 @@ def test_fetch_binance_order_book_rejects_invalid_depth():
     session = _DummySession({"bids": [], "asks": []})
     with pytest.raises(ValueError):
         data_collector.fetch_binance_order_book("BTCUSDT", depth=0, session=session)
+
+
+def test_fetch_binance_basis_computes_basis_points():
+    futures_payload = {"markPrice": "50000", "time": 1_609_459_200_000}
+    spot_payload = {"price": "49000"}
+    session = _SequentialSession([futures_payload, spot_payload])
+
+    frame = data_collector.fetch_binance_basis("BTCUSDT", session=session)
+
+    assert list(frame.columns) == [
+        "timestamp",
+        "basis",
+        "basis_bp",
+        "futures_price",
+        "spot_price",
+    ]
+    assert frame.shape[0] == 1
+
+    row = frame.iloc[0]
+    expected = (50_000 - 49_000) / 49_000 * 10_000
+    assert row["basis"] == pytest.approx(expected)
+    assert row["basis_bp"] == pytest.approx(expected)
+    assert row["futures_price"] == pytest.approx(50_000.0)
+    assert row["spot_price"] == pytest.approx(49_000.0)
+    assert row["timestamp"].tzinfo is not None
+    assert len(session.calls) == 2
 
 
 def test_load_enriched_market_data_aligns_daily_series(monkeypatch):

--- a/tests/test_ingestion_store.py
+++ b/tests/test_ingestion_store.py
@@ -83,6 +83,73 @@ def test_store_derivatives_upserts_and_tracks_latest_timestamp() -> None:
     assert stored_basis == pytest.approx(200.0)
 
 
+def test_store_derivatives_preserves_existing_basis_values() -> None:
+    engine = _setup_engine()
+    initial_funding = pd.DataFrame(
+        {
+            "timestamp": [
+                pd.Timestamp("2024-02-01T00:00:00Z"),
+                pd.Timestamp("2024-02-01T08:00:00Z"),
+            ],
+            "funding_rate": [0.01, 0.02],
+        }
+    )
+    initial_basis = pd.DataFrame(
+        {
+            "timestamp": [pd.Timestamp("2024-02-01T00:00:00Z")],
+            "basis": [125.0],
+        }
+    )
+
+    ingestion_store.store_derivatives(
+        initial_funding,
+        pd.DataFrame(),
+        initial_basis,
+        engine=engine,
+        symbol="BTCUSDT",
+    )
+
+    follow_up_funding = pd.DataFrame(
+        {
+            "timestamp": [
+                pd.Timestamp("2024-02-01T00:00:00Z"),
+                pd.Timestamp("2024-02-01T08:00:00Z"),
+            ],
+            "funding_rate": [0.015, 0.025],
+        }
+    )
+    follow_up_basis = pd.DataFrame(
+        {
+            "timestamp": [pd.Timestamp("2024-02-01T08:00:00Z")],
+            "basis": [175.0],
+        }
+    )
+
+    ingestion_store.store_derivatives(
+        follow_up_funding,
+        pd.DataFrame(),
+        follow_up_basis,
+        engine=engine,
+        symbol="BTCUSDT",
+    )
+
+    query = select(ingestion_store.DERIVATIVES_TABLE.c.basis).where(
+        ingestion_store.DERIVATIVES_TABLE.c.timestamp == pd.Timestamp("2024-02-01T00:00:00Z"),
+        ingestion_store.DERIVATIVES_TABLE.c.symbol == "BTCUSDT",
+    )
+    with engine.connect() as conn:
+        preserved_basis = conn.execute(query).scalar_one()
+    assert preserved_basis == pytest.approx(125.0)
+
+    follow_up_query = select(ingestion_store.DERIVATIVES_TABLE.c.basis).where(
+        ingestion_store.DERIVATIVES_TABLE.c.timestamp == pd.Timestamp("2024-02-01T08:00:00Z"),
+        ingestion_store.DERIVATIVES_TABLE.c.symbol == "BTCUSDT",
+    )
+    with engine.connect() as conn:
+        updated_basis = conn.execute(follow_up_query).scalar_one()
+    assert updated_basis == pytest.approx(175.0)
+
+
 def test_store_news_deduplicates_by_url() -> None:
     engine = _setup_engine()
     news = pd.DataFrame(

--- a/tests/test_ingestion_store.py
+++ b/tests/test_ingestion_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 import pandas as pd
+import pytest
 from sqlalchemy import create_engine, select
 
 from crypto_analyzer.data import ingestion_store
@@ -34,8 +35,23 @@ def test_store_derivatives_upserts_and_tracks_latest_timestamp() -> None:
             "open_interest": [1_000.0, 1_100.0],
         }
     )
+    basis = pd.DataFrame(
+        {
+            "timestamp": [
+                pd.Timestamp("2024-01-01T00:00:00Z"),
+                pd.Timestamp("2024-01-01T16:00:00Z"),
+            ],
+            "basis": [150.0, 200.0],
+        }
+    )
 
-    result = ingestion_store.store_derivatives(funding, open_interest, engine=engine, symbol="BTCUSDT")
+    result = ingestion_store.store_derivatives(
+        funding,
+        open_interest,
+        basis,
+        engine=engine,
+        symbol="BTCUSDT",
+    )
     assert result.inserted == 3
 
     latest = ingestion_store.latest_derivatives_timestamp(engine, symbol="BTCUSDT")
@@ -57,6 +73,14 @@ def test_store_derivatives_upserts_and_tracks_latest_timestamp() -> None:
     with engine.connect() as conn:
         stored_value = conn.execute(query).scalar_one()
     assert stored_value == 0.05
+
+    basis_query = select(ingestion_store.DERIVATIVES_TABLE.c.basis).where(
+        ingestion_store.DERIVATIVES_TABLE.c.timestamp == pd.Timestamp("2024-01-01T16:00:00Z"),
+        ingestion_store.DERIVATIVES_TABLE.c.symbol == "BTCUSDT",
+    )
+    with engine.connect() as conn:
+        stored_basis = conn.execute(basis_query).scalar_one()
+    assert stored_basis == pytest.approx(200.0)
 
 
 def test_store_news_deduplicates_by_url() -> None:

--- a/tests/test_timescale_writer.py
+++ b/tests/test_timescale_writer.py
@@ -90,6 +90,41 @@ def test_save_market_data_requires_symbol(mock_connection: MagicMock, monkeypatc
     writer.execute_batch.assert_not_called()  # type: ignore[attr-defined]
 
 
+def test_save_derivatives_data_accepts_basis_bp(
+    mock_connection: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_execute_batch(cursor, sql, params, page_size=None):  # type: ignore[no-untyped-def]
+        captured["sql"] = sql
+        captured["params"] = params
+        captured["page_size"] = page_size
+
+    monkeypatch.setattr(writer, "execute_batch", fake_execute_batch)
+
+    payload = [
+        {
+            "timestamp": "2024-01-01T00:00:00Z",
+            "symbol": "BTCUSDT",
+            "funding_rate": "0.01",
+            "open_interest": "123.45",
+            "basis_bp": "150.5",
+        }
+    ]
+
+    rows = writer.save_derivatives_data(payload, connection=mock_connection)
+
+    assert rows == 1
+    params = captured["params"]
+    assert isinstance(params, list)
+    row = params[0]
+    assert isinstance(row[0], datetime)
+    assert row[1] == "BTCUSDT"
+    assert row[2] == pytest.approx(0.01)
+    assert row[3] == pytest.approx(123.45)
+    assert row[4] == pytest.approx(150.5)
+
+
 def test_save_sentiment_index_validates_range(mock_connection: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(writer, "execute_batch", MagicMock())
 


### PR DESCRIPTION
## Summary
- add a Binance helper to compute futures basis versus spot and expose the value in basis points
- persist basis data alongside funding and open interest with retries in the Binance ingestion job
- extend ingestion and Timescale writers plus tests to cover the new basis signal

## Checklist
- [ ] tests pass
- [ ] typing ok
- [ ] doc updated
- [ ] perf note

## Import-time artifact
Link: N/A

## Before vs After
| Metric | Before | After |
|---|---|---|
| Import time (ms) |  |  |
| RSS (MB) |  |  |
| Imported modules |  |  |
| Inference throughput (rows/min) |  |  |

## Removed symbols / packages
- None

------
https://chatgpt.com/codex/tasks/task_e_68f88158cadc8327aeed0d23c6ec49c3