### PR TITLE
Add Whale Alert daily ingestion job

### DIFF
--- a/src/crypto_analyzer/data/ingestion_store.py
+++ b/src/crypto_analyzer/data/ingestion_store.py
@@ -126,6 +126,23 @@ FEAR_GREED_TABLE = Table(
     Column("fetched_at", DateTime(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
 )
 
+WHALE_TRANSACTIONS_TABLE = Table(
+    "whale_transactions",
+    _METADATA,
+    Column("timestamp", DateTime(timezone=True), nullable=False),
+    Column("transaction_hash", String(128), nullable=False),
+    Column("blockchain", String(64)),
+    Column("currency", String(32)),
+    Column("amount", Float),
+    Column("amount_usd", Float),
+    Column("from_address", String(128)),
+    Column("from_owner", String(128)),
+    Column("to_address", String(128)),
+    Column("to_owner", String(128)),
+    Column("fetched_at", DateTime(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+    UniqueConstraint("timestamp", "transaction_hash", name="ux_whale_transactions"),
+)
+
 
 @dataclass(frozen=True, slots=True)
 class StoreResult:
@@ -248,6 +265,10 @@ def latest_coinmetrics_timestamp(engine: Engine, *, asset: str) -> pd.Timestamp 
 
 def latest_fear_greed_timestamp(engine: Engine) -> pd.Timestamp | None:
     return _latest_timestamp(FEAR_GREED_TABLE, engine)
+
+
+def latest_whale_transaction_timestamp(engine: Engine) -> pd.Timestamp | None:
+    return _latest_timestamp(WHALE_TRANSACTIONS_TABLE, engine)
 
 
 def store_derivatives(
@@ -419,12 +440,62 @@ def store_fear_greed_index(index_frame: pd.DataFrame, *, engine: Engine) -> Stor
     return StoreResult(inserted)
 
 
+def store_whale_transactions(transactions: pd.DataFrame, *, engine: Engine) -> StoreResult:
+    if transactions.empty:
+        return StoreResult(0)
+
+    frame = transactions.copy()
+    if "timestamp" not in frame.columns:
+        frame = frame.reset_index()
+    frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True, errors="coerce")
+    frame = frame.dropna(subset=["timestamp", "transaction_hash"]).reset_index(drop=True)
+
+    if "transaction_hash" in frame.columns:
+        frame["transaction_hash"] = frame["transaction_hash"].astype(str).str.strip()
+        frame = frame.loc[frame["transaction_hash"] != ""]
+
+    if "currency" in frame.columns:
+        mask = frame["currency"].notna()
+        frame.loc[mask, "currency"] = frame.loc[mask, "currency"].astype(str).str.upper()
+        frame.loc[~mask, "currency"] = None
+
+    for column in ("from_address", "from_owner", "to_address", "to_owner", "blockchain"):
+        if column in frame.columns:
+            mask = frame[column].notna()
+            frame.loc[mask, column] = frame.loc[mask, column].astype(str).str.strip()
+            frame.loc[~mask, column] = None
+
+    records = _prepare_records(frame)
+    if not records:
+        return StoreResult(0)
+
+    update_columns = (
+        "blockchain",
+        "currency",
+        "amount",
+        "amount_usd",
+        "from_address",
+        "from_owner",
+        "to_address",
+        "to_owner",
+    )
+    inserted = _upsert(
+        WHALE_TRANSACTIONS_TABLE,
+        records,
+        engine,
+        ("timestamp", "transaction_hash"),
+        update_columns=update_columns,
+    )
+    return StoreResult(inserted)
+
+
 __all__ = [
     "StoreResult",
     "ensure_schema",
     "latest_coinmetrics_timestamp",
     "latest_derivatives_timestamp",
     "latest_fear_greed_timestamp",
+    "latest_whale_transaction_timestamp",
     "latest_glassnode_timestamp",
     "store_coinmetrics_flows",
     "store_derivatives",
@@ -433,4 +504,5 @@ __all__ = [
     "store_news",
     "store_orderbook",
     "store_reddit_sentiment",
+    "store_whale_transactions",
 ]

--- a/src/crypto_analyzer/scheduling/data_ingestion.py
+++ b/src/crypto_analyzer/scheduling/data_ingestion.py
@@ -27,6 +27,7 @@ from crypto_analyzer.data.ingestion_store import (
     latest_derivatives_timestamp,
     latest_fear_greed_timestamp,
     latest_glassnode_timestamp,
+    latest_whale_transaction_timestamp,
     store_coinmetrics_flows,
     store_derivatives,
     store_fear_greed_index,
@@ -34,9 +35,13 @@ from crypto_analyzer.data.ingestion_store import (
     store_news,
     store_orderbook,
     store_reddit_sentiment,
+    store_whale_transactions,
 )
 from crypto_analyzer.data.news_fetcher import fetch_cryptopanic_news
-from crypto_analyzer.data.onchain_fetcher import fetch_coinmetrics_exchange_flows
+from crypto_analyzer.data.onchain_fetcher import (
+    fetch_coinmetrics_exchange_flows,
+    fetch_whale_alert_transactions,
+)
 from crypto_analyzer.data.sentiment_index_fetcher import fetch_fear_greed_index
 from crypto_analyzer.data.social_sentiment import fetch_reddit_sentiment
 from crypto_analyzer.utils.logging import get_logger
@@ -130,6 +135,11 @@ class DataIngestionScheduler:
             api_key = get_secret("GLASSNODE_API_KEY")
         self._glassnode_api_key = api_key
 
+        whale_key = getattr(onchain_cfg, "whale_api_key", None) if onchain_cfg else None
+        if not whale_key:
+            whale_key = get_secret("WHALE_API_KEY")
+        self._whale_api_key = whale_key
+
     # ------------------------------------------------------------------
     # Job scheduling helpers
     # ------------------------------------------------------------------
@@ -180,15 +190,35 @@ class DataIngestionScheduler:
             )
 
         daily_time = self.settings.daily_run_time
-        cron = CronTrigger(hour=daily_time.hour, minute=daily_time.minute, timezone=self.timezone)
+        daily_cron = CronTrigger(hour=daily_time.hour, minute=daily_time.minute, timezone=self.timezone)
         self.scheduler.add_job(
             self._wrap_job(self._run_daily_job, job_id="daily"),
-            cron,
+            daily_cron,
             id="daily_job",
             replace_existing=True,
             max_instances=1,
             kwargs={"attempt": 1},
         )
+
+        if not self._whale_api_key:
+            self.logger.info(
+                "Whale Alert job disabled; missing API key",
+                extra={"job_id": "whale"},
+            )
+        else:
+            whale_cron = CronTrigger(
+                hour=daily_time.hour,
+                minute=daily_time.minute,
+                timezone=self.timezone,
+            )
+            self.scheduler.add_job(
+                self._wrap_job(self._run_whale_daily, job_id="whale"),
+                whale_cron,
+                id="whale_daily_job",
+                replace_existing=True,
+                max_instances=1,
+                kwargs={"attempt": 1},
+            )
 
     def start(self) -> None:
         """Start the underlying APScheduler instance."""
@@ -438,6 +468,35 @@ class DataIngestionScheduler:
                 "fear_greed_rows": fear_greed_result.inserted,
             },
         )
+
+    def _run_whale_daily(self) -> None:
+        if not self._whale_api_key:
+            self.logger.warning(
+                "Whale Alert API key missing; skipping fetch",
+                extra={"job_id": "whale"},
+            )
+            return
+
+        end = pd.Timestamp(datetime.now(tz=UTC))
+        start = end - pd.Timedelta(days=1)
+        last_seen = latest_whale_transaction_timestamp(self.engine)
+
+        extra: dict[str, Any] = {
+            "job_id": "whale",
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+        }
+        if last_seen is not None:
+            extra["latest_stored"] = last_seen.isoformat()
+
+        self.logger.info("Fetching Whale Alert transactions", extra=extra)
+        transactions = fetch_whale_alert_transactions(
+            api_key=self._whale_api_key,
+            start=start,
+            end=end,
+        )
+        result = store_whale_transactions(transactions, engine=self.engine)
+        self._log_store_result("whale", {"records": result.inserted})
 
     def _log_store_result(self, job_id: str, metrics: dict[str, Any]) -> None:
         payload = {"job_id": job_id}

--- a/tests/test_ingestion_store.py
+++ b/tests/test_ingestion_store.py
@@ -178,3 +178,36 @@ def test_store_news_deduplicates_by_url() -> None:
     with engine.connect() as conn:
         sentiment_value = conn.execute(query).scalar_one()
     assert sentiment_value == 0.5
+
+
+def test_store_whale_transactions_upserts_latest_timestamp() -> None:
+    engine = _setup_engine()
+    base = pd.Timestamp("2024-03-01T00:00:00Z")
+    transactions = pd.DataFrame(
+        {
+            "timestamp": [base, base + pd.Timedelta(hours=6)],
+            "transaction_hash": ["hash-1", "hash-2"],
+            "currency": ["btc", "eth"],
+            "amount": [12.5, 20.0],
+            "amount_usd": [325_000.0, 450_000.0],
+            "from_address": ["addr-1", None],
+            "to_address": ["addr-2", "addr-3"],
+        }
+    )
+
+    result = ingestion_store.store_whale_transactions(transactions, engine=engine)
+    assert result.inserted == 2
+
+    latest = ingestion_store.latest_whale_transaction_timestamp(engine)
+    assert latest is not None
+    assert latest.tz_convert("UTC").to_pydatetime() == datetime(2024, 3, 1, 6, tzinfo=timezone.utc)
+
+    update = transactions.iloc[[1]].assign(amount_usd=[475_000.0])
+    ingestion_store.store_whale_transactions(update, engine=engine)
+
+    query = select(ingestion_store.WHALE_TRANSACTIONS_TABLE.c.amount_usd).where(
+        ingestion_store.WHALE_TRANSACTIONS_TABLE.c.transaction_hash == "hash-2"
+    )
+    with engine.connect() as conn:
+        stored_amount = conn.execute(query).scalar_one()
+    assert stored_amount == pytest.approx(475_000.0)


### PR DESCRIPTION
## Summary
- add a whale_transactions table and persistence helper to the scheduler ingestion store
- schedule a dedicated Whale Alert cron job that respects the existing daily cadence and API key checks
- cover the Whale Alert storage path with a unit test exercising inserts and upserts

## Checklist
- [x] tests pass
- [ ] typing ok
- [ ] doc updated
- [ ] perf note

## Import-time artifact
Link: N/A

## Before vs After
| Metric | Before | After |
|---|---|---|
| Import time (ms) | - | - |
| RSS (MB) | - | - |
| Imported modules | - | - |
| Inference throughput (rows/min) | - | - |

## Removed symbols / packages
-

------
https://chatgpt.com/codex/tasks/task_e_68f89a8d217c8327b727110568cccd53