### PR TITLE
Add Twitter sentiment ingestion and storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
+## Database schema updates
+
+Deployments that already created the TimescaleDB schema need to add the new
+Twitter sentiment counters. Run the following SQL against your Timescale
+instance (feel free to append `IF NOT EXISTS` for idempotency):
+
+```sql
+ALTER TABLE social_sentiment
+    ADD COLUMN twitter_positive_count BIGINT,
+    ADD COLUMN twitter_negative_count BIGINT;
+```
+
 #### Windows: pandas build failure (`Could not parse vswhere.exe output`)
 
 On some Windows setups, installing the dependencies can fail while building

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "psycopg[binary]==3.1.12",
     "psycopg2-binary==2.9.9",
     "vaderSentiment==3.3.2",
+    "tweepy==4.14.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ SQLAlchemy==2.0.35
 psycopg[binary]==3.1.12
 psycopg2-binary==2.9.9
 vaderSentiment==3.3.2
+tweepy==4.14.0
 
 # Formatting & linting
 black==24.4.2

--- a/src/crypto_analyzer/data/db.py
+++ b/src/crypto_analyzer/data/db.py
@@ -88,6 +88,8 @@ TABLE_DEFINITIONS: dict[str, str] = {
             reddit_score DOUBLE PRECISION,
             twitter_score DOUBLE PRECISION,
             mentions BIGINT,
+            twitter_positive_count BIGINT,
+            twitter_negative_count BIGINT,
             PRIMARY KEY (timestamp)
         )
     """,
@@ -149,6 +151,8 @@ COMBINED_FEATURES_VIEW = """
         ss.reddit_score,
         ss.twitter_score,
         ss.mentions,
+        ss.twitter_positive_count,
+        ss.twitter_negative_count,
         news_agg.sentiment AS news_sentiment
     FROM market_data AS md
     LEFT JOIN derivatives_signals AS ds

--- a/src/crypto_analyzer/data/social_sentiment.py
+++ b/src/crypto_analyzer/data/social_sentiment.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Sequence
 from datetime import datetime
-from typing import Any
+from typing import Any, Callable
 
 import pandas as pd
 import requests
@@ -12,10 +13,260 @@ from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
 
 from crypto_analyzer.utils.logging import get_logger
 
+try:  # pragma: no cover - optional dependency during some tests
+    import tweepy
+except ModuleNotFoundError:  # pragma: no cover - allow fetch_twitter_sentiment to degrade gracefully
+    tweepy = None  # type: ignore[assignment]
+
 LOGGER = get_logger(__name__)
 
 _PUSHSHIFT_BASE_URL = "https://api.pushshift.io/reddit"
 _VALID_CONTENT_TYPES = {"comment", "submission"}
+
+
+def _empty_twitter_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        columns=[
+            "timestamp",
+            "twitter_score",
+            "positive_count",
+            "negative_count",
+            "mentions",
+        ]
+    )
+
+
+def _normalise_datetime(value: Any) -> pd.Timestamp:
+    ts = pd.Timestamp(value)
+    if ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    else:
+        ts = ts.tz_convert("UTC")
+    return ts
+
+
+def _format_twitter_time(ts: pd.Timestamp) -> str:
+    if ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    else:
+        ts = ts.tz_convert("UTC")
+    return ts.isoformat().replace("+00:00", "Z")
+
+
+def _build_twitter_query(keywords: Sequence[str]) -> str:
+    tokens: list[str] = []
+    for keyword in keywords:
+        term = str(keyword or "").strip()
+        if not term:
+            continue
+        if " " in term:
+            term = f'"{term}"'
+        tokens.append(term)
+    if not tokens:
+        raise ValueError("At least one non-empty keyword must be provided")
+    joined = " OR ".join(tokens)
+    return f"({joined}) -is:retweet lang:en"
+
+
+def _isinstance_of_tweepy_error(exc: Exception, name: str) -> bool:
+    if tweepy is None:
+        return False
+    modules: list[Any] = [tweepy]
+    errors_module = getattr(tweepy, "errors", None)
+    if errors_module is not None:
+        modules.append(errors_module)
+    for module in modules:
+        cls = getattr(module, name, None)
+        if isinstance(cls, type) and issubclass(cls, Exception) and isinstance(exc, cls):
+            return True
+    return False
+
+
+def _extract_next_token(meta: Any) -> str | None:
+    if meta is None:
+        return None
+    token: Any
+    if isinstance(meta, dict):
+        token = meta.get("next_token")
+    else:
+        getter = getattr(meta, "get", None)
+        if callable(getter):
+            token = getter("next_token")
+        else:
+            token = getattr(meta, "next_token", None)
+    if not token:
+        return None
+    token_str = str(token).strip()
+    return token_str or None
+
+
+def fetch_twitter_sentiment(
+    keywords: Sequence[str],
+    *,
+    start: datetime | pd.Timestamp | None = None,
+    end: datetime | pd.Timestamp | None = None,
+    bearer_token: str | None = None,
+    max_tweets: int = 300,
+    max_results: int = 100,
+    interval: str = "1H",
+    client: Any | None = None,
+    analyzer: SentimentIntensityAnalyzer | None = None,
+    backoff_seconds: int = 900,
+    sleep: Callable[[float], None] = time.sleep,
+) -> pd.DataFrame:
+    """Fetch recent tweets for *keywords* and aggregate sentiment scores by interval."""
+
+    query = _build_twitter_query(keywords)
+
+    api_client = client
+    if api_client is None:
+        if tweepy is None:
+            LOGGER.warning("tweepy is not installed; skipping Twitter sentiment fetch")
+            return _empty_twitter_frame()
+        if not bearer_token:
+            LOGGER.warning("Twitter bearer token missing; skipping Twitter sentiment fetch")
+            return _empty_twitter_frame()
+        try:
+            api_client = tweepy.Client(bearer_token=bearer_token, wait_on_rate_limit=False)  # type: ignore[attr-defined]
+        except Exception as exc:  # pragma: no cover - defensive, tweepy may raise configuration errors
+            LOGGER.warning("Failed to initialise Twitter client", exc_info=exc)
+            return _empty_twitter_frame()
+
+    start_ts = _normalise_datetime(start) if start is not None else None
+    end_ts = _normalise_datetime(end) if end is not None else None
+    if start_ts is not None and end_ts is not None and start_ts > end_ts:
+        raise ValueError("start must be earlier than or equal to end")
+
+    if max_tweets <= 0:
+        return _empty_twitter_frame()
+    max_results = max(10, min(max_results, 100))
+
+    analyser = analyzer or SentimentIntensityAnalyzer()
+    fetched = 0
+    next_token: str | None = None
+    rows: list[dict[str, Any]] = []
+
+    while fetched < max_tweets:
+        params: dict[str, Any] = {
+            "query": query,
+            "max_results": max_results,
+            "tweet_fields": ["created_at", "lang"],
+        }
+        if start_ts is not None:
+            params["start_time"] = _format_twitter_time(start_ts)
+        if end_ts is not None:
+            params["end_time"] = _format_twitter_time(end_ts)
+        if next_token:
+            params["next_token"] = next_token
+
+        try:
+            response = api_client.search_recent_tweets(**params)  # type: ignore[call-arg]
+        except Exception as exc:  # pragma: no cover - tweepy raises its own hierarchy
+            if _isinstance_of_tweepy_error(exc, "TooManyRequests"):
+                LOGGER.warning(
+                    "Twitter rate limit reached; backing off",
+                    extra={"backoff_seconds": backoff_seconds},
+                    exc_info=exc,
+                )
+                if backoff_seconds > 0:
+                    try:
+                        sleep(float(backoff_seconds))
+                    except Exception:  # pragma: no cover - defensive, sleep should rarely fail
+                        pass
+                return _empty_twitter_frame()
+            if _isinstance_of_tweepy_error(exc, "TweepyException"):
+                LOGGER.warning("Twitter API error when fetching sentiment", exc_info=exc)
+                return _empty_twitter_frame()
+            raise
+
+        tweets = getattr(response, "data", None) or []
+        if not tweets:
+            break
+
+        for tweet in tweets:
+            if fetched >= max_tweets:
+                break
+            text = getattr(tweet, "text", None)
+            if text is None:
+                continue
+            text_value = str(text).strip()
+            if not text_value:
+                continue
+            created_raw = getattr(tweet, "created_at", None)
+            if created_raw is None:
+                continue
+            try:
+                created_ts = _normalise_datetime(created_raw)
+            except (TypeError, ValueError):  # pragma: no cover - skip unexpected values
+                continue
+            try:
+                scores = analyser.polarity_scores(text_value)
+            except Exception as exc:  # pragma: no cover - ensure a single failure doesn't abort loop
+                LOGGER.warning("Failed to compute tweet sentiment", exc_info=exc)
+                continue
+            compound = float(scores.get("compound", 0.0))
+            rows.append(
+                {
+                    "timestamp": created_ts,
+                    "compound": compound,
+                    "is_positive": compound > 0.05,
+                    "is_negative": compound < -0.05,
+                }
+            )
+            fetched += 1
+
+        next_token = _extract_next_token(getattr(response, "meta", None))
+        if not next_token:
+            break
+
+    if not rows:
+        LOGGER.info(
+            "No tweets matched sentiment query",
+            extra={"query": query, "tweets_processed": 0},
+        )
+        return _empty_twitter_frame()
+
+    frame = pd.DataFrame(rows)
+    freq = interval.lower() if isinstance(interval, str) else interval
+    try:
+        frame["bucket"] = frame["timestamp"].dt.floor(freq)
+    except ValueError:
+        LOGGER.warning("Invalid interval '%s' supplied; defaulting to 1H", interval)
+        frame["bucket"] = frame["timestamp"].dt.floor("1H")
+
+    grouped = frame.groupby("bucket", dropna=False)
+    summary = grouped.agg(
+        twitter_score=("compound", "mean"),
+        positive_count=("is_positive", "sum"),
+        negative_count=("is_negative", "sum"),
+    )
+    summary["mentions"] = (summary["positive_count"] + summary["negative_count"]).astype(int)
+
+    result = summary.reset_index().rename(columns={"bucket": "timestamp"})
+    result["timestamp"] = pd.to_datetime(result["timestamp"], utc=True, errors="coerce")
+    result = result.dropna(subset=["timestamp"]).reset_index(drop=True)
+    result["twitter_score"] = result["twitter_score"].astype(float)
+    result["positive_count"] = result["positive_count"].astype(int)
+    result["negative_count"] = result["negative_count"].astype(int)
+    result["mentions"] = result["mentions"].astype(int)
+    result = result.sort_values("timestamp").reset_index(drop=True)
+
+    positives = int(frame["is_positive"].sum())
+    negatives = int(frame["is_negative"].sum())
+    neutrals = len(frame) - positives - negatives
+    LOGGER.info(
+        "Fetched twitter sentiment",
+        extra={
+            "query": query,
+            "tweets_processed": len(frame),
+            "positives": positives,
+            "negatives": negatives,
+            "neutrals": neutrals,
+            "buckets": len(result),
+        },
+    )
+
+    return result
 
 
 def _normalise_pushshift_time(value: Any) -> Any:
@@ -169,4 +420,4 @@ def fetch_reddit_sentiment(
     return frame
 
 
-__all__ = ["fetch_reddit_sentiment"]
+__all__ = ["fetch_reddit_sentiment", "fetch_twitter_sentiment"]

--- a/src/crypto_analyzer/data/timescale_writer.py
+++ b/src/crypto_analyzer/data/timescale_writer.py
@@ -340,15 +340,26 @@ def save_social_sentiment(
         mentions = _coerce_int(record.get("mentions"), field="mentions")
         if mentions is not None and mentions < 0:
             raise ValueError("Mentions count cannot be negative")
-        payload.append((ts, reddit_score, twitter_score, mentions))
+        pos_value = record.get("twitter_positive_count", record.get("positive_count"))
+        neg_value = record.get("twitter_negative_count", record.get("negative_count"))
+        twitter_positive = _coerce_int(pos_value, field="twitter_positive_count")
+        twitter_negative = _coerce_int(neg_value, field="twitter_negative_count")
+        if twitter_positive is not None and twitter_positive < 0:
+            raise ValueError("Twitter positive count cannot be negative")
+        if twitter_negative is not None and twitter_negative < 0:
+            raise ValueError("Twitter negative count cannot be negative")
+        payload.append((ts, reddit_score, twitter_score, mentions, twitter_positive, twitter_negative))
 
     sql = (
-        "INSERT INTO social_sentiment (timestamp, reddit_score, twitter_score, mentions) "
-        "VALUES (%s, %s, %s, %s) "
+        "INSERT INTO social_sentiment (timestamp, reddit_score, twitter_score, mentions, "
+        "twitter_positive_count, twitter_negative_count) "
+        "VALUES (%s, %s, %s, %s, %s, %s) "
         "ON CONFLICT (timestamp) DO UPDATE SET "
         "reddit_score = EXCLUDED.reddit_score, "
         "twitter_score = EXCLUDED.twitter_score, "
-        "mentions = EXCLUDED.mentions"
+        "mentions = EXCLUDED.mentions, "
+        "twitter_positive_count = EXCLUDED.twitter_positive_count, "
+        "twitter_negative_count = EXCLUDED.twitter_negative_count"
     )
 
     with _managed_connection(connection, connect_kwargs) as conn:

--- a/tests/test_social_sentiment_fetcher.py
+++ b/tests/test_social_sentiment_fetcher.py
@@ -5,8 +5,12 @@ from typing import Any
 
 import pytest
 import requests
+import tweepy
 
-from crypto_analyzer.data.social_sentiment import fetch_reddit_sentiment
+from crypto_analyzer.data.social_sentiment import (
+    fetch_reddit_sentiment,
+    fetch_twitter_sentiment,
+)
 
 
 class DummyAnalyzer:
@@ -38,6 +42,30 @@ class DummySession:
         return DummyResponse(self._payload)
 
 
+class DummyTweet:
+    def __init__(self, text: str, created_at: datetime) -> None:
+        self.text = text
+        self.created_at = created_at
+
+
+class DummyTwitterResponse:
+    def __init__(self, tweets: list[DummyTweet], *, next_token: str | None = None) -> None:
+        self.data = tweets
+        self.meta = {"next_token": next_token} if next_token else {}
+
+
+class DummyTwitterClient:
+    def __init__(self, responses: list[DummyTwitterResponse]) -> None:
+        self._responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    def search_recent_tweets(self, **kwargs: Any) -> DummyTwitterResponse:
+        self.calls.append(kwargs)
+        if self._responses:
+            return self._responses.pop(0)
+        return DummyTwitterResponse([])
+
+
 def test_fetch_reddit_sentiment_computes_expected_metrics() -> None:
     payload = {
         "data": [
@@ -62,6 +90,91 @@ def test_fetch_reddit_sentiment_computes_expected_metrics() -> None:
     assert row["reddit_positive_count"] == 1
     assert row["reddit_negative_count"] == 1
     assert session.calls[0]["params"]["subreddit"] == "CryptoCurrency"
+
+
+def test_fetch_twitter_sentiment_aggregates_expected_values() -> None:
+    timestamp = datetime(2024, 9, 1, 12, 0, tzinfo=timezone.utc)
+    tweets = [
+        DummyTwitterResponse(
+            [
+                DummyTweet("Bullish on BTC", timestamp + timedelta(minutes=5)),
+                DummyTweet("BTC looks weak", timestamp + timedelta(minutes=20)),
+                DummyTweet("BTC recovering", timestamp + timedelta(hours=1, minutes=5)),
+            ]
+        )
+    ]
+    client = DummyTwitterClient(tweets)
+    analyzer = DummyAnalyzer(
+        {
+            "Bullish on BTC": 0.6,
+            "BTC looks weak": -0.4,
+            "BTC recovering": 0.5,
+        }
+    )
+
+    frame = fetch_twitter_sentiment(
+        ["Bitcoin", "BTC"],
+        start=timestamp,
+        end=timestamp + timedelta(hours=2),
+        client=client,
+        analyzer=analyzer,
+        interval="1H",
+        max_tweets=10,
+    )
+
+    assert frame.shape == (2, 5)
+    first_row = frame.iloc[0]
+    assert first_row["twitter_score"] == pytest.approx(0.1)
+    assert first_row["positive_count"] == 1
+    assert first_row["negative_count"] == 1
+    assert first_row["mentions"] == 2
+    second_row = frame.iloc[1]
+    assert second_row["positive_count"] == 1
+    assert second_row["negative_count"] == 0
+    assert second_row["mentions"] == 1
+
+    call = client.calls[0]
+    assert call["query"] == "(Bitcoin OR BTC) -is:retweet lang:en"
+    assert call["start_time"].endswith("Z")
+    assert call["end_time"].endswith("Z")
+    assert call["max_results"] == 100
+
+
+def test_fetch_twitter_sentiment_requires_token_when_client_missing() -> None:
+    frame = fetch_twitter_sentiment(["BTC"], bearer_token=None)
+    assert frame.empty
+
+
+def test_fetch_twitter_sentiment_handles_rate_limit() -> None:
+    class RateLimitedClient:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def search_recent_tweets(self, **_: Any) -> Any:
+            self.calls += 1
+            response = requests.Response()
+            response.status_code = 429
+            response.reason = "Too Many Requests"
+            response._content = b"{\"errors\": [{\"message\": \"rate limit\"}]}"
+            raise tweepy.errors.TooManyRequests(response)
+
+    client = RateLimitedClient()
+    sleep_calls: list[float] = []
+
+    def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    frame = fetch_twitter_sentiment(
+        ["BTC"],
+        client=client,
+        analyzer=DummyAnalyzer({}),
+        sleep=fake_sleep,
+        max_tweets=5,
+    )
+
+    assert frame.empty
+    assert sleep_calls == [900.0]
+    assert client.calls == 1
 
 
 def test_fetch_reddit_sentiment_normalises_time_parameters() -> None:


### PR DESCRIPTION
## Summary
- add a tweepy-powered `fetch_twitter_sentiment` helper that aggregates tweet sentiment with VADER
- store Twitter positive/negative counts alongside the average score in Timescale and document the schema update
- cover the new logic with tests and add tweepy to the dependency set

## Testing
- pytest tests/test_social_sentiment_fetcher.py


------
https://chatgpt.com/codex/tasks/task_e_68f89103469c8327af7449796c9ab8f3