### PR TITLE
Create combined features materialized view

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,40 @@ ALTER TABLE social_sentiment
     ADD COLUMN twitter_negative_count BIGINT;
 ```
 
+### Combined features materialized view
+
+Schema initialisation now provisions a `combined_features` materialized view
+that pre-joins the market, derivative, on-chain, sentiment and news signals. The
+view stores one row per `(timestamp, symbol)` with columns such as
+`open/high/low/close`, `funding_rate`, `active_addresses`, the
+Fear & Greed index, social scores and aggregated news sentiment so feature store
+queries no longer repeat the join.
+
+To build or rebuild the view manually run:
+
+```sql
+DROP MATERIALIZED VIEW IF EXISTS combined_features;
+CREATE MATERIALIZED VIEW combined_features AS
+    SELECT ...;  -- see ``crypto_analyzer.data.db`` for the canonical SELECT
+CREATE UNIQUE INDEX IF NOT EXISTS idx_combined_features_timestamp_symbol
+    ON combined_features (timestamp, symbol);
+```
+
+Refresh the materialized view after ingesting new data so downstream consumers
+observe the latest features:
+
+```sql
+REFRESH MATERIALIZED VIEW combined_features;
+-- or keep the relation readable during the refresh (requires the unique index)
+REFRESH MATERIALIZED VIEW CONCURRENTLY combined_features;
+```
+
+Large backfills benefit from scheduling the refresh (for example nightly) or
+recomputing only recent partitions into staging tables before swapping them in.
+If the schema of an upstream table changes, drop and recreate the materialized
+view so it reflects the new layout. Creation fails fast when required source
+tables are missing, helping diagnose incomplete deployments.
+
 #### Windows: pandas build failure (`Could not parse vswhere.exe output`)
 
 On some Windows setups, installing the dependencies can fail while building

--- a/src/crypto_analyzer/data/db.py
+++ b/src/crypto_analyzer/data/db.py
@@ -373,14 +373,28 @@ def refresh_combined_features(
 
     keyword = " CONCURRENTLY" if concurrently else ""
     statement = f"REFRESH MATERIALIZED VIEW{keyword} combined_features"
+    original_autocommit_value = getattr(conn, "autocommit", False)
+    original_autocommit = bool(original_autocommit_value)
+    autocommit_enabled = False
+
     try:
+        if concurrently and not original_autocommit:
+            conn.autocommit = True
+            autocommit_enabled = True
+
         with conn.cursor() as cursor:
             cursor.execute(statement)
-        conn.commit()
+
+        if not concurrently and not original_autocommit:
+            conn.commit()
     except Exception as exc:
-        conn.rollback()
+        if not concurrently and not original_autocommit:
+            conn.rollback()
         LOGGER.error("Failed to refresh combined_features materialized view: %s", exc)
         raise
+    finally:
+        if autocommit_enabled:
+            conn.autocommit = original_autocommit_value
 
 
 def _ensure_column_exists(

--- a/src/crypto_analyzer/data/db.py
+++ b/src/crypto_analyzer/data/db.py
@@ -2,8 +2,11 @@
 
 This module provides helpers to connect to a TimescaleDB/PostgreSQL instance and
 ensure that all tables required by the project exist as hypertables.  The
-``combined_features`` view aggregates the most important features for the ML
-pipeline in a single relation.
+``combined_features`` materialized view aggregates the most important features
+for the ML pipeline in a single relation so feature engineering queries can hit
+a precomputed join instead of recalculating it on the fly.  Recreate or refresh
+the materialized view whenever one of the underlying tables changes schema or
+receives new data.
 
 Typical usage from the command line::
 
@@ -125,12 +128,40 @@ HYPERTABLE_STATEMENTS: tuple[str, ...] = (
     "SELECT create_hypertable('news', 'timestamp', if_not_exists => TRUE)",
 )
 
-COMBINED_FEATURES_VIEW = """
-    CREATE OR REPLACE VIEW combined_features AS
+_PREFERRED_MARKET_INTERVAL = CONFIG.interval.replace("'", "''")
+
+COMBINED_FEATURES_DEPENDENCIES: tuple[str, ...] = (
+    "market_data",
+    "derivatives_signals",
+    "onchain_metrics",
+    "sentiment_index",
+    "social_sentiment",
+    "news",
+)
+
+COMBINED_FEATURES_MATERIALIZED_VIEW = f"""
+    CREATE MATERIALIZED VIEW combined_features AS
+    WITH base_market_data AS (
+        SELECT DISTINCT ON (timestamp, symbol)
+            timestamp,
+            symbol,
+            open,
+            high,
+            low,
+            close,
+            volume,
+            quote_volume,
+            trades
+        FROM market_data
+        ORDER BY
+            timestamp,
+            symbol,
+            CASE WHEN interval = '{_PREFERRED_MARKET_INTERVAL}' THEN 0 ELSE 1 END,
+            interval
+    )
     SELECT
         md.timestamp,
         md.symbol,
-        md.interval,
         md.open,
         md.high,
         md.low,
@@ -151,10 +182,8 @@ COMBINED_FEATURES_VIEW = """
         ss.reddit_score,
         ss.twitter_score,
         ss.mentions,
-        ss.twitter_positive_count,
-        ss.twitter_negative_count,
         news_agg.sentiment AS news_sentiment
-    FROM market_data AS md
+    FROM base_market_data AS md
     LEFT JOIN derivatives_signals AS ds
         ON ds.timestamp = md.timestamp AND ds.symbol = md.symbol
     LEFT JOIN onchain_metrics AS oc
@@ -170,6 +199,11 @@ COMBINED_FEATURES_VIEW = """
         FROM news
         GROUP BY timestamp
     ) AS news_agg ON news_agg.timestamp = md.timestamp
+"""
+
+COMBINED_FEATURES_INDEX = """
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_combined_features_timestamp_symbol
+        ON combined_features (timestamp, symbol)
 """
 
 
@@ -273,6 +307,82 @@ def _execute_statements(conn: PGConnection, statements: Iterable[str]) -> None:
             cursor.execute(statement)
 
 
+def _ensure_combined_features_dependencies(conn: PGConnection) -> None:
+    """Validate that the tables required by ``combined_features`` exist."""
+
+    with conn.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_schema = 'public'
+              AND table_name = ANY(%s)
+            """,
+            (list(COMBINED_FEATURES_DEPENDENCIES),),
+        )
+        existing = {name for (name,) in cursor.fetchall()}
+
+    missing = set(COMBINED_FEATURES_DEPENDENCIES) - existing
+    if missing:
+        joined = ", ".join(sorted(missing))
+        raise RuntimeError(
+            "Cannot create combined_features materialized view; missing tables: %s" % joined
+        )
+
+
+def _create_combined_features_materialized_view(conn: PGConnection) -> None:
+    """Create the ``combined_features`` materialized view and its index."""
+
+    _ensure_combined_features_dependencies(conn)
+    LOGGER.info("Creating combined_features materialized view")
+    _execute_statements(
+        conn,
+        (
+            "DROP MATERIALIZED VIEW IF EXISTS combined_features",
+            "DROP VIEW IF EXISTS combined_features",
+            COMBINED_FEATURES_MATERIALIZED_VIEW,
+            COMBINED_FEATURES_INDEX,
+        ),
+    )
+
+
+def refresh_combined_features(
+    conn: PGConnection,
+    *,
+    concurrently: bool = False,
+) -> None:
+    """Refresh the ``combined_features`` materialized view.
+
+    Parameters
+    ----------
+    conn:
+        Open psycopg2 connection targeting TimescaleDB.
+    concurrently:
+        Request ``REFRESH MATERIALIZED VIEW CONCURRENTLY`` to keep the view
+        accessible for reads during refresh.  Requires the unique index created
+        by :func:`_create_combined_features_materialized_view`.
+
+    Notes
+    -----
+    Schedule refreshes after data ingestion completes (e.g. nightly) so model
+    training jobs always see up-to-date features.  ``REFRESH CONCURRENTLY``
+    avoids blocking reads but still needs to reprocess the full dataset; when
+    refresh time becomes an issue consider partial refresh strategies such as
+    materializing only recent partitions into staging tables.
+    """
+
+    keyword = " CONCURRENTLY" if concurrently else ""
+    statement = f"REFRESH MATERIALIZED VIEW{keyword} combined_features"
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(statement)
+        conn.commit()
+    except Exception as exc:
+        conn.rollback()
+        LOGGER.error("Failed to refresh combined_features materialized view: %s", exc)
+        raise
+
+
 def _ensure_column_exists(
     conn: PGConnection,
     table_name: str,
@@ -319,8 +429,7 @@ def initialize_schema(conn: PGConnection) -> None:
         LOGGER.info("Converting tables to hypertables")
         _execute_statements(conn, HYPERTABLE_STATEMENTS)
 
-        LOGGER.info("Creating combined_features view")
-        _execute_statements(conn, (COMBINED_FEATURES_VIEW,))
+        _create_combined_features_materialized_view(conn)
 
         conn.commit()
     except Exception:

--- a/tests/test_timescale_schema.py
+++ b/tests/test_timescale_schema.py
@@ -82,19 +82,45 @@ def test_create_materialized_view_runs_all_statements(monkeypatch) -> None:
 
 
 def test_refresh_combined_features_concurrently() -> None:
-    conn = MagicMock()
-    cursor = _mock_cursor(conn)
+    class _CursorStub:
+        def __init__(self, conn: "_ConnectionStub") -> None:
+            self._conn = conn
+            self.executed: list[str] = []
+
+        def execute(self, statement: str) -> None:
+            assert self._conn.autocommit, "autocommit should be enabled for concurrent refresh"
+            self.executed.append(statement)
+
+        def __enter__(self) -> "_CursorStub":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - no cleanup required
+            return None
+
+    class _ConnectionStub:
+        def __init__(self) -> None:
+            self.autocommit = False
+            self.commit = MagicMock()
+            self.rollback = MagicMock()
+            self._cursor = _CursorStub(self)
+
+        def cursor(self) -> _CursorStub:
+            return self._cursor
+
+    conn = _ConnectionStub()
 
     db.refresh_combined_features(conn, concurrently=True)
 
-    cursor.execute.assert_called_once_with(
+    assert conn._cursor.executed == [
         "REFRESH MATERIALIZED VIEW CONCURRENTLY combined_features"
-    )
-    conn.commit.assert_called_once()
+    ]
+    conn.commit.assert_not_called()
+    assert conn.autocommit is False
 
 
 def test_refresh_combined_features_logs_and_rolls_back(caplog: pytest.LogCaptureFixture) -> None:
     conn = MagicMock()
+    conn.autocommit = False
     cursor = _mock_cursor(conn)
     cursor.execute.side_effect = RuntimeError("lock contention")
 

--- a/tests/test_timescale_schema.py
+++ b/tests/test_timescale_schema.py
@@ -1,0 +1,107 @@
+"""Tests for TimescaleDB schema helpers."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _SQLText(str):
+    def format(self, *args, **kwargs):
+        return _SQLText(self)
+
+
+class _SQLModule:
+    def SQL(self, text: str) -> _SQLText:
+        return _SQLText(text)
+
+    def Identifier(self, value: str) -> str:
+        return value
+
+
+_psycopg2_stub = SimpleNamespace(
+    OperationalError=RuntimeError,
+    sql=_SQLModule(),
+    connect=MagicMock(),
+)
+
+sys.modules.setdefault("psycopg2", _psycopg2_stub)
+sys.modules.setdefault("psycopg2.sql", _psycopg2_stub.sql)
+sys.modules.setdefault(
+    "psycopg2.extensions", SimpleNamespace(connection=object)
+)
+
+_config_module = ModuleType("crypto_analyzer.utils.config")
+_config_module.CONFIG = SimpleNamespace(
+    interval="1h",
+    database=SimpleNamespace(url=None),
+)
+sys.modules.setdefault("crypto_analyzer.utils.config", _config_module)
+
+from crypto_analyzer.data import db
+
+
+def _mock_cursor(conn: MagicMock) -> MagicMock:
+    cursor = conn.cursor.return_value.__enter__.return_value
+    return cursor
+
+
+def test_dependency_check_raises_for_missing_tables() -> None:
+    conn = MagicMock()
+    cursor = _mock_cursor(conn)
+    cursor.fetchall.return_value = [("market_data",), ("news",)]
+
+    with pytest.raises(RuntimeError) as excinfo:
+        db._ensure_combined_features_dependencies(conn)
+
+    assert "missing tables" in str(excinfo.value)
+
+
+def test_create_materialized_view_runs_all_statements(monkeypatch) -> None:
+    conn = MagicMock()
+    cursor = _mock_cursor(conn)
+    cursor.fetchall.return_value = [(name,) for name in db.COMBINED_FEATURES_DEPENDENCIES]
+
+    executed: list[str] = []
+
+    def capture_statements(_: MagicMock, statements: tuple[str, ...]) -> None:
+        executed.extend(statements)
+
+    monkeypatch.setattr(db, "_execute_statements", capture_statements)
+
+    db._create_combined_features_materialized_view(conn)
+
+    assert executed[0] == "DROP MATERIALIZED VIEW IF EXISTS combined_features"
+    assert executed[1] == "DROP VIEW IF EXISTS combined_features"
+    assert db.COMBINED_FEATURES_MATERIALIZED_VIEW in executed
+    assert db.COMBINED_FEATURES_INDEX in executed
+
+
+def test_refresh_combined_features_concurrently() -> None:
+    conn = MagicMock()
+    cursor = _mock_cursor(conn)
+
+    db.refresh_combined_features(conn, concurrently=True)
+
+    cursor.execute.assert_called_once_with(
+        "REFRESH MATERIALIZED VIEW CONCURRENTLY combined_features"
+    )
+    conn.commit.assert_called_once()
+
+
+def test_refresh_combined_features_logs_and_rolls_back(caplog: pytest.LogCaptureFixture) -> None:
+    conn = MagicMock()
+    cursor = _mock_cursor(conn)
+    cursor.execute.side_effect = RuntimeError("lock contention")
+
+    caplog.set_level(logging.ERROR)
+
+    with pytest.raises(RuntimeError):
+        db.refresh_combined_features(conn)
+
+    conn.rollback.assert_called_once()
+    assert "Failed to refresh combined_features materialized view" in caplog.text


### PR DESCRIPTION
## Summary
- replace the combined_features plain view with a materialized view that deduplicates market candles, indexes timestamp/symbol, and validates its table dependencies
- add a refresh helper with logging plus documentation covering rebuild/refresh guidance for the feature store
- introduce schema helper tests with lightweight psycopg2/config stubs to exercise the new materialized-view logic

## Testing
- pytest tests/test_timescale_schema.py

------
https://chatgpt.com/codex/tasks/task_e_68f8a57165ec832798a4af2be09ba60f